### PR TITLE
docs: add initial PRD/ROADMAP/tasks and project setup

### DIFF
--- a/.claude/agents/docs/development-planner.md
+++ b/.claude/agents/docs/development-planner.md
@@ -62,7 +62,7 @@ You are a top-tier project manager and technical architect. Your task is to thor
 
 #### 4️⃣ **Task Completion & Roadmap Update**
 
-- Update `/tasks/XXX-description.md` checkboxes as implementation steps complete
+- Update `docs/tasks/XXX-description.md` checkboxes as implementation steps complete
 - Mark completed items with `[x]` in the task file
 - Update Change History section with completion date and summary
 - Mark completed tasks with ✅ in ROADMAP.md
@@ -113,10 +113,10 @@ The Structure-First Approach is a development methodology that **completes the o
 2. **Task Creation**
 
 - Learn the existing codebase and understand the current state
-- Create new task files in the `/tasks` directory
+- Create new task files in the `docs/tasks` directory
 - Naming format: `XXX-description.md` (e.g., `001-setup.md`)
 - Include high-level specifications, related files, acceptance criteria, and implementation steps
-- Reference the last completed tasks in `/tasks` directory for examples. For instance, if the current task is `012`, reference `011` and `010` as examples.
+- Reference the last completed tasks in `docs/tasks` directory for examples. For instance, if the current task is `012`, reference `011` and `010` as examples.
 - These examples are completed tasks, so their content reflects the final state of completed work (checked boxes and change summaries). For new tasks, the document should have empty boxes and no change summaries. Refer to `000-sample.md` for an initial state sample.
 
 3. **Task Implementation**
@@ -128,11 +128,11 @@ The Structure-First Approach is a development methodology that **completes the o
 
 4. **Task Completion & Roadmap Update**
 
-- Update `/tasks/XXX-description.md` task file:
+- Update `docs/tasks/XXX-description.md` task file:
   - Mark completed items with `[x]` checkboxes
   - Fill in the Change History table with date and changes summary
 - Mark completed tasks with ✅ in ROADMAP.md
-- Add `**Must** Read:` reference link to completed tasks
+- The `**Must** Read:` link is already present from creation time — leave it intact (do NOT add it here)
 
 ## Development Phases
 
@@ -141,6 +141,7 @@ The Structure-First Approach is a development methodology that **completes the o
 - **Task 001: Project Structure and Routing Setup** - Priority
   - blockedBy: none
   - blocks: Task 002, Task 003
+  - **Must** Read: [001-route-structure.md](/docs/tasks/001-route-structure.md)
   - Create entire route structure based on Next.js App Router
   - Create empty shell files for all major pages
   - Implement common layout component skeleton
@@ -148,6 +149,7 @@ The Structure-First Approach is a development methodology that **completes the o
 - **Task 002: Type Definitions and Interface Design**
   - blockedBy: Task 001
   - blocks: Task 003, Task 005
+  - **Must** Read: [002-type-definitions.md](/docs/tasks/002-type-definitions.md)
   - Create TypeScript interface and type definition files
   - Design database schema (implementation excluded)
   - Define API response types
@@ -157,7 +159,7 @@ The Structure-First Approach is a development methodology that **completes the o
 - **Task 003: Common Component Library Implementation** ✅ - Completed
   - blockedBy: Task 001, Task 002
   - blocks: Task 004
-  - **Must** Read: [003-component-library.md](/tasks/003-component-library.md)
+  - **Must** Read: [003-component-library.md](/docs/tasks/003-component-library.md)
   - ✅ Implement common components based on shadcn/ui
   - ✅ Apply design system and style guide
   - ✅ Write dummy data generation and management utilities
@@ -165,7 +167,7 @@ The Structure-First Approach is a development methodology that **completes the o
 - **Task 004: Complete All Page UIs** ✅ - Completed
   - blockedBy: Task 003
   - blocks: Task 005, Task 006
-  - **Must** Read: [004-page-ui.md](/tasks/004-page-ui.md)
+  - **Must** Read: [004-page-ui.md](/docs/tasks/004-page-ui.md)
   - ✅ Implement all page component UIs (using hardcoded dummy data)
   - ✅ Responsive design and mobile optimization
   - ✅ User flow verification and navigation completion
@@ -175,6 +177,7 @@ The Structure-First Approach is a development methodology that **completes the o
 - **Task 005: Database and API Development** - Priority
   - blockedBy: Task 002, Task 004
   - blocks: Task 006, Task 007
+  - **Must** Read: [005-database-api.md](/docs/tasks/005-database-api.md)
   - Build database and configure ORM
   - Implement RESTful API or GraphQL API
   - Replace dummy data with actual API calls
@@ -182,6 +185,7 @@ The Structure-First Approach is a development methodology that **completes the o
 - **Task 006: Authentication and Authorization System Implementation**
   - blockedBy: Task 004, Task 005
   - blocks: Task 007
+  - **Must** Read: [006-auth-system.md](/docs/tasks/006-auth-system.md)
   - Build user authentication system
   - Implement role-based access control
   - Security middleware and session management
@@ -191,6 +195,7 @@ The Structure-First Approach is a development methodology that **completes the o
 - **Task 007: Additional Features and User Experience Enhancement**
   - blockedBy: Task 005, Task 006
   - blocks: Task 008
+  - **Must** Read: [007-advanced-features.md](/docs/tasks/007-advanced-features.md)
   - Implement advanced user features
   - Real-time features (WebSocket, SSE, etc.)
   - File upload and media processing
@@ -198,6 +203,7 @@ The Structure-First Approach is a development methodology that **completes the o
 - **Task 008: Performance Optimization and Deployment**
   - blockedBy: Task 007
   - blocks: none
+  - **Must** Read: [008-perf-deploy.md](/docs/tasks/008-perf-deploy.md)
   - Implement performance optimization and caching strategies
   - Build CI/CD pipeline
   - Configure monitoring and logging system
@@ -236,7 +242,7 @@ The Structure-First Approach is a development methodology that **completes the o
 2. **Scope**: Break down into units completable within 1-2 weeks
 3. **Independence**: Maintain minimal dependencies with other Tasks
 4. **Specificity**: Specify concrete features rather than abstract expressions
-5. **Language**: Task files (`/tasks/XXX-description.md`) should be written in **English**
+5. **Language**: Task files (`docs/tasks/XXX-description.md`) should be written in **English**
    - All sections including Overview, Acceptance Criteria, Implementation Steps, and Notes should be in English
 6. **Dependency Management**:
    - **blockedBy**: List tasks that MUST be completed before this task can start
@@ -251,7 +257,8 @@ The Structure-First Approach is a development methodology that **completes the o
   - **Phase Title Only**: In-progress or pending Phase
 
 - **Task Status**:
-  - **✅ - Completed**: Completed task (add `**Must** Read: [filename](/tasks/XXX-xxx.md)` reference when completed)
+  - **Every task** (regardless of status) MUST include `**Must** Read: [filename](/docs/tasks/XXX-xxx.md)` as the FIRST sub-bullet, immediately after `blocks:`. This is added at ROADMAP creation time, not at completion.
+  - **✅ - Completed**: Completed task
   - **- Priority**: Task that should start immediately
   - **No Status**: Pending task
 
@@ -307,17 +314,28 @@ Verify that the generated ROADMAP.md meets the following criteria:
 
 You MUST generate the following files in this exact order:
 
+#### ⚠️ Path Resolution (READ FIRST)
+
+All paths below are **relative to the repository root** (the directory containing `package.json` / `CLAUDE.md`), NOT the filesystem root (`/`).
+
+- `<repo-root>/docs/ROADMAP.md` ✅
+- `<repo-root>/docs/tasks/000-sample.md` ✅ — `tasks/` lives **inside `docs/`**
+- `/tasks/...` ❌ — never write to filesystem root
+- `<repo-root>/tasks/...` ❌ — legacy location, do not use
+
+If `docs/tasks/` does not exist, create it. Use `Write` with the absolute path resolved from the current working directory.
+
 #### 1. ROADMAP.md
-- Path: `/docs/ROADMAP.md`
+- Path: `<repo-root>/docs/ROADMAP.md`
 - Follow the structure and guidelines defined above
 
 #### 2. Task Template File
-- Path: `/tasks/000-sample.md`
+- Path: `<repo-root>/docs/tasks/000-sample.md`
 - Create an English-language template file that new tasks can reference
 - Include all sections: Overview, Related Features, Related Files, Acceptance Criteria, Implementation Steps, Notes, Change History
 
 #### 3. Individual Task Files
-- Path: `/tasks/XXX-description.md` for each task defined in ROADMAP.md
+- Path: `<repo-root>/docs/tasks/XXX-description.md` for each task defined in ROADMAP.md
 - Generate a task file for **every** task declared in ROADMAP.md Development Phases — none may be skipped
 - Each task file must:
   - Be written in English following the 000-sample.md template structure
@@ -327,12 +345,27 @@ You MUST generate the following files in this exact order:
   - Leave Change History empty (to be filled when completed)
 
 **Example**: If ROADMAP.md defines Task 001 through Task 017, you must create:
-- `/tasks/001-route-structure.md`
-- `/tasks/002-type-definitions.md`
+- `<repo-root>/docs/tasks/001-route-structure.md`
+- `<repo-root>/docs/tasks/002-type-definitions.md`
 - ... (continue for all tasks)
-- `/tasks/017-final-qa.md`
+- `<repo-root>/docs/tasks/017-final-qa.md`
 
 **IMPORTANT**: Do NOT stop after creating ROADMAP.md. Continue generating ALL task files before completing the task.
+
+#### 🔍 Self-Verification Before Reporting Completion (MANDATORY)
+
+Before returning your final response, you MUST execute this verification loop:
+
+1. Run `Glob` with pattern `docs/tasks/*.md` from the repository root.
+2. Count the returned files. Expected count = (number of tasks defined in ROADMAP.md Development Phases) + 1 (for `000-sample.md`).
+3. If count < expected:
+   - Identify which task files are missing by cross-referencing ROADMAP.md task IDs against the Glob results.
+   - **Resume generation immediately** — create the missing task files using `Write`.
+   - Re-run the Glob check.
+4. If count matches expected, run a final `Glob` on `tasks/*.md` (repo root) to confirm NO files were accidentally created in the legacy location. If any exist, move their contents to `docs/tasks/` and delete the misplaced files.
+5. Only after both checks pass, report completion to the user with a summary listing every generated file path.
+
+**Do NOT** report "ROADMAP.md and task files generated" without performing this verification. Context budget pressure is not a valid reason to skip task file generation — if the budget is tight, generate task files in smaller batches across multiple tool calls, but NEVER terminate early with task files missing.
 
 ---
 

--- a/.gitignore
+++ b/.gitignore
@@ -198,3 +198,4 @@ $RECYCLE.BIN/
 *.lnk
 
 # End of https://www.toptal.com/developers/gitignore/api/webstorm+all,visualstudiocode,windows,macos.claude/runtime/
+.claude/runtime/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@
 - **Service Name**: [your service name]
 - **Goal**: [Problem to solve and value to provide]
 - **Target Users**: [Primary user target]
-- **My Role**: [Your persona — e.g., CTO, CEO, Product Manager, Tech Lead. Determines how the agent addresses you during plan consultation. Leave blank to skip consultation step]
+- **My Role**: PM
 
 ## Core Principles
 > **Clean Architecture**: All projects use 4-layer CA (Domain → Application → Infrastructure → Presentation). Inner layers MUST NOT depend on outer layers.

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -1,0 +1,495 @@
+# tkstarDev PRD
+
+## Core Information
+
+**Purpose**: 1인 기업(개발자)의 개인 브랜드 웹사이트로, 사이트 자체가 이력서 역할을 하며 B2B(기업/HR) 채용 제안과 B2C(프리랜서 플랫폼) 의뢰 모두를 단일 도메인(tkstar.dev)에서 수렴시킨다. 주 네비게이션은 **검색 중심(Cmd+K Command Palette)**이며, 청중 분기는 별도 분기 CTA가 아닌 **콘텐츠 라우팅(About는 B2B 친화 / Projects·Case Study는 B2C 친화)**으로 자연스럽게 수행된다.
+**Users**: ① B2B 청중 — 기업 채용/HR 담당자, B2B 프리랜서 프로젝트 매니저 (이력·기술 깊이·신뢰성 검토). ② B2C 청중 — 크몽 등 프리랜서 플랫폼에서 유입된 클라이언트 (결과물·후기·문제 해결 능력 검토).
+**Scope Note**: 콘텐츠 100% static (DB 없음). 한국어 only(i18n 없음). 결제·가격 페이지 없음(메일 문의로 대체). 모든 콘텐츠는 velite + MDX로 관리되며 빌드 타임에 정적 생성된다. 디자인 정본은 `docs/design-system/prototype.html` + `docs/design-system/proto/*` (React 18 + babel-standalone 데모) — 구현 시 React Router v7 ESM 모듈로 포팅 필요.
+
+## User Journey
+
+```
+1. 진입 (Landing Page, 홈)
+   ├─ Hero: whoami 프롬프트 + "ship solo. ship fast." 카피 + 핵심 요약
+   │   ├─ [검색해서 이동] → Cmd+K Command Palette 오픈 (F016)
+   │   ├─ [/about] 빠른 링크 → About Page
+   │   └─ [/projects] 빠른 링크 → Projects Page
+   │
+   ├─ Featured Project 섹션 → 클릭 시 Project Detail
+   └─ Recent Posts 3행 + "모두 보기" → Blog Page / Blog Detail
+
+2. 글로벌 네비게이션 (전 페이지 공통)
+   ├─ Cmd+K / Ctrl+K / `/` 단축키 (입력 포커스 외) → Command Palette 오픈
+   │   ├─ routes (/about, /projects, /blog, /contact, /legal) 인덱스
+   │   ├─ projects 슬러그 인덱스
+   │   ├─ posts 슬러그 인덱스
+   │   ├─ ↑↓ 네비, ↵ 진입, Esc 닫기, 토큰 기반 다중 키워드 필터
+   │   └─ 그룹 헤더(pages / projects / posts)
+   ├─ Topbar: 브랜드(tkstar.dev) / 현재 경로(~/about) / 검색 트리거 / 테마 토글
+   └─ Footer: © + GitHub / X / RSS / Contact / (앱 등록 시) Legal Index
+
+3. 청중별 자연 수렴 동선
+   ├─ B2B 청중 → About Page 본문 검토 → "PDF로 저장하기" → window.print() → Contact
+   └─ B2C 청중 → Projects (ls-style 행 리스트) → Project Detail Case Study → "의뢰하기" CTA → Contact
+
+4. Contact 페이지 (의뢰/제안 접수)
+   ├─ 폼 입력: 이름, 회사(선택), 이메일, 의뢰 유형(B2B/B2C/기타), 메시지
+   ├─ 클라이언트 검증(이름·이메일 정규식·메시지 10자) + Cloudflare Turnstile
+   │   ↓
+   │   [검증 성공] → Resend 발신 (hello@tkstar.dev → 본인 메일)
+   │       ↓ 자동응답 메일 발송 (제출자에게)
+   │       ↓ 성공 화면 ("자동응답 메일이 {email}으로 발송되었습니다. 평균 회신 24시간 이내.")
+   │   [검증 실패/필드 오류] → 인라인 에러 표시, 폼 유지
+   │
+   └─ 발신 실패 (Resend 오류) → 에러 토스트 + "직접 메일 보내기" 링크 (mailto)
+
+5. 보조 동선
+   ├─ Blog → 글 목록 → 글 상세 (RSS 피드 구독, sticky sidebar TOC + 공유)
+   ├─ Project Detail (sticky sidebar: meta + on-this-page TOC) → prev/next + 의뢰하기
+   ├─ Blog Detail (sticky sidebar: TOC + share) → prev/next + 모든 글
+   ├─ Legal Index (`/legal`) → 출시 앱 카드 → 앱별 Terms/Privacy
+   └─ App Terms/Privacy → chrome-free webview 모드(Topbar/Footer 미노출, max-width 680px)
+
+6. Not Found Fallback
+   └─ 미존재 경로 → 터미널 메타포 메시지(`cd: no such route: <path>`) + Home 복귀 링크
+
+7. 외부 노출
+   ├─ 검색엔진/SNS 공유 시 SSR + Satori OG 이미지(1200×630)로 미리보기 자동 생성
+   ├─ Google Search Console / Naver Search Advisor에 sitemap.xml 제출 (F019)
+   ├─ /sitemap.xml — index 가능 페이지만 (Home, About, Projects, Project Detail, Blog, Blog Detail, Contact, Legal Index)
+   ├─ /robots.txt — User-agent: *, Allow: /, Sitemap 위치 명시
+   └─ JSON-LD 구조화 데이터로 Rich Result 노출 (Person / BlogPosting / CreativeWork / BreadcrumbList)
+```
+
+## Feature Specifications
+
+### 1. Core Features
+
+| ID | Feature Name | Description | Priority | Related Pages |
+|----|--------------|-------------|----------|---------------|
+| **F001** | Hero (whoami + 검색 + 빠른 링크) | `whoami` 프롬프트 + "ship solo. ship fast." 카피 + 3-버튼 클러스터([검색해서 이동], [/about], [/projects]). 청중 분기는 별도 CTA가 아닌 콘텐츠 라우팅으로 자연 수렴 | Core (랜딩 진입점) | Home Page |
+| **F002** | About (사이트 자체 이력서) | 이력·기술스택·경력·학력·수상 표시. 화면용 + 인쇄용 듀얼 레이아웃 | Core (B2B 청중 주요 검토 자료) | About Page |
+| **F003** | PDF 저장 (CSS print) | About 페이지 "⎙ PDF" 버튼 → `window.print()` 호출. `@media print` 전용 스타일로 Topbar/Footer/검색트리거/토글 숨김, 색상 단순화 | Core (이력서 다운로드 대체) | About Page |
+| **F004** | Projects 목록 (ls-style 행 리스트) | `slug/ + title + date / summary / stack pills` 행 구조 + 태그 필터 칩. 카드 그리드 아님. velite + MDX 컬렉션, frontmatter Zod 검증 | Core (포트폴리오 진열) | Projects Page |
+| **F005** | Project Case Study | 프로젝트 상세 페이지. 문제 정의 → 접근 → 결과(수치/스크린샷) 구조. shiki 코드블록. 데스크탑 880px+에서 sticky sidebar(meta: year/role/stack pills + on-this-page TOC). 하단 prev/next 프로젝트 + 가운데 "의뢰하기 →" primary CTA | Core (B2C 청중 신뢰성 검증) | Project Detail Page |
+| **F006** | Blog 목록 | 발행일 역순 정렬, 태그 필터. 월 1편 작성 운영 | Core (전문성 노출, SEO 자산) | Blog Page |
+| **F007** | Blog 상세 | MDX 본문, shiki 코드블록, Satori OG, 데스크탑 880px+에서 sticky sidebar(on-this-page TOC + 공유 도구: copy link / X 공유). 하단 prev/next + 가운데 "모든 글" 버튼 | Core (글 단위 SEO 진입점) | Blog Detail Page |
+| **F008** | Contact Form | 이름/회사(선택)/이메일/의뢰 유형(B2B·B2C·기타)/메시지 입력. Resend로 hello@tkstar.dev → 본인 메일 발신, 제출자에게 React Email 템플릿 자동응답 | Core (모든 분기의 수렴점) | Contact Page |
+| **F009** | Contact 스팸 방지 | Cloudflare Turnstile 위젯으로 폼 제출 검증 (Workers 친화 선택) | Core (메일 only 채널 보호) | Contact Page |
+| **F016** | Cmd+K Command Palette (글로벌 검색 네비) | 모든 routes(/about, /projects, /blog, /contact, /legal) + projects 슬러그 + posts 슬러그를 인덱싱한 클라이언트 사이드 검색. ⌘K(macOS) / Ctrl+K(Windows·Linux) / `/` 단축키로 오픈(입력 포커스 중엔 무시). 토큰 기반 다중 키워드 필터, ↑↓ 네비, ↵ 진입, Esc 닫기, 그룹 헤더(pages/projects/posts). **사이트의 주 네비게이션 패러다임** | Core (주 네비게이션) | All Pages (root layout 마운트) |
+
+### 2. Required Support Features
+
+| ID | Feature Name | Description | Priority | Related Pages |
+|----|--------------|-------------|----------|---------------|
+| **F010** | 다크모드 토글 | 시스템 `prefers-color-scheme` 기본 추종, 헤더 토글로 강제 전환. 선택은 localStorage(`proto-theme`) 저장. **`[data-theme='dark|light']` HTML 속성 셀렉터 전략** (Tailwind v4 클래스 전략 X) | Support (디자인 톤 — 다크 기본) | All Pages |
+| **F011** | SSR + 동적 OG 이미지 | React Router v7 Framework mode SSR. 블로그/프로젝트 슬러그별 Satori로 OG 이미지(1200×630 통일) 빌드/요청 시 생성 | Support (검색엔진·SNS 공유 미리보기) | Blog Detail Page, Project Detail Page |
+| **F012** | RSS 피드 | 블로그 글 RSS 2.0 XML 자동 생성 (`/rss.xml` 엔드포인트) | Support (구독자 채널 확보) | Blog Page |
+| **F013** | 분석 (쿠키 없음) | Cloudflare Web Analytics 스니펫 삽입. 쿠키·개인정보 수집 없음 | Support (트래픽 가시성, 운영용) | All Pages |
+| **F014** | 앱 약관 라우팅 (스켈레톤) | 출시 앱별 이용약관/개인정보처리방침 페이지 + `/legal` 인덱스(앱 목록 허브). velite collection으로 `legal/apps/[slug]/terms.mdx`, `privacy.mdx` 관리. **앱 내부 WebView 친화 chrome-free 모드** (Topbar/Footer 미노출, max-width 680px, 본문/TOC 중심). MVP에서는 라우팅 + 빈 템플릿만 준비 | Support (앱 출시 시 점진적 채움) | Legal Index Page, App Terms Page, App Privacy Page |
+| **F017** | Home Featured + Recent Posts | Hero 아래 `## featured` (Project 데이터 모델의 `featured: true` 항목, 큰 카드 1개) + `## recent posts` (최근 3개 행 + "모두 보기 →") | Support (Home 정보 밀도, SEO 진입점) | Home Page |
+| **F018** | SEO 메타데이터 & Sitemap | 페이지별 `<title>`, `<meta name="description">`, canonical URL. Open Graph(og:title/description/image/url/type) + Twitter Card(summary_large_image). React Router v7 `meta` export로 페이지별 정의. `/sitemap.xml` resource route — 정적 routes + projects/posts 슬러그 + Legal Index만 포함 (개별 App Terms/Privacy 및 404는 제외). `/robots.txt` resource route — User-agent: *, Allow: /, Sitemap 위치 명시. JSON-LD 구조화 데이터: Person(Home/About), BlogPosting(Blog Detail), CreativeWork/SoftwareSourceCode(Project Detail), BreadcrumbList. **차등 인덱싱 정책**: App Terms/App Privacy는 `noindex, follow` (앱 심사 시 URL 접근은 허용), Not Found Fallback은 `noindex, nofollow`. | Support (검색엔진 가시성) | All Pages (root layout meta + 페이지별 meta export) |
+| **F019** | 검색엔진 등록 (Google + Naver) | Google Search Console 도메인 소유권 인증 + sitemap.xml 제출. Naver Search Advisor `naver-site-verification` 메타 태그 + sitemap 제출 (한국어 사이트 필수). Bing Webmaster Tools는 후순위 [ASSUMPTION: MVP 후 등록]. 인증 메타 태그는 환경변수(`GOOGLE_SITE_VERIFICATION`, `NAVER_SITE_VERIFICATION`)로 관리, root layout에서 조건부 렌더. 검증: 배포 후 `site:tkstar.dev` 검색으로 indexing 확인. | Support (검색엔진 등록) | All Pages (root layout) |
+
+### 3. Deferred / Removed Features
+
+- **(Removed)** ~~F001 청중 분기 split CTA~~ — design 정본의 검색 우선 컨셉 채택으로 폐기. F001은 "Hero whoami + 검색 + 빠른 링크"로 재정의됨.
+- **(Removed)** ~~F015 청중 분기 기억 (localStorage `audience`)~~ — F001 폐기에 따라 동시 폐기. 단, `proto-theme` localStorage는 F010이 그대로 사용.
+- 뉴스레터 구독 / 이메일 마케팅
+- 블로그 댓글 시스템 (Giscus 등)
+- i18n (영문/일문 등 추가 언어)
+- 가격표 / 결제 페이지
+- `/uses`, `/now` 페이지 (운영 부담 대비 가치 낮아 제외)
+- 별도 PDF 이력서 트리 (CSS print로 충분)
+- DB 기반 콘텐츠 관리 (CMS, Supabase 등 — 현재 static MDX로 충분)
+- 인증/회원가입/로그인 (1인 기업 사이트, 사용자 계정 불필요)
+- Motion 라이브러리 도입 — design 정본은 절제된 CSS-only motion(`@keyframes blink/fade` + 120ms hover transition)만 사용. **MVP에서는 CSS-only로 충분, Motion 라이브러리 도입 보류** [ASSUMPTION: 추후 인터랙션 보강 시 재검토]
+
+## Menu Structure
+
+```
+🌐 tkstarDev Navigation
+
+📌 Header / Topbar (전 페이지 공통, chrome-free 모드 제외)
+├── 🏷  Brand: tkstar.dev → Home
+├── 🛣  현재 경로 표시 (브레드크럼 형태, ~ + path)
+├── 🔍 Search Trigger (⌘K) → F016 (Command Palette)
+└── 🌓 Theme Toggle → F010 (다크모드)
+
+🔗 Footer (전 페이지 공통, chrome-free 모드 제외)
+├── © 2026 tkstar.dev · solo
+├── 🐙 GitHub 링크 (외부)
+├── 𝕏  X 링크 (외부)
+├── 📡 RSS Feed (`/rss.xml`) → F012
+├── ✉️ Contact 빠른 링크 → Contact Page
+├── ⚖️ Legal Index (앱 1개 이상 등록 시 노출) → Legal Index Page (F014)
+└── 📊 (비가시) Analytics 스니펫 → F013
+
+🧭 글로벌 네비게이션 (전 페이지 공통)
+└── ⌨️ Cmd+K / Ctrl+K / `/` → Command Palette (F016)
+    ├── pages: /, /about, /projects, /blog, /contact, /legal
+    ├── projects: 모든 프로젝트 슬러그
+    └── posts: 모든 블로그 슬러그
+
+🧭 콘텐츠 내부 진입
+├── Home → Featured Project 카드 / Recent Posts 행 → 각 상세
+├── Projects Page → ls-style 행 클릭 → Project Detail Page → F005
+├── Blog Page → 글 카드 클릭 → Blog Detail Page → F007, F011
+└── Legal Index → 앱 카드 → App Terms / App Privacy (chrome-free)
+
+🚧 Not Found Fallback
+└── 미존재 경로 → 터미널 메시지 + Home 복귀 링크
+
+🤖 크롤러 / 검색엔진 인덱싱 (사용자 비가시)
+├── 📋 /sitemap.xml — index 가능 페이지만 (F018)
+├── 🚫 /robots.txt — User-agent: *, Allow: /, Sitemap 위치 (F018)
+└── 🏷️ root layout `<head>` — Google/Naver site verification (F019)
+
+🪟 chrome-free Layout (App Terms / App Privacy)
+└── Topbar/Footer 미노출, `.legal` 컨테이너만 (max-width 680px, sober mode)
+```
+
+## Page-by-Page Detailed Features
+
+### Home Page
+
+> **Implemented Features:** `F001`, `F017`, `F016`, `F010`, `F013`, `F018`, `F019` | **Menu Location:** Brand 클릭 → Home
+
+| Item | Content |
+|------|---------|
+| **Role** | 사이트의 첫 진입점. whoami 자기소개 + 검색 진입 + Featured Project + Recent Posts로 두 청중을 모두 자연스럽게 수렴 |
+| **Entry Path** | 외부 검색 결과 / SNS 공유 / 직접 입력 / 헤더 브랜드 클릭 |
+| **User Actions** | Hero 카피 확인 → [검색해서 이동] 클릭(또는 ⌘K) → palette 오픈 / [/about] 또는 [/projects] 빠른 링크 / Featured Project 카드 클릭 / Recent Posts 행 클릭 / "모두 보기 →" 클릭 / 다크모드 토글 |
+| **Key Features** | • Hero: `whoami` 프롬프트 + "ship solo. ship fast." 카피 + 핵심 요약 (역할, 한 줄 소개)<br>• 3-버튼 클러스터: [검색해서 이동] → palette / [/about] / [/projects]<br>• Featured Project 섹션 — Project 모델 `featured: true` 항목, 큰 카드 1개 (F017)<br>• Recent Posts 섹션 — 최근 3개 행 + "모두 보기 →" → Blog Page (F017) |
+| **Next Navigation** | palette / About / Projects / Project Detail / Blog / Blog Detail |
+
+### About Page
+
+> **Implemented Features:** `F002`, `F003`, `F016`, `F010`, `F013`, `F018`, `F019` | **Menu Location:** palette / Home 빠른 링크 / Footer
+
+| Item | Content |
+|------|---------|
+| **Role** | 사이트 자체가 이력서. 이력·기술스택·경력·학력·수상을 한 페이지에 정리하여 B2B 청중의 검토를 즉시 만족 |
+| **Entry Path** | palette `/about` / Home 빠른 링크 / Footer Contact 인근 / 외부 검색 결과 |
+| **User Actions** | 본문 스크롤로 섹션별 검토. 인쇄 시 "⎙ PDF" 버튼 클릭 → 시스템 인쇄 다이얼로그에서 PDF 저장 |
+| **Key Features** | • 헤더: 이름 + 한 줄 포지셔닝 + 이메일 + [⎙ PDF] 버튼<br>• 기술스택 카드 3개 (frontend / edge·backend / quality) — 카테고리별 그룹<br>• 경력 (역순)<br>• 학력 / 수상 카드 2개 [ASSUMPTION: 자격증 데이터 추가 시 별도 카드]<br>• `@media print` 스타일: Topbar/Footer/검색트리거/토글 숨김, 색상 단순화 (F003) |
+| **Next Navigation** | palette / Projects / Blog / Contact |
+
+### Projects Page
+
+> **Implemented Features:** `F004`, `F016`, `F010`, `F013`, `F018`, `F019` | **Menu Location:** palette / Home 빠른 링크
+
+| Item | Content |
+|------|---------|
+| **Role** | 프로젝트 포트폴리오 진열. B2C 청중에게 "이 사람이 내 문제를 해결할 수 있는가"의 1차 답변 |
+| **Entry Path** | palette `/projects` / Home 빠른 링크 / Home Featured Project 카드 / About 페이지 내부 링크 |
+| **User Actions** | 태그 칩으로 필터링 → ls-style 행 훑기 → 관심 프로젝트 행 클릭 |
+| **Key Features** | • **ls-style 행 리스트** (카드 그리드 아님)<br>  - 행 구조: `slug/ + title + date(YYYY-MM)` / `summary` / `stack pills`<br>• 태그 필터 칩 (상단)<br>• velite + MDX collection (frontmatter Zod 검증)<br>• 행 클릭 → Project Detail Page 이동 |
+| **Next Navigation** | Project Detail Page / Contact Page |
+
+### Project Detail Page
+
+> **Implemented Features:** `F005`, `F011`, `F016`, `F010`, `F013`, `F018`, `F019` | **Menu Location:** Projects Page → 행 클릭 / Home Featured
+
+| Item | Content |
+|------|---------|
+| **Role** | Case Study. 한 프로젝트를 "문제 → 접근 → 결과(수치/스크린샷)" 구조로 깊이 있게 보여주어 신뢰성 입증 |
+| **Entry Path** | Projects Page에서 행 클릭 / Home Featured 카드 / 외부 검색·SNS 공유 (Satori OG) |
+| **User Actions** | 본문 스크롤로 문제·접근·결과 순차 검토 → sticky sidebar에서 섹션 점프 → 코드블록·스크린샷 확인 → 하단 [의뢰하기 →] CTA 또는 prev/next로 이동 |
+| **Key Features** | • frontmatter: title / summary / date(YYYY-MM) / stack / tags / metrics / featured / cover<br>• 본문(MDX): 문제(problem) → 접근(approach) → 결과(metrics + 코드/스크린샷)<br>• shiki 코드블록 highlight<br>• Satori 동적 OG 1200×630 (F011)<br>• **데스크탑 880px+ sticky sidebar (`.two-col`)**<br>  - meta 박스: year / role / stack pills<br>  - on-this-page TOC: problem / approach / results 앵커 [ASSUMPTION: MDX 헤딩 자동 추출, rehype-toc 또는 velite 후처리]<br>• 하단 3분할: `← prev` / **`의뢰하기 →` primary** / `next →` |
+| **Next Navigation** | prev/next 프로젝트 / Projects Page / Contact Page |
+
+### Blog Page
+
+> **Implemented Features:** `F006`, `F012`, `F016`, `F010`, `F013`, `F018`, `F019` | **Menu Location:** palette / Home Recent Posts "모두 보기"
+
+| Item | Content |
+|------|---------|
+| **Role** | 글 목록 진열. 월 1편 작성으로 전문성 노출 + SEO 자산 누적 |
+| **Entry Path** | palette `/blog` / Home Recent Posts → "모두 보기" / 외부 검색 결과 / RSS 리더의 백링크 |
+| **User Actions** | 발행일 역순 목록 훑기 → 태그 필터 → 글 카드/제목 클릭 → RSS 구독 링크 사용 |
+| **Key Features** | • 발행일 역순 정렬<br>• 태그 필터<br>• 글 행: 제목, 발행일(date), 한 줄 요약(lede), 태그, 읽는 시간(read)<br>• RSS 피드 링크 (`/rss.xml`) (F012) |
+| **Next Navigation** | 글 카드 클릭 → Blog Detail Page |
+
+### Blog Detail Page
+
+> **Implemented Features:** `F007`, `F011`, `F016`, `F010`, `F013`, `F018`, `F019` | **Menu Location:** Blog Page → 글 카드 클릭 / Home Recent Posts
+
+| Item | Content |
+|------|---------|
+| **Role** | 글 단위 SEO 진입점. 외부 검색에서 직접 도달하는 첫 페이지로 자주 동작 |
+| **Entry Path** | Blog Page에서 카드 클릭 / Home Recent Posts / 외부 검색 / SNS 공유(Satori OG) / RSS 리더 |
+| **User Actions** | 본문 읽기 → sticky sidebar TOC로 섹션 점프 → 코드블록 복사 → 사이드바 share(copy link / X) → 하단 prev/next 또는 "모든 글" |
+| **Key Features** | • frontmatter: title / lede / date / tags / read<br>• MDX 본문 + shiki 코드블록 highlight<br>• Satori 동적 OG 1200×630 (F011)<br>• **데스크탑 880px+ sticky sidebar (`.two-col`)**<br>  - on-this-page TOC: h2 헤딩 자동 추출 앵커<br>  - share 도구: [copy link] / [share on X]<br>• 하단 3분할: `← prev` / **[모든 글] → /blog** / `next →` |
+| **Next Navigation** | prev/next 글 / Blog Page / Contact Page |
+
+### Contact Page
+
+> **Implemented Features:** `F008`, `F009`, `F016`, `F010`, `F013`, `F018`, `F019` | **Menu Location:** palette / Footer / About·Project Detail의 의뢰 CTA
+
+| Item | Content |
+|------|---------|
+| **Role** | B2B 채용 제안과 B2C 의뢰 모두를 메일 채널로 수렴. 가격은 노출하지 않고 메시지로 협의 시작 |
+| **Entry Path** | palette `/contact` / Footer Contact 링크 / About 본문 / Project Detail의 "의뢰하기" CTA |
+| **User Actions** | 폼 작성: 이름, 회사(선택), 이메일, 의뢰 유형(B2B/B2C/기타) 라디오, 메시지 → Turnstile 검증 → 제출 |
+| **Key Features** | • 입력 필드: 이름, 회사(선택), 이메일, 의뢰 유형 라디오, 메시지<br>• 클라이언트 검증: 이름·이메일 정규식·메시지 10자 이상<br>• Cloudflare Turnstile 위젯 (F009)<br>• 제출 → Resend로 hello@tkstar.dev → 본인 메일 발신 (F008)<br>• 제출자에게 React Email 템플릿 자동응답 메일<br>• 성공 화면 카피: "자동응답 메일이 {email}으로 발송되었습니다. 평균 회신 24시간 이내."<br>• 발신 실패 시 mailto 폴백 링크 |
+| **Next Navigation** | 성공 → Contact 성공 상태 화면 / 실패 → 폼 유지 + 에러 표시 |
+
+### Legal Index Page
+
+> **Implemented Features:** `F014`, `F016`, `F010`, `F013`, `F018`, `F019` | **Menu Location:** Footer — Legal (앱 1개 이상 등록 시 노출)
+
+| Item | Content |
+|------|---------|
+| **Role** | 출시 앱 목록 허브. 각 앱의 Terms/Privacy 링크를 카드 형태로 진열 |
+| **Entry Path** | Footer Legal 링크 (앱 등록 후) / palette `/legal` / 외부 앱 내부 링크의 폴백 |
+| **User Actions** | 앱 카드 훑기 → 원하는 앱의 Terms 또는 Privacy 클릭 |
+| **Key Features** | • velite collection 인덱스 — `legal/apps/[slug]/terms.mdx`, `privacy.mdx` 자동 수집<br>• 앱 카드: 앱명 / slug / [terms.mdx] / [privacy.mdx] 링크<br>• MVP에서는 데이터 0개 또는 1개(`moai`) 시연용. 앱 출시 시 점진적 채움<br>• 일반 chrome (Topbar/Footer 노출) |
+| **Next Navigation** | 앱 카드 클릭 → App Terms Page 또는 App Privacy Page (chrome-free) |
+
+### App Terms Page
+
+> **Implemented Features:** `F014`, `F010`, `F013`, `F018`, `F019` | **Menu Location:** Legal Index → 앱 카드 / 출시 앱 내부 링크
+
+| Item | Content |
+|------|---------|
+| **Role** | 출시 앱별 이용약관 페이지. 앱 내부 WebView에서 호출되므로 chrome-free sober 모드 |
+| **Entry Path** | 출시 앱 내부 "이용약관" 링크 (WebView) / Legal Index Page |
+| **User Actions** | 약관 본문 읽기 (스크롤). 외부 링크 클릭으로 앱·스토어로 복귀 |
+| **Key Features** | • velite collection: `legal/apps/[slug]/terms.mdx`<br>• MDX 본문 렌더링 + 발효일 메타 [ASSUMPTION: 약관 표준 메타]<br>• **chrome-free 레이아웃** — Topbar/Footer 미노출, `.legal` 컨테이너 (max-width 680px, sober mode, TOC, 표 스타일)<br>• MVP: 빈 템플릿 + 라우팅만 준비 (F014)<br>• **SEO 정책**: `<meta name='robots' content='noindex, follow'>` (앱 심사 시 URL 접근 허용 + 검색엔진 인덱싱 차단). canonical은 유지하여 검토자 URL 공유 시 정본 경로 보장. sitemap.xml에서 제외 |
+| **Next Navigation** | 같은 앱의 Privacy 페이지 / 외부 앱·스토어 |
+
+### App Privacy Page
+
+> **Implemented Features:** `F014`, `F010`, `F013`, `F018`, `F019` | **Menu Location:** Legal Index → 앱 카드 / 출시 앱 내부 링크
+
+| Item | Content |
+|------|---------|
+| **Role** | 출시 앱별 개인정보처리방침 페이지. 앱 내부 WebView에서 호출되므로 chrome-free sober 모드 |
+| **Entry Path** | 출시 앱 내부 "개인정보처리방침" 링크 (WebView) / Legal Index Page |
+| **User Actions** | 처리방침 본문 읽기. 외부 링크로 복귀 |
+| **Key Features** | • velite collection: `legal/apps/[slug]/privacy.mdx`<br>• MDX 본문 렌더링 + 시행일·문의 채널(hello@tkstar.dev) 메타 [ASSUMPTION: 표준 메타]<br>• **chrome-free 레이아웃** — Topbar/Footer 미노출, `.legal` 컨테이너 (max-width 680px, sober mode)<br>• MVP: 빈 템플릿 + 라우팅만 준비 (F014)<br>• **SEO 정책**: `<meta name='robots' content='noindex, follow'>` (앱 심사 시 URL 접근 허용 + 검색엔진 인덱싱 차단). canonical은 유지하여 검토자 URL 공유 시 정본 경로 보장. sitemap.xml에서 제외 |
+| **Next Navigation** | 같은 앱의 Terms 페이지 / 외부 앱·스토어 |
+
+### Not Found Fallback
+
+> **Implemented Features:** `F016`, `F010`, `F013`, `F018`, `F019` | **Menu Location:** 미존재 경로 진입 시
+
+| Item | Content |
+|------|---------|
+| **Role** | 미존재 경로의 폴백. 터미널 메타포로 디자인 톤 일관성 유지 |
+| **Entry Path** | 잘못된 URL 직접 입력 / 깨진 링크 클릭 |
+| **User Actions** | 메시지 확인 → "← /home" 링크 클릭 또는 ⌘K로 검색 |
+| **Key Features** | • 터미널 메시지: `cd: no such route: <path>`<br>• "← /home" 복귀 링크<br>• [ASSUMPTION: React Router v7 splat(`*`) 라우트 또는 ErrorBoundary로 구현]<br>• **SEO 정책**: `<meta name='robots' content='noindex, nofollow'>` + 404 응답 코드. splat 라우트가 어떤 path든 받기 때문에 명시적 차단 필수. sitemap.xml에서 제외 |
+| **Next Navigation** | Home / Command Palette |
+
+## Acceptance Criteria
+
+> 핵심 5개 Feature(F003, F008, F009, F011, F016)에 대해 Given-When-Then 형식의 검증 가능 기준. TDD-First 원칙에 따라 각 항목은 테스트로 자동화 가능해야 한다. 그 외 Feature(F001/F002/F004-F007/F010/F012-F019)는 콘텐츠/SEO/UI 표시 위주로, 별도 AC 없이 Page-by-Page Key Features의 bullet을 검증 기준으로 사용한다.
+
+### F003 — PDF 저장 (CSS print)
+
+- **AC-F003-1**: Given About 페이지에서 사용자가 `[⎙ PDF]` 버튼을 클릭한다 / When `window.print()` 다이얼로그가 열린다 / Then `@page { size: A4; margin: 0 }` 적용 + Topbar/Footer/검색트리거/토글이 시각적으로 숨겨진다(`display: none`).
+- **AC-F003-2**: Given 본문에 OKLCH 색상이 포함된 섹션이 존재한다 / When 인쇄 미리보기를 본다 / Then `print-color-adjust: exact`가 적용되어 화면과 동일한 색이 유지된다(또는 sRGB로 자동 변환되어도 가독성 손상이 없다).
+- **AC-F003-3**: Given 인쇄 미리보기가 열린 상태 / When 페이지 경계에 도달한다 / Then 섹션 헤딩(`h2`)이 페이지 하단에 고립되지 않는다(`break-after: avoid` 또는 `page-break-inside: avoid`).
+
+### F008 — Contact Form
+
+- **AC-F008-1**: Given 사용자가 `/contact`에서 이름·이메일·메시지(10자 이상)·의뢰 유형을 채우고 Turnstile을 통과한다 / When `submit` 클릭 / Then Resend API가 1회 호출되어 hello@tkstar.dev → 본인 메일이 발신되고, 제출자에게 자동응답 메일이 발송되며, 성공 화면이 표시된다.
+- **AC-F008-2**: Given 이메일 필드가 RFC 5322 위반 형식("foo@", "foo.com" 등) / When `submit` 클릭 / Then 클라이언트 측에서 차단되어 인라인 에러 메시지가 표시되고 네트워크 요청이 발생하지 않는다.
+- **AC-F008-3**: Given 메시지 길이가 10자 미만이거나 5000자를 초과한다 / When `submit` 클릭 / Then 인라인 에러 + 폼 상태 유지(입력값 손실 없음).
+- **AC-F008-4**: Given Resend API가 5xx 또는 네트워크 오류로 실패한다 / When 응답 수신 / Then 에러 토스트 + `mailto:hello@tkstar.dev?subject=...&body=...` 폴백 링크가 노출된다(폼 입력값을 mailto body에 prefill).
+
+### F009 — Contact 스팸 방지 (Turnstile)
+
+- **AC-F009-1**: Given Contact 폼이 마운트된다 / When Turnstile 위젯이 렌더된다 / Then `cf-turnstile-response` 토큰이 폼 상태에 바인딩되고, 토큰이 비어있으면 submit 버튼이 비활성화된다.
+- **AC-F009-2**: Given 클라이언트가 위조한 토큰을 함께 submit / When 서버가 `https://challenges.cloudflare.com/turnstile/v0/siteverify`에 검증 요청 / Then `success: false`를 받아 400 응답 + Resend 호출이 일어나지 않는다.
+- **AC-F009-3**: Given 동일 IP가 1시간 내 5회 이상 submit한다 / When 6번째 submit / Then 서버가 429 응답 + "잠시 후 다시 시도해주세요" 메시지(Workers KV 또는 DO 기반 rate-limit).
+
+### F011 — SSR + 동적 OG 이미지
+
+- **AC-F011-1**: Given `/blog/[slug]` 또는 `/projects/[slug]`의 OG 이미지 URL을 요청한다 / When Satori가 frontmatter(title/date/tags)로 PNG를 생성 / Then 1200×630 PNG + `Content-Type: image/png` + `Cache-Control: public, max-age=31536000, immutable` 응답.
+- **AC-F011-2**: Given 존재하지 않는 slug에 대한 OG 요청 / When 리소스 라우트 핸들러 실행 / Then 404가 아니라 default fallback PNG(브랜드 로고 + "tkstar.dev")를 반환한다.
+- **AC-F011-3**: Given Satori 렌더링이 실패한다(폰트 binary 누락 등) / When 응답 생성 / Then 정적 fallback PNG로 graceful degradation + Workers logs에 에러 기록.
+
+### F016 — Cmd+K Command Palette
+
+- **AC-F016-1**: Given 페이지에 입력 포커스가 없다 / When 사용자가 ⌘K(macOS) 또는 Ctrl+K(Win/Linux) 또는 `/`를 입력 / Then palette가 열리고 검색 input에 자동 포커스된다.
+- **AC-F016-2**: Given input/textarea/contenteditable에 포커스가 있다 / When 위 단축키 입력 / Then palette가 열리지 않고 기본 입력 동작이 유지된다.
+- **AC-F016-3**: Given palette가 열린 상태 + 검색어 "rou nav" 입력 / When 토큰 기반 필터 실행 / Then "rou"와 "nav"를 모두 포함하는 항목만 그룹 헤더(pages/projects/posts) 별로 표시된다.
+- **AC-F016-4**: Given 결과 리스트 / When ↓ ↑로 네비 + ↵로 진입 + Esc로 닫기 / Then 키보드만으로 모든 동작이 수행되고, 마우스 호버로 선택 인덱스가 동기화된다.
+- **AC-F016-5**: Given 사이트가 처음 로드된다 / When 검색 인덱스 fetch / Then 인덱스 JSON은 gzip 100KB 이하 + 본문(body)을 포함하지 않으며 세션당 1회만 fetch된다.
+
+---
+
+## Assumptions Register
+
+> PRD 곳곳에 분산된 `[ASSUMPTION]` 태그를 한 곳에 모아 **해소 게이트**(어느 ROADMAP 단계까지 구체화되어야 하는지)와 함께 관리한다. 게이트 통과 시 해당 가정을 PRD 본문에서 [FACT]로 갱신하거나 제거한다.
+
+| ID | 위치 | 가정 내용 | 해소 게이트 | 해소 시점 |
+|----|------|-----------|-------------|-----------|
+| A001 | About Page Key Features | 자격증 데이터 추가 시 별도 카드 | F002 구현 PR | About 데이터 모델 확정 시 |
+| A002 | Project Detail Key Features | on-this-page TOC는 rehype-toc 또는 velite 후처리로 자동 추출 | F005 구현 PR | velite 도입 PR(Phase 2) |
+| A003 | App Terms / App Privacy | 약관/처리방침 표준 메타(version/effective_date 외) | F014 구현 PR | 첫 앱(`moai`) 등록 시 |
+| A004 | Not Found Fallback | React Router v7 splat(`*`) 또는 ErrorBoundary 구현 방식 | F018/F019 구현 시 | Phase 1(라우팅 스켈레톤) |
+| A005 | Tech Stack — JetBrains Mono | Satori OG에서 폰트 binary fetch 경로 | F011 구현 PR | Satori 도입 시 |
+| A006 | Tech Stack — Content Pipeline | velite / shiki / Satori / Zod 미설치 → 작업 시 `bun add -D ...` | velite 도입 PR(Phase 2) | Phase 2 시작 시 일괄 |
+| A007 | Tech Stack — Search Index | 별도 검색 라이브러리 없이 includes/score 단순 검색 | F016 구현 PR | 데이터 규모 증가 시 재검토 |
+| A008 | Tech Stack — SEO | 검색엔진 verification 토큰은 wrangler secrets put으로 주입 | F019 구현 PR | 배포 후 토큰 발급 시 |
+| A009 | Tech Stack — Email | React Email / Resend / Turnstile 미설치 + 환경변수 필요 | F008/F009 구현 PR | Phase 3 Contact 작업 시 |
+| A010 | Tech Stack — Hosting | 도메인 등록 채널(CF Registrar / Porkbun) 미정 | 배포 PR 직전 | DNS 작업 시점 |
+| A011 | F019 — Bing | Bing Webmaster Tools는 MVP 후 등록 | MVP 완료 후 | 운영 안정화 후 |
+| A012 | Deferred — Motion | Motion 라이브러리는 추후 인터랙션 보강 시 재검토 | MVP 완료 후 | 사용자 피드백 수집 후 |
+
+> **운용 규칙**: 새 `[ASSUMPTION]` 태그를 PRD 본문에 추가할 때는 반드시 본 표에 ID와 해소 게이트를 함께 등록한다. ROADMAP의 각 phase 종료 시점에 본 표를 점검하여 해당 phase가 게이트인 항목이 모두 [FACT]로 전환됐는지 확인한다.
+
+---
+
+## Data Model
+
+> 본 프로젝트는 **DB를 사용하지 않는다**. 아래 "모델"은 빌드 타임에 velite가 MDX 파일을 파싱하여 생성하는 **콘텐츠 컬렉션 스키마**이다(frontmatter Zod 검증). 런타임에는 정적 JSON으로 번들된다. 명명은 design 정본(`docs/design-system/proto/data.jsx`)을 따른다.
+
+### Project (프로젝트 Case Study 콘텐츠)
+
+| 필드 | 타입 | 비고 |
+|------|------|------|
+| `slug` | string | URL 경로용 고유 식별자 |
+| `title` | string | 프로젝트명 |
+| `summary` (alias `lede`) | string | 한 줄 요약 |
+| `date` | string (YYYY-MM 또는 ISO) | 프로젝트 시기 (design은 `YYYY-MM` 사용) |
+| `tags` | string[] | 분류 태그 |
+| `stack` | string[] | 사용 기술 (사이드바 stack pills + 행 리스트의 stack pills) |
+| `metrics` | [string, string][] | 결과 지표 키-값 쌍 (예: `["MAU", "12k"]`) |
+| `featured` | boolean (optional) | Home Featured 섹션 노출 여부 (`true`인 첫 항목 사용) |
+| `cover` | string (optional) | 1200×630 cover 이미지 경로 (Project Detail의 `.cover` + Satori OG fallback) |
+| `body` | MDX | 본문 — 내부에 problem / approach / results 섹션을 작성. frontmatter 필드 아님 |
+
+### Post (블로그 글 콘텐츠)
+
+| 필드 | 타입 | 비고 |
+|------|------|------|
+| `slug` | string | URL 경로용 |
+| `title` | string | 글 제목 |
+| `lede` (alias `summary`) | string | 한 줄 요약 |
+| `date` | string (ISO) | 발행일 |
+| `tags` | string[] | 분류 태그 |
+| `read` (alias `reading_time`) | number (분) | 예상 읽는 시간 |
+| `body` | MDX | 본문 |
+
+### AppLegalDoc (앱별 약관/개인정보처리방침 콘텐츠)
+
+| 필드 | 타입 | 비고 |
+|------|------|------|
+| `app_slug` | string | 앱 식별자 (`moai` 등) |
+| `doc_type` | `"terms" \| "privacy"` | 문서 유형 |
+| `version` | string | 버전 표기 |
+| `effective_date` | string (ISO) | 발효일 (terms) / 시행일 (privacy) |
+| `body` | MDX | 본문 |
+
+### ContactSubmission (Contact Form 1회성 인메모리 페이로드, 영속 저장 없음)
+
+- `name`, `company`(optional), `email`, `inquiry_type`("B2B" | "B2C" | "etc"), `message`, `turnstile_token`
+
+### ThemePreference (브라우저 localStorage 키 — F010 전용)
+
+- key: `proto-theme`, value: `"dark" | "light"` (시스템 추종이 기본, 강제 전환 시에만 저장)
+
+## Tech Stack (Latest Versions)
+
+### Frontend Framework
+
+- **React Router 7.14.0 (Framework mode, SSR)** — 정적 콘텐츠도 SEO/OG 미리보기를 위해 SSR 사용
+- **TypeScript 5.9.3** — 타입 안정성
+- **React 19.2.4 / React DOM 19.2.4** — UI 라이브러리
+
+### Styling & UI
+
+- **TailwindCSS 4.2.2** (`@tailwindcss/vite` 4.2.2)
+  - 디자인 토큰은 design 정본(`docs/design-system/styles.css` `:root`)을 Tailwind v4 `@theme { --color-*, --font-* }` 블록으로 이식
+  - **다크모드: `[data-theme='dark|light']` HTML 속성 셀렉터 전략** (Tailwind v4 클래스 전략 X). `@variant dark (&:where([data-theme='dark'], [data-theme='dark'] *))` 커스텀 변형 정의
+  - 색상 함수: `oklch()` / `color-mix(in oklab, ...)` native 사용 (모던 브라우저만 타깃)
+  - `backdrop-filter: blur(...)` 사용 (Topbar / Palette backdrop)
+- **CSS-only 애니메이션** — `@keyframes blink/fade` + `transition: all 120ms ease`. Motion 라이브러리는 MVP 보류 (Deferred 참고)
+
+### Typography
+
+- **JetBrains Mono** — primary mono 폰트 (전 페이지 본문/UI/코드)
+- **Self-host 권장** — `/public/fonts/JetBrainsMono-*.woff2` + CSS `@font-face`로 자가 호스팅 (Cloudflare Workers + SSR 환경에서 CDN race condition / FOIT/FOUT 방지)
+- design 정본의 `Gaegu` / `Caveat` 임포트는 **drop** (와이어프레임 단계에서만 사용)
+- Satori OG 이미지 렌더링 시 `JetBrainsMono-Regular.ttf` binary asset을 fetch/import 형태로 전달 [ASSUMPTION: assets fetch 경로는 구현 단계에서 결정]
+
+### Content Pipeline
+
+- **velite** — MDX 컬렉션 빌더 (Project, Post, AppLegalDoc) [ASSUMPTION: 미설치, 작업 시 `bun add -D velite`]
+- **MDX** — 콘텐츠 작성 포맷
+- **shiki** — 코드블록 syntax highlight (rehype-shiki 또는 velite 플러그인) [ASSUMPTION: 미설치]. `.codeblock` 외곽 컨테이너만 디자인 토큰을 따르고 내부 토큰 색상은 shiki 출력에 위임
+- **Satori** — 빌드 타임/SSR 동적 OG 이미지 생성 (1200×630 표준) [ASSUMPTION: 미설치]
+- **Zod** — frontmatter 스키마 검증 (velite 내장 사용) [ASSUMPTION: velite 의존으로 자동 포함]
+- **on-this-page TOC** — MDX 헤딩 자동 추출 [ASSUMPTION: rehype-slug + 자체 TOC 추출 또는 velite 후처리]
+
+### Search Index (F016)
+
+- **velite collection JSON을 클라이언트 번들로 import** — routes / projects 슬러그 / posts 슬러그를 in-memory 토큰 검색 [ASSUMPTION: 별도 검색 라이브러리 없이 단순 includes/score, 데이터 규모 작음]
+
+### SEO & Indexing
+
+- **sitemap.xml / robots.txt** — React Router v7 resource route로 동적 생성 (별도 라이브러리 불필요). `BuildSitemap.service`가 velite collection을 읽어 index 가능 페이지만 출력
+- **JSON-LD Structured Data** — `<script type="application/ld+json">` 직접 삽입. schema.org 표준 (Person, BlogPosting, CreativeWork/SoftwareSourceCode, BreadcrumbList)
+- **Meta Tags (per-page)** — React Router v7 `meta` export로 페이지별 `<title>`, `description`, `canonical`, OG, Twitter Card 정의
+- **Search Engine Verification** — `GOOGLE_SITE_VERIFICATION` / `NAVER_SITE_VERIFICATION` 환경변수로 root layout `<head>` 조건부 렌더 [ASSUMPTION: 배포 후 Search Console / Naver Search Advisor에서 토큰 발급 → wrangler secrets put으로 주입]
+- **Indexing Policy** — App Terms/App Privacy는 `noindex, follow` (앱 심사용 URL 접근 허용, 검색엔진 분산 방지), Not Found Fallback은 `noindex, nofollow`. canonical은 모든 페이지 유지
+
+### Forms & Email
+
+- **React Email** — Contact 자동응답 메일 템플릿 [ASSUMPTION: 미설치]
+- **Resend** — Contact form 발신 (hello@tkstar.dev → 본인 메일, 제출자 자동응답 메일). 월 3,000건 무료 [ASSUMPTION: 미설치, 환경변수 `RESEND_API_KEY` 필요]
+- **Cloudflare Turnstile** — Contact form 스팸 방지. Workers 친화 [ASSUMPTION: 클라이언트 위젯 + 서버 검증, 환경변수 `TURNSTILE_SECRET` 필요]
+
+### Hosting / Edge / Email Routing
+
+- **Cloudflare Workers (SSR)** — `wrangler 4.85.0`, `@cloudflare/vite-plugin 1.33.2`로 배포
+- **Cloudflare Email Routing** — 수신: `hello@tkstar.dev` → 개인 Gmail forward (무료)
+- **Cloudflare Web Analytics** — 쿠키 없는 분석 스니펫
+- **도메인** — `tkstar.dev` (Cloudflare Registrar 또는 Porkbun → CF transfer) [ASSUMPTION: 등록 채널은 사용자가 결정]
+
+### Build / Dev / Quality
+
+- **Vite 8.0.3** — 번들러
+- **@vitejs/plugin-react 6.0.1** — React 플러그인
+- **Vitest 4.1.5** + **jsdom 29.1.0** + **@testing-library/react 16.3.2** + **@testing-library/jest-dom 6.9.1** + **@testing-library/dom 10.4.1** — 테스트 (TDD-First, Clean Architecture 4-layer 적용)
+- **Biome 2.4.13** — Lint & Format
+- **isbot 5.1.36** — 봇 판별 (SSR 분기)
+
+### Package Management
+
+- **bun** — 의존성 관리 (`bun.lock` 사용)
+
+### Implementation Notes (design ↔ production 갭)
+
+- design 정본(`prototype.html` + `proto/*.jsx`)은 **React 18 + babel-standalone IIFE 환경** 가정으로 작성됨 (`window.X` 글로벌 패턴). production 빌드에 그대로 import 불가 — **React Router v7 ESM 모듈 + React 19 컴포넌트로 포팅 필요**.
+- design `design-canvas.jsx`(31KB) / `tweaks-panel.jsx`(18KB)는 **디자이너 작업용 운영 도구**(Figma-ish 캔버스 + 라이브 트윅 패널, omelette 호스트 의존). **사용자 노출 X, production 번들에 포함하지 않음**.
+- design `components/*.jsx`(home V1/V2/V3, terminal 등)는 **와이어프레임 변형 모음**. 정본은 `proto/*` 쪽이며 그 외 변형은 폐기 또는 참조 자료.
+- design `terminal.css` + `components/terminal.jsx`(`TermWindow` chrome)는 **폐기됨** — 정본의 `prototype.css`(`.topbar` / `.foot`)로 대체.
+
+---
+
+## Consistency Validation (Web)
+
+### Step 1: Feature Specs → Page Connection
+- F001 → Home / F002, F003 → About / F004 → Projects / F005 → Project Detail / F006 → Blog / F007 → Blog Detail / F008, F009 → Contact / F010 → All Pages / F011 → Project Detail, Blog Detail / F012 → Blog (RSS) / F013 → All Pages / F014 → Legal Index, App Terms, App Privacy / F016 → All Pages (root layout) / F017 → Home / F018 → All Pages (차등 인덱싱 정책 — App Terms/Privacy noindex,follow / 404 noindex,nofollow) / F019 → All Pages (root layout) — 모두 매핑됨.
+
+### Step 2: Menu Structure → Page Connection
+- Header(Brand→Home, 검색트리거→F016, 토글→F010), Footer(GitHub/X/RSS/Contact/Legal Index), Cmd+K palette(F016), 콘텐츠 내부(Project Detail / Blog Detail / Legal Index / App Terms / App Privacy / Not Found Fallback) 모두 Page-by-Page에 정의됨.
+
+### Step 3: Page-by-Page → Back-reference
+- 모든 페이지의 Implemented Features는 Feature Specifications에 정의됨. 모든 페이지는 palette(F016) 또는 콘텐츠 내부 링크로 도달 가능. App Terms/Privacy는 chrome-free + Legal Index/앱 내부 링크 경유.
+
+### Step 4: Missing & Orphan
+- Feature Specs에만 있고 페이지에 없는 항목: 없음.
+- 페이지에만 있고 Feature Specs에 없는 항목: 없음.
+- 메뉴에만 있고 페이지가 없는 항목: 없음.
+- F018, F019는 root layout 마운트 패턴(F016과 동일)으로 모든 페이지에 매핑됨 — Missing/Orphan 없음.
+- F018의 차등 인덱싱 정책은 페이지 Key Features에 명시되어 있어 정합성 유지.
+
+### Step 5–6 (Medium ONLY)
+- Small scale, 단일 사용자, 인증 없음 → 해당 없음.

--- a/docs/PROJECT-STRUCTURE.md
+++ b/docs/PROJECT-STRUCTURE.md
@@ -1,0 +1,591 @@
+# Project Structure Guide
+
+## Overview
+
+**tkstarDev**는 1인 기업(개발자)의 개인 브랜드 웹사이트로, 사이트 자체가 이력서 역할을 하며 B2B(기업/HR) 채용 제안과 B2C(프리랜서 의뢰)를 단일 도메인(`tkstar.dev`)에서 수렴시킨다. **콘텐츠 100% static (DB 없음)**, **한국어 only**, **Cmd+K 검색 중심 네비게이션**을 핵심 패러다임으로 한다.
+
+본 프로젝트는 정적 콘텐츠 사이트임에도 불구하고 **Clean Architecture 4-layer 분리**를 엄격히 적용한다. 이는 (1) Resend / Turnstile / Satori / velite 등 다수의 Infrastructure 외부 의존성을 격리하고, (2) Contact Form / Command Palette 검색 / OG 이미지 생성 등 비자명한 Application 유스케이스를 테스트 가능하게 만들기 위함이다.
+
+**Architecture Pattern**: Clean Architecture (4-layer separation)
+**Framework**: React Router 7.14 Framework mode (SSR)
+**Runtime**: Cloudflare Workers (`wrangler 4.85.0`, `@cloudflare/vite-plugin 1.33.2`)
+**Key Characteristics**:
+- Platform-agnostic core (`app/`)는 Cloudflare Workers SSR에 1차 타깃, Express/Fastify 어댑터 추가 가능
+- 의존성 흐름은 단방향: **Presentation → Application → Domain**
+- **Infrastructure는 Application의 Port를 구현**하는 형태로 DI 컨테이너에서 조립됨
+- 콘텐츠는 **velite + MDX**로 빌드 타임에 정적 컬렉션으로 변환되어 Infrastructure read-side adapter 역할
+
+---
+
+## Top-Level Directory Structure
+
+```
+tkstar-dev/
+├── app/                              # 핵심 애플리케이션 (Clean Architecture 4-layer)
+│   ├── domain/                       # 비즈니스 엔티티 + 스키마 + 에러
+│   ├── application/                  # 유스케이스 + Port 정의
+│   ├── infrastructure/               # 외부 시스템 어댑터 + DI
+│   ├── presentation/                 # UI 컴포넌트 + 훅 + 라이브러리 + 라우트 모듈
+│   │   └── routes/                   # React Router v7 라우트 모듈 (CA Presentation 내부)
+│   ├── root.tsx                      # 루트 컴포넌트 (ThemeProvider, CommandPalette mount)
+│   ├── routes.ts                     # flatRoutes({ rootDirectory: "presentation/routes" })
+│   ├── entry.server.tsx              # SSR 엔트리
+│   ├── entry.client.tsx              # 하이드레이션 엔트리
+│   ├── app.css                       # Tailwind v4 진입점 + @theme 토큰
+│   └── env.d.ts                      # 클라이언트 환경변수 타입
+│
+├── workers/                          # Cloudflare Workers SSR 엔트리
+│   └── app.ts                        # fetch handler → React Router request handler
+│
+├── content/                          # velite 소스 (MDX 원본)
+│   ├── projects/                     # *.mdx → Project collection
+│   ├── posts/                        # *.mdx → Post collection
+│   └── legal/
+│       └── apps/[slug]/              # terms.mdx + privacy.mdx → AppLegalDoc
+│
+├── .velite/                          # velite 빌드 산출물 (생성, gitignore)
+│
+├── public/                           # 정적 자산 (빌드 없이 서빙)
+│   ├── fonts/                        # JetBrainsMono *.woff2 self-host
+│   └── favicon, robots.txt, etc.
+│
+├── docs/                             # 문서
+│   ├── PRD.md                        # 제품 요구사항 정본
+│   ├── ROADMAP.md                    # 구현 단계 정의
+│   ├── PROJECT-STRUCTURE.md          # (본 문서)
+│   └── design-system/                # 디자인 정본 (production 번들 제외)
+│       ├── prototype.html            # React 18 + babel-standalone 데모
+│       ├── styles.css                # 디자인 토큰 (oklch, color-mix)
+│       └── proto/                    # *.jsx 와이어프레임 정본
+│
+├── test/                             # 레이어 간 공유 테스트 유틸
+│   ├── fixtures/                     # 공용 픽스처 (mock projects/posts)
+│   └── utils/                        # 테스트 헬퍼 (renderWithRouter 등)
+│
+├── .claude/                          # AI agent / harness 설정
+├── velite.config.ts                  # velite 컬렉션 + Zod frontmatter 스키마
+├── react-router.config.ts            # React Router v7 설정 (ssr: true 등)
+├── vite.config.ts                    # Vite + @cloudflare/vite-plugin + @tailwindcss/vite
+├── wrangler.toml                     # Cloudflare Workers 배포 설정
+├── biome.json                        # Lint & Format
+├── vitest.config.ts                  # 테스트 설정 (jsdom env)
+├── tsconfig.json / tsconfig.app.json # TS 설정 + path alias
+├── package.json
+└── bun.lock
+```
+
+**Key directories**:
+- `app/` — 핵심 애플리케이션 (4-layer CA)
+- `app/presentation/routes/` — React Router v7 라우트 모듈 (Presentation 레이어 내부에 위치, `flatRoutes({ rootDirectory: "presentation/routes" })`로 file convention 자동 추론)
+- `workers/` — Cloudflare Workers SSR 엔트리 (Platform Adapter)
+- `content/` — velite MDX 소스 (콘텐츠 정본)
+- `.velite/` — velite 빌드 산출물 (런타임 read-side 데이터)
+- `public/fonts/` — JetBrains Mono self-host (Edge SSR + FOIT 방지)
+- `public/wasm/` — yoga.wasm (Satori standalone build용)
+- `public/search-index.json` — 빌드 타임 검색 인덱스 산출물 (F016)
+- `docs/design-system/` — 디자인 정본 (production 번들 **제외**, 디자인 서브에이전트 참고용)
+- `test/` — 레이어 간 공유 테스트 유틸 (단위 테스트는 각 레이어 `__tests__/`에 colocate)
+
+---
+
+## app/ Directory (Core Application)
+
+Clean Architecture 4-layer 구조를 따른다. 안쪽 레이어(Domain)는 어떤 외부 의존성도 가지지 않으며, 바깥 레이어(Presentation)는 안쪽 레이어만 import 한다.
+
+### app/domain/
+
+**Role**: 비즈니스 엔티티 정의 — 외부 의존성 없음 (React, velite, Resend 등 어떤 라이브러리도 import 금지)
+
+**CA Layer**: Domain (innermost)
+
+**Contains**:
+- **Entity** (`*.entity.ts`) — 콘텐츠 도메인 모델 (Project, Post, AppLegalDoc)
+- **Value Object** (`*.vo.ts`) — 불변 값 객체 (ContactSubmission, ThemePreference)
+- **Types** — 도메인 관련 TypeScript 타입 (Slug, InquiryType, Tag 등)
+- **Schemas** (`*.schema.ts`) — Zod 검증 스키마 (frontmatter 검증 규칙은 여기서 정의 → velite/Application 양쪽이 재사용)
+- **Errors** — 도메인 전용 에러 클래스 (`ProjectNotFoundError`, `InvalidContactSubmissionError`)
+
+**Dependency Rule**: **No imports from outer layers**. `zod`만 허용 (스키마 정의 도구이며 런타임 의존성 없음).
+
+**Structure**:
+```
+app/domain/
+├── project/
+│   ├── project.entity.ts             # Entity (slug, title, summary, date, tags, stack, metrics, featured, cover, body)
+│   ├── project.schema.ts             # Zod frontmatter 스키마
+│   ├── project.errors.ts
+│   └── __tests__/
+│       └── project.schema.test.ts
+├── post/
+│   ├── post.entity.ts                # Entity (slug, title, lede, date, tags, read, body)
+│   ├── post.schema.ts
+│   └── __tests__/
+├── legal/
+│   ├── app-legal-doc.entity.ts       # Entity (app_slug, doc_type, version, effective_date, body)
+│   └── app-legal-doc.schema.ts
+├── contact/
+│   ├── contact-submission.vo.ts      # Value Object (name, company?, email, inquiry_type, message)
+│   ├── contact-submission.schema.ts  # 이름·이메일 정규식·메시지 10자
+│   └── contact.errors.ts
+└── theme/
+    └── theme-preference.vo.ts        # "dark" | "light"
+```
+
+---
+
+### app/application/
+
+**Role**: 유스케이스 (비즈니스 로직 오케스트레이션) + 외부 시스템 인터페이스 정의
+
+**CA Layer**: Application
+
+**Contains**:
+- **Service** (`*.service.ts`) — 유스케이스 / 비즈니스 로직 서비스 구현 (Domain 엔티티 사용 + Port 호출)
+- **Port** (`*.port.ts`) — 외부 시스템 인터페이스 (Infrastructure가 구현)
+- **Mapper** (`*.mapper.ts`) — Entity ↔ DTO 변환 (필요 시)
+
+**Port와 Service 관계**:
+- `*.port.ts` — 인터페이스 정의 ("무엇을 할 수 있는가")
+- `*.service.ts` — 유스케이스 / 비즈니스 로직 구현 ("어떻게 하는가") — file-conventions.md에 따라 유스케이스도 `*.service.ts`로 통일
+
+**Dependency Rule**: Domain만 import 허용. Infrastructure는 import 금지 (Port만 정의하고 구현체는 DI로 주입받음).
+
+**Structure**:
+```
+app/application/
+├── content/
+│   ├── ports/
+│   │   ├── project-repository.port.ts  # findAll, findBySlug, findFeatured, findRelated(prev/next)
+│   │   ├── post-repository.port.ts     # findAll, findBySlug, findRecent(n)
+│   │   └── legal-repository.port.ts    # findAppDoc(app_slug, doc_type), listApps
+│   └── services/
+│       ├── list-projects.service.ts
+│       ├── get-project-detail.service.ts    # prev/next 포함
+│       ├── get-featured-project.service.ts  # Home Featured (F017)
+│       ├── list-posts.service.ts
+│       ├── get-post-detail.service.ts
+│       ├── get-recent-posts.service.ts      # Home Recent 3개 (F017)
+│       └── __tests__/
+├── contact/
+│   ├── ports/
+│   │   ├── email-sender.port.ts        # send(to, template, data)
+│   │   └── captcha-verifier.port.ts    # verify(token) → boolean
+│   └── services/
+│       ├── submit-contact-form.service.ts # F008 + F009
+│       └── __tests__/
+├── search/
+│   └── services/
+│       └── build-search-index.service.ts  # F016 — routes/projects/posts 토큰 인덱스
+├── og/
+│   ├── ports/
+│   │   └── og-image-renderer.port.ts   # render(template, data) → PNG bytes
+│   └── services/
+│       ├── render-project-og.service.ts # F011
+│       └── render-post-og.service.ts
+├── feed/
+│   └── services/
+│       └── build-rss-feed.service.ts    # F012
+└── seo/
+    └── services/
+        └── build-sitemap.service.ts     # F018
+```
+
+---
+
+### app/infrastructure/
+
+**Role**: 외부 시스템 통합 (Application의 Port 구현체)
+
+**CA Layer**: Infrastructure
+
+**Contains**:
+- **config/** — DI 컨테이너 (Composition Root) — Workers 부팅 시 모든 의존성 조립. **수제 Plain object/Map 방식** (의존성 그래프 작아 라이브러리 도입 미사용)
+- **content/** — velite read-side 어댑터 (`.velite/` 산출물을 Domain 엔티티로 매핑) — `*.repository.ts` 구현체
+- **email/** — Resend + React Email 통합
+- **captcha/** — Cloudflare Turnstile 서버 검증
+- **og/** — Satori standalone + Workers Asset Binding으로 폰트/yoga.wasm 로드
+- **analytics/** — Cloudflare Web Analytics 스니펫 주입 헬퍼
+- **search/** — 빌드 타임 검색 인덱스 빌더 산출 위치 (F016 산출물은 Application 서비스가 생성, `public/search-index.json` 출력)
+
+**Dependency Rule**: Application의 Port를 구현하기 위해 Application/Domain을 import. Presentation은 import 금지.
+
+**Structure**:
+```
+app/infrastructure/
+├── config/
+│   ├── container.ts                  # 수제 DI: type Container = {...}; buildContainer(env): Container
+│   └── __tests__/
+├── content/
+│   ├── velite-project.repository.ts  # implements project-repository.port — `.velite/projects` 매핑
+│   ├── velite-post.repository.ts
+│   ├── velite-legal.repository.ts
+│   ├── mappers/                      # velite raw output → Domain Entity (`*.mapper.ts`)
+│   └── __tests__/
+├── email/
+│   ├── resend-email-sender.ts        # implements email-sender.port (env.RESEND_API_KEY)
+│   ├── templates/                    # React Email 템플릿 (자동응답 메일)
+│   └── __tests__/
+├── captcha/
+│   ├── turnstile-verifier.ts         # implements captcha-verifier.port (env.TURNSTILE_SECRET)
+│   └── __tests__/
+├── og/
+│   ├── satori-og-renderer.ts         # implements og-image-renderer.port — env.ASSETS.fetch()로 ttf/yoga.wasm 로드
+│   └── __tests__/
+├── search/
+│   └── __tests__/                    # build-search-index.service.ts (Application)에서 호출되는 빌드 산출물 검증
+└── analytics/
+    └── cloudflare-web-analytics.ts
+```
+
+**velite Content Pipeline 노트**: velite는 빌드 타임에 `content/**/*.mdx`를 파싱하여 Zod 검증을 거친 JSON으로 `.velite/` 디렉토리에 출력한다. Infrastructure 레이어의 `velite-project.repository.ts` 등은 이 정적 산출물을 import하여 Domain 엔티티로 매핑하는 read-side 어댑터로 동작한다. 즉 velite는 "DB 없이도 Repository 패턴을 유지"하기 위한 빌드 타임 ETL이며, **DB가 없다는 점이 CA를 약화시키지 않는다**.
+
+**Search Index 빌드 노트 (F016)**: velite afterBuild 훅 또는 별도 빌드 스크립트(`build-search-index.service.ts`)에서 `.velite/projects.json` + `posts.json`의 `{slug, title, summary, tags}`만 추출하여 `public/search-index.json`으로 출력한다. 본문(body)은 제외하여 인덱스 크기를 최소화하고, 클라이언트는 lazy fetch + CDN 캐싱으로 로드한다. 정적 라우트 목록(`/about`, `/projects`, ... )은 빌드 타임에 하드코딩 머지.
+
+---
+
+### app/presentation/
+
+**Role**: UI, 훅, Presentation 전용 라이브러리 (라우트는 별도 `app/routes/` 또는 `app/presentation/routes/`)
+
+**CA Layer**: Presentation (outermost)
+
+**Contains**:
+- **components/** — UI 컴포넌트 (Topbar, Footer, CommandPalette, ProjectRow, PostRow, CodeBlock, OnThisPageToc, ContactForm, ThemeToggle 등) — React 컴포넌트는 PascalCase 파일명을 유지 (file-conventions.md는 PascalCase 컴포넌트를 별도로 제한하지 않음)
+- **hooks/** — 커스텀 React 훅 (`useTheme`, `useCommandPalette`, `useTurnstile`)
+- **lib/** — Presentation 유틸 (`formatDate`, `slugifyHeading`, `printResume` 트리거)
+- **layouts/** — chrome / chrome-free (Topbar/Footer 노출 vs `.legal` 컨테이너) 레이아웃
+
+**Dependency Rule**: Application 유스케이스만 import 허용. Infrastructure 직접 import 금지 (loader/action에서 DI 컨테이너로 유스케이스를 받아 호출).
+
+**Structure**:
+```
+app/presentation/
+├── components/
+│   ├── chrome/
+│   │   ├── Topbar.tsx                # 브랜드 / 경로 / 검색트리거 / 테마토글
+│   │   ├── Footer.tsx                # GitHub / X / RSS / Contact / Legal Index
+│   │   └── ThemeToggle.tsx           # F010 — [data-theme] 속성 셀렉터 전략
+│   ├── palette/
+│   │   └── CommandPalette.tsx        # F016 — Cmd+K / Ctrl+K / `/`
+│   ├── project/
+│   │   ├── ProjectRow.tsx            # ls-style 행 (slug/ + title + date / summary / stack pills)
+│   │   ├── ProjectMetaSidebar.tsx    # year / role / stack pills
+│   │   └── OnThisPageToc.tsx
+│   ├── post/
+│   │   ├── PostRow.tsx
+│   │   └── ShareTools.tsx            # copy link / X 공유
+│   ├── content/
+│   │   ├── MdxRenderer.tsx           # velite body → React (shiki 코드블록)
+│   │   └── CodeBlock.tsx
+│   ├── contact/
+│   │   ├── ContactForm.tsx           # F008
+│   │   └── TurnstileWidget.tsx       # F009
+│   └── notfound/
+│       └── TerminalNotFound.tsx      # `cd: no such route: <path>`
+├── hooks/
+│   ├── useTheme.ts                   # localStorage `proto-theme` + system 추종
+│   ├── useCommandPalette.ts          # 단축키 + 토큰 검색
+│   └── useTurnstile.ts
+├── lib/
+│   ├── format.ts                     # date YYYY-MM 등
+│   └── print.ts                      # F003 — window.print()
+└── layouts/
+    ├── ChromeLayout.tsx              # Topbar + Footer (대부분의 페이지)
+    └── ChromeFreeLayout.tsx          # `.legal` 컨테이너만 (App Terms/Privacy)
+```
+
+---
+
+### app/presentation/routes/ (React Router v7 Routes — Presentation 내부)
+
+**Role**: 페이지 / 리소스 라우트 진입점. loader / action에서 DI 컨테이너로부터 유스케이스를 받아 호출하고 Presentation 컴포넌트에 데이터를 전달.
+
+**CA Layer**: Presentation 내부 (CA 가시성 확보를 위해 `app/routes/` 대신 `app/presentation/routes/`에 배치)
+
+**Dependency Rule**: Application 유스케이스 + Presentation 컴포넌트만 import. Domain 엔티티 타입은 사용 가능하나 Infrastructure 직접 import 금지.
+
+**typegen 정합성**: `app/routes.ts`에서 `flatRoutes({ rootDirectory: "presentation/routes" })`로 등록. 라우트 모듈 파일이 `appDirectory`(=`app/`) 내부에 있으므로 `.react-router/types/` 자동 생성이 정상 동작 ([React Router Type Safety](https://reactrouter.com/explanation/type-safety)). 모듈을 `app/` 외부로 옮기면 typegen이 깨지므로 금지.
+
+```ts
+// app/routes.ts
+import { flatRoutes } from "@react-router/fs-routes";
+import type { RouteConfig } from "@react-router/dev/routes";
+export default flatRoutes({ rootDirectory: "presentation/routes" }) satisfies RouteConfig;
+```
+
+**Route file conventions (React Router v7 file-based, rootDirectory=presentation/routes)**:
+```
+app/presentation/routes/
+├── _index.tsx                        # Home (`/`) — Hero whoami + Featured + Recent Posts
+├── about.tsx                         # `/about` — 이력서 + PDF 인쇄 듀얼 레이아웃
+├── projects._index.tsx               # `/projects` — ls-style 행 리스트 + 태그 필터
+├── projects.$slug.tsx                # `/projects/:slug` — Case Study + sticky sidebar
+├── blog._index.tsx                   # `/blog` — 발행일 역순 + 태그 필터
+├── blog.$slug.tsx                    # `/blog/:slug` — sticky sidebar (TOC + share)
+├── contact.tsx                       # `/contact` — Form + Resend + Turnstile
+├── legal._index.tsx                  # `/legal` — 출시 앱 목록 (chrome 노출)
+├── legal.$app.terms.tsx              # `/legal/:app/terms` — chrome-free
+├── legal.$app.privacy.tsx            # `/legal/:app/privacy` — chrome-free
+├── rss[.xml].tsx                     # `/rss.xml` — RSS 2.0 XML resource route
+├── sitemap[.xml].tsx                 # `/sitemap.xml` — F018 sitemap resource route
+├── robots[.txt].tsx                  # `/robots.txt` — F018 robots resource route
+├── og.projects.$slug[.png].tsx       # `/og/projects/:slug.png` — Satori PNG resource route
+├── og.blog.$slug[.png].tsx           # `/og/blog/:slug.png` — Satori PNG resource route
+└── $.tsx                             # splat — Not Found Fallback (터미널 메타포)
+```
+
+**loader / action 패턴**:
+- `loader({ context })`에서 `context.container.get('listProjects')` 등으로 유스케이스를 꺼내 실행
+- `action({ context, request })`에서 `context.container.get('submitContactForm')` 호출 (Contact)
+- 리소스 라우트(`rss[.xml]`, `og.*[.png]`)는 컴포넌트 export 없이 `loader`만 export하여 Response를 직접 반환
+
+---
+
+### app/ Root Files
+
+| File | Role | When to modify |
+|------|------|----------------|
+| `root.tsx` | React Router 루트 컴포넌트, `[data-theme]` 부착, `<CommandPalette/>` 마운트, Cloudflare Web Analytics 스니펫 | 글로벌 Provider / 전역 컴포넌트 추가 시 |
+| `routes.ts` | `flatRoutes({ rootDirectory: "presentation/routes" })` — file convention 자동 추론 | 라우트 디렉토리 변경 시 |
+| `entry.server.tsx` | SSR 엔트리. `isbot`로 봇 분기, `renderToReadableStream` 사용 (Workers 친화) | SSR 커스터마이징 시 |
+| `entry.client.tsx` | 하이드레이션 엔트리 | 거의 수정 없음 |
+| `app.css` | Tailwind v4 진입점. `@theme { --color-*, --font-* }` 토큰 + `@variant dark (&:where([data-theme='dark'], [data-theme='dark'] *))` 커스텀 변형 | 디자인 토큰 추가/변경 시 |
+| `env.d.ts` | 클라이언트 환경변수 타입 (`import.meta.env`) | 클라이언트 환경변수 추가 시 |
+
+---
+
+## workers/ Directory (Cloudflare Workers Entry)
+
+**Role**: Cloudflare Workers 런타임 엔트리포인트. `fetch(request, env, ctx)` 핸들러에서 (1) DI 컨테이너를 환경변수(`env.RESEND_API_KEY`, `env.TURNSTILE_SECRET` 등)로 조립, (2) React Router v7 request handler를 생성, (3) `context`에 컨테이너를 주입하여 호출.
+
+**CA Layer**: Platform Adapter (Composition Root의 호출 지점)
+
+**Structure**:
+```
+workers/
+└── app.ts                            # default export { fetch }
+```
+
+**의존성 흐름**:
+```
+workers/app.ts
+  └─ Infrastructure/config/container.ts (수제 DI 조립)
+      └─ buildContainer(env) → { listProjects, submitContactForm, ... }
+      └─ Infrastructure/* (Resend, Turnstile, Velite Repos, Satori) 인스턴스화
+          └─ satori-og-renderer는 env.ASSETS Fetcher 주입받아 ttf/yoga.wasm 로드
+  └─ React Router request handler 생성
+      └─ getLoadContext: () => ({ container })
+  └─ Presentation routes의 loader/action이 context.container 사용
+```
+
+**환경변수 / 바인딩** (`wrangler.toml`):
+- `RESEND_API_KEY` (secret) — Resend 발신
+- `TURNSTILE_SECRET` (secret) — Cloudflare Turnstile 서버 검증
+- `CONTACT_TO_EMAIL` (var) — 본인 수신 메일
+- `GOOGLE_SITE_VERIFICATION` (var, optional) — F019 Google Search Console 인증
+- `NAVER_SITE_VERIFICATION` (var, optional) — F019 Naver Search Advisor 인증
+- `ASSETS` (assets binding, `directory = "./public"`) — F011 Satori 폰트/yoga.wasm 로드용 ([Cloudflare Static Assets Binding](https://developers.cloudflare.com/workers/static-assets/binding/))
+
+```toml
+# wrangler.toml 발췌
+name = "tkstar-dev"
+main = "workers/app.ts"
+compatibility_date = "2026-04-01"
+
+[assets]
+binding = "ASSETS"
+directory = "./public"
+
+[vars]
+CONTACT_TO_EMAIL = "..."
+```
+
+---
+
+## content/ and .velite/ (Content Source + Build Output)
+
+**Role**: 콘텐츠 정본(`content/`)과 velite 빌드 산출물(`.velite/`).
+
+**CA Layer 매핑**: **Infrastructure read-side adapter의 입력 / 출력**
+- `content/` → 빌드 타임 입력 (개발자가 작성하는 MDX 정본)
+- `.velite/` → 런타임 입력 (Domain 엔티티로 매핑되어 Repository가 반환)
+
+**Architectural Rationale**: DB가 없는 정적 사이트에서도 **Repository 패턴을 깨뜨리지 않기 위해** velite를 빌드 타임 ETL로 사용한다. velite의 Zod frontmatter 검증은 Domain 스키마와 동일한 정의를 공유(`app/domain/*/*.schema.ts`)하여 컴파일 타임에 콘텐츠 무결성을 보장한다.
+
+**Structure**:
+```
+content/
+├── projects/
+│   ├── proto-toolkit.mdx             # frontmatter + body
+│   └── ...
+├── posts/
+│   ├── 2026-04-shipping-solo.mdx
+│   └── ...
+└── legal/
+    └── apps/
+        └── moai/
+            ├── terms.mdx
+            └── privacy.mdx
+
+.velite/                              # gitignore — 빌드 시 자동 생성
+├── projects.json
+├── posts.json
+└── legal.json
+```
+
+---
+
+## public/ Directory
+
+**Role**: 빌드 없이 직접 서빙되는 정적 자산.
+
+**CA Layer**: 없음 (Workers의 static asset 바인딩으로 서빙)
+
+**Contains**:
+- `fonts/JetBrainsMono-*.woff2` — 본문/UI 웹폰트 self-host (FOIT/FOUT 방지)
+- `fonts/JetBrainsMono-Regular.ttf` — Satori OG 렌더링용 (woff2는 Satori 미지원 → ttf 별도)
+- `wasm/yoga.wasm` — `satori/standalone` 초기화용 ([Satori standalone build for Cloudflare Workers](https://github.com/vercel/satori))
+- `search-index.json` — F016 빌드 타임 검색 인덱스 산출물 (클라이언트 lazy fetch)
+- `favicon.ico` (RSS / sitemap / robots는 `/rss.xml`, `/sitemap.xml`, `/robots.txt` 동적 resource route로 처리)
+
+**Asset Binding 사용 패턴**: `wrangler.toml`의 `[assets]` 블록(`binding = "ASSETS"`, `directory = "./public"`)으로 노출되며, Worker 코드에서 `env.ASSETS.fetch("https://x.local/fonts/JetBrainsMono-Regular.ttf").then(r => r.arrayBuffer())`로 ArrayBuffer 획득. URL hostname은 무관(pathname만 매칭)이며 외부 RTT가 없는 내부 fetch라 빠름.
+
+---
+
+## docs/ Directory (Documentation + Design Source)
+
+**Role**: 문서 + **디자인 정본 보관소**.
+
+**Contains**:
+- `PRD.md`, `ROADMAP.md`, `PROJECT-STRUCTURE.md` (본 문서)
+- `design-system/` — **디자인 정본 (production 번들 제외)**
+
+**design-system/ 처리 규칙 (중요)**:
+- `prototype.html` + `proto/*.jsx`는 **React 18 + babel-standalone IIFE 환경** 가정. `window.X` 글로벌 패턴 사용
+- production 빌드에 그대로 import 불가 — **React Router v7 ESM + React 19 컴포넌트로 포팅 필요** (`app/presentation/components/`로 이식)
+- 위치상 `app/` 외부이므로 `app/`에서 자연스럽게 import 그래프 외부에 있음 → 추가 차단 도구 불필요
+- 디자인 서브에이전트(`ux-design-lead`)가 **참고 정본**으로 사용. 코드 산출물의 import 대상이 아님
+
+---
+
+## test/ Directory (Shared Test Utilities)
+
+**Role**: 레이어 간 공유 테스트 픽스처 / 헬퍼.
+
+**Contains**:
+- `fixtures/` — mock projects/posts/legal 데이터, 공용 Zod 픽스처
+- `utils/` — `renderWithRouter`, `createMockContainer` 등 헬퍼
+
+**중요**: 단위 테스트 파일은 각 CA 레이어 내부의 `__tests__/` 디렉토리에 **co-locate**한다 (예: `app/domain/project/__tests__/project.schema.test.ts`). `test/`는 **레이어 간 공유 유틸 전용**.
+
+---
+
+## Path Aliases
+
+```typescript
+// tsconfig.app.json (예상)
+{
+  "compilerOptions": {
+    "paths": {
+      "~/*": ["./app/*"],
+      "~/domain/*": ["./app/domain/*"],
+      "~/application/*": ["./app/application/*"],
+      "~/infrastructure/*": ["./app/infrastructure/*"],
+      "~/presentation/*": ["./app/presentation/*"],
+      "#content/*": ["./.velite/*"]
+    }
+  }
+}
+```
+
+**Usage example**:
+```typescript
+// app/presentation/routes/projects.$slug.tsx
+import type { Project } from "~/domain/project/project.entity";
+import { ProjectMetaSidebar } from "~/presentation/components/project/ProjectMetaSidebar";
+// loader에서 context.container.get("getProjectDetail") 호출
+```
+
+---
+
+## Dependency Direction Rules (Summary)
+
+```
+Presentation (routes/, presentation/)
+    ↓ may import
+Application (application/)
+    ↓ may import
+Domain (domain/)
+    ↑ implemented by
+Infrastructure (infrastructure/)  ← workers/app.ts (Composition Root) wires everything
+```
+
+**금지 사항**:
+- Domain → Application/Infrastructure/Presentation import **금지**
+- Application → Infrastructure import **금지** (Port만 정의)
+- Presentation → Infrastructure 직접 import **금지** (loader/action에서 context로 유스케이스 받음)
+- `app/**` → `docs/design-system/**` import **금지** (위치상 자연 격리, 디자인 서브에이전트 참고용)
+
+---
+
+## File Location Summary by Task
+
+| Task | Location |
+|------|----------|
+| 새 페이지 추가 | `app/presentation/routes/` (file convention 준수) |
+| UI 컴포넌트 추가 | `app/presentation/components/` (PascalCase 컴포넌트 파일명 유지) |
+| 비즈니스 로직(유스케이스) 추가 | `app/application/{domain}/services/*.service.ts` |
+| 외부 시스템 인터페이스 정의 | `app/application/{domain}/ports/*.port.ts` |
+| 외부 시스템 구현 (Resend/Turnstile/Satori) | `app/infrastructure/{email\|captcha\|og}/` (Repository 구현은 `*.repository.ts`) |
+| 콘텐츠 모델/스키마 정의 | `app/domain/{project\|post\|legal\|contact}/` (`*.entity.ts`, `*.vo.ts`, `*.schema.ts`) |
+| MDX 콘텐츠 작성 | `content/{projects\|posts\|legal/apps}/` |
+| 정적 자산 추가 | `public/` |
+| 테스트 작성 | 각 레이어의 `__tests__/` (단위) / `test/` (공유 유틸) |
+| Cloudflare Workers 환경변수 추가 | `wrangler.toml` + `app/infrastructure/config/container.ts` |
+| 디자인 토큰 변경 | `app/app.css` (`@theme` 블록) — `docs/design-system/styles.css`에서 이식 |
+
+---
+
+## Cross-cutting Concerns Mapping
+
+| Concern | Layer | Module |
+|---------|-------|--------|
+| F010 다크모드 (`[data-theme]` + `proto-theme` localStorage) | Presentation | `presentation/hooks/useTheme.ts` + `root.tsx` |
+| F011 Satori OG 이미지 | Application Port + Infrastructure 구현 (Asset Binding) + Resource Route | `application/og/` + `infrastructure/og/satori-og-renderer.ts` (env.ASSETS Fetcher 주입) + `presentation/routes/og.*[.png].tsx` |
+| F012 RSS | Application 유스케이스 + Resource Route | `application/feed/services/build-rss-feed.service.ts` + `presentation/routes/rss[.xml].tsx` |
+| F013 Cloudflare Web Analytics | Presentation 스니펫 | `root.tsx` |
+| F016 Cmd+K Command Palette | Application 빌드 서비스 + Presentation(UI) | `application/search/services/build-search-index.service.ts` (→ `public/search-index.json`) + `presentation/components/palette/CommandPalette.tsx` (lazy fetch) |
+| F018 SEO sitemap/robots/JSON-LD | Application + Resource Route + Presentation meta | `application/seo/services/build-sitemap.service.ts` + `presentation/routes/{sitemap,robots}[.*].tsx` + 페이지별 `meta` export |
+| F019 검색엔진 인증 | Presentation 환경변수 조건부 렌더 | `root.tsx`의 `<head>` (`GOOGLE_SITE_VERIFICATION` / `NAVER_SITE_VERIFICATION` env) |
+| Contact (F008/F009) | Application 유스케이스 + Infrastructure 어댑터 2종 | `application/contact/services/submit-contact-form.service.ts` + `infrastructure/email/resend-email-sender.ts` + `infrastructure/captcha/turnstile-verifier.ts` |
+
+---
+
+## Architectural Decisions (Resolved)
+
+본 절은 초안에 포함되어 있던 [ASSUMPTION]을 교차 검증(context7 + WebSearch)으로 확정한 결정 사항이다.
+
+### D1. 라우트 디렉토리: `app/presentation/routes/` (CA Presentation 내부)
+- `app/routes.ts`에서 `flatRoutes({ rootDirectory: "presentation/routes" })`로 등록 — file convention 자동 추론 + CA 가시성 둘 다 확보
+- 라우트 모듈은 반드시 `appDirectory`(=`app/`) 내부에 위치 — typegen 정상 동작 조건 ([Issue #12993](https://github.com/remix-run/react-router/issues/12993))
+- **근거**: [React Router File Route Conventions](https://reactrouter.com/how-to/file-route-conventions), [Type Safety](https://reactrouter.com/explanation/type-safety)
+
+### D2. DI 컨테이너: 수제 Plain object/Map
+- `app/infrastructure/config/container.ts`의 `buildContainer(env): Container` 함수 한 개로 모든 의존성 조립
+- 의존성 그래프 깊이가 ~10개 수준 → `awilix` / `tsyringe` 등 라이브러리 ROI 낮음
+- `reflect-metadata` polyfill 불필요 (Workers 친화)
+
+### D3. F016 검색 인덱스: 빌드 타임 정적 산출물
+- `build-search-index.service.ts`(velite afterBuild 훅 또는 별도 스크립트)가 `.velite/*` → `public/search-index.json` 출력
+- 클라이언트는 lazy fetch + CDN 캐싱으로 로드. body 제외(`{slug, title, summary, tags}`만)하여 인덱스 크기 최소화
+- 콘텐츠 100+ 도달 시 FlexSearch/Fuse 도입 검토 (현재는 단순 토큰 매칭)
+
+### D4. design-system 격리: 위치 기반 자연 격리
+- `docs/design-system/`은 `app/` 외부 → import 그래프에 자연스럽게 포함되지 않음
+- 추가 차단 도구(Lint 규칙 등) 불필요. 디자인 서브에이전트의 참고 정본으로만 사용
+
+### D5. Satori 폰트/WASM 바인딩: Cloudflare Workers Asset Binding
+- `wrangler.toml`의 `[assets]` 블록(`binding = "ASSETS"`, `directory = "./public"`) 사용
+- Worker 내부에서 `env.ASSETS.fetch("https://x.local/fonts/JetBrainsMono-Regular.ttf").then(r => r.arrayBuffer())`로 폰트 ArrayBuffer 획득
+- `satori/standalone` + `env.ASSETS.fetch(".../wasm/yoga.wasm")`로 yoga.wasm 수동 로드 — Workers WASM 동적 로딩 제약 우회
+- **근거**: [Cloudflare Static Assets Binding](https://developers.cloudflare.com/workers/static-assets/binding/), [Satori Standalone Build](https://github.com/vercel/satori), [6 Pitfalls of Dynamic OG on Workers](https://dev.to/devoresyah/6-pitfalls-of-dynamic-og-image-generation-on-cloudflare-workers-satori-resvg-wasm-1kle)

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,0 +1,620 @@
+# tkstarDev Development Roadmap
+
+> 1인 기업(개발자) 개인 브랜드 사이트 `tkstar.dev`를 React Router v7 Framework + Cloudflare Workers SSR + Clean Architecture 4-layer로 빌드하기 위한 단계별 구현 계획. 본 로드맵은 PRD(F001~F019)와 PROJECT-STRUCTURE(CA 4-layer + velite + Workers Asset Binding)를 task 단위로 분해한 정본이며, **Structure-First → Inside-Out (Domain → Application → Infrastructure → Presentation) → TDD-First** 순서를 따른다.
+
+## Overview
+
+tkstarDev는 다음 핵심 가치를 단일 도메인에서 달성한다:
+
+- **사이트 자체가 이력서**: B2B(채용/HR)와 B2C(프리랜서 의뢰) 양쪽 청중을 콘텐츠 라우팅(About / Projects)으로 자연 수렴
+- **검색 우선 네비게이션**: Cmd+K Command Palette (F016)가 주 네비게이션 패러다임
+- **DB 없는 정적 콘텐츠 파이프라인**: velite + MDX + Zod 빌드 타임 ETL로 Repository 패턴 유지
+- **Edge SSR + 동적 OG**: Cloudflare Workers + Satori standalone + Asset Binding으로 슬러그별 OG 1200×630 이미지 생성
+- **운영 비용 0원 지향**: Cloudflare Workers / Email Routing / Web Analytics / Turnstile + Resend 무료 티어
+
+## Development Workflow
+
+1. **Task Planning**
+   - 기존 코드베이스를 학습하고 현재 상태를 파악한다
+   - `ROADMAP.md`를 갱신하여 새 task를 포함시킨다
+   - 우선순위가 높은 task를 마지막 완료 task 다음에 삽입한다
+
+2. **Task Creation**
+   - `/tasks` 디렉토리에 새 task 파일을 생성한다 (`XXX-description.md`)
+   - 직전 완료 task(예: `011`, `010`)를 참고 자료로 사용한다
+   - 신규 task는 모든 체크박스가 비어 있고 Change History도 비어 있다
+
+3. **Task Implementation**
+   - task 파일의 사양을 따른다
+   - **Inside-Out TDD**: Domain `__tests__` → Application `__tests__` → Infrastructure `__tests__` → Presentation `__tests__` 순서로 Red → Green → Refactor
+   - 각 step 진행 후 task 파일의 progress를 갱신한다
+
+4. **Task Completion & Roadmap Update**
+   - `/tasks/XXX-*.md`의 체크박스를 `[x]`로 갱신하고 Change History에 기록한다
+   - 본 ROADMAP.md의 해당 task에 ✅를 표기하고 `**Must** Read:` 링크를 추가한다
+   - PR 생성: `feature/issue-N-{slug}` 또는 `chore/{slug}` / `docs/{slug}` 브랜치 → squash merge → `git checkout development && git pull --ff-only`
+
+## Branch & PR 정책 요약
+
+| 변경 유형 | 브랜치 prefix | Plan/TDD phase 필수 |
+|----------|---------------|---------------------|
+| 기능 구현 (F001~F019) | `feature/issue-N-*` | ✅ Phase 1 Plan + Phase 2 TDD 필수 |
+| 버그 수정 | `fix/issue-N-*` | ✅ Phase 1 Plan + Phase 2 TDD 필수 |
+| 문서 변경 | `docs/*` | ❌ 생략 (PR 리뷰가 안전망) |
+| 설정/하니스/잡일 | `chore/*` | ❌ 생략 (PR 리뷰가 안전망) |
+
+> **PR-only**: `development`, `main` 브랜치에 직접 push 금지. ROADMAP.md 체크박스 업데이트조차 PR 경유.
+
+---
+
+## Phase 0: Setup & Toolchain
+
+> **목표**: 빈 React Router v7 + Cloudflare Workers + Clean Architecture 4-layer 프로젝트 골격을 만들고, 빌드/테스트/린트 파이프라인을 가동시킨다. 이후 모든 phase는 이 골격 위에서 진행된다.
+>
+> **진입 조건**: PRD/PROJECT-STRUCTURE 정본 확정 (현재 시점)
+> **완료 조건 (DoD)**: `bun run typecheck`, `bun run lint`, `bun run test`, `bun run dev`(또는 `bun run start`), `bunx wrangler dev`가 모두 무오류 통과. `app/{domain,application,infrastructure,presentation}/` 4-layer 디렉토리가 placeholder index와 함께 존재.
+
+- [ ] **Task 001: 프로젝트 스캐폴딩 + Bun + TypeScript + Biome 셋업**
+  - blockedBy: none
+  - blocks: Task 002, Task 003
+  - Layer: 전 layer (인프라성)
+  - 관련 Feature: 없음 (toolchain)
+  - 관련 AC: 없음
+  - 검증: `bun --version`, `bun run typecheck`, `bun run lint`, `bun run format` 통과
+  - 산출물:
+    - `package.json` (bun, react 19.2.4, react-router 7.14.0, typescript 5.9.3, biome 2.4.13)
+    - `tsconfig.json` / `tsconfig.app.json` (path alias `~/*` → `./app/*` 등)
+    - `biome.json`
+    - `.gitignore` 보강 (`.velite/`, `.react-router/`, `node_modules/`, `dist/`, `.wrangler/`)
+  - PR 1개 / 브랜치: `chore/scaffold-bun-rr7-biome`
+
+- [ ] **Task 002: Clean Architecture 4-layer 디렉토리 골격 + path alias**
+  - blockedBy: Task 001
+  - blocks: Task 004, Task 006, Task 007, Task 008, Task 009
+  - Layer: 전 layer (구조)
+  - 관련 Feature: 없음 (구조)
+  - 관련 AC: 없음
+  - 검증: `app/{domain,application,infrastructure,presentation}/` 디렉토리 존재 + 각 layer에 `index.ts` placeholder + 의존성 방향(Domain ← Application ← Infrastructure / Presentation ← Application) Lint 또는 README로 문서화
+  - 산출물:
+    - `app/domain/{project,post,legal,contact,theme}/` 빈 모듈
+    - `app/application/{content,contact,search,og,feed,seo}/{ports,services}/` 빈 모듈
+    - `app/infrastructure/{config,content,email,captcha,og,search,analytics}/` 빈 모듈
+    - `app/presentation/{components,hooks,lib,layouts,routes}/` 빈 모듈
+    - `test/{fixtures,utils}/` 빈 디렉토리
+  - PR 1개 / 브랜치: `chore/ca-4layer-skeleton`
+
+- [ ] **Task 003: Vite + React Router v7 Framework + Cloudflare Workers + Tailwind v4 빌드 파이프라인**
+  - blockedBy: Task 001
+  - blocks: Task 004, Task 005, Task 016
+  - Layer: Platform Adapter (workers/) + Presentation 진입점
+  - 관련 Feature: 없음 (toolchain)
+  - 관련 AC: 없음
+  - 검증: `bun run dev` Vite dev server 부팅 / `bunx wrangler dev` Workers dev 부팅 / 빈 root 페이지가 SSR로 응답 / `bun run test:coverage`가 빈 상태에서도 Vitest coverage 리포트 생성 + threshold 설정 통과
+  - 산출물:
+    - `vite.config.ts` (`@cloudflare/vite-plugin 1.33.2`, `@tailwindcss/vite 4.2.2`, `@vitejs/plugin-react 6.0.1`)
+    - `react-router.config.ts` (`ssr: true`)
+    - `wrangler.toml` (`name = "tkstar-dev"`, `main = "workers/app.ts"`, `compatibility_date = "2026-04-01"`, `[assets] binding="ASSETS" directory="./public"`)
+    - `workers/app.ts` (fetch handler → React Router request handler 스텁)
+    - `app/{root.tsx, routes.ts, entry.server.tsx, entry.client.tsx, app.css, env.d.ts}` 최소 동작본
+    - `app/routes.ts`: `flatRoutes({ rootDirectory: "presentation/routes" })`
+    - `app/presentation/routes/_index.tsx` (빈 placeholder)
+    - `vitest.config.ts` — `test.coverage.thresholds = { lines: 80, branches: 75, functions: 80, statements: 80 }` (1인 정적 사이트 기준; Phase 6 진입 시 T021에서 동일 수치로 재확인). 제외 경로: `**/*.config.*`, `**/__tests__/**`, `**/*.d.ts`, `workers/app.ts`(SSR entry), `app/entry.{server,client}.tsx`
+  - PR 1개 / 브랜치: `chore/vite-rr7-workers-tailwind-pipeline`
+
+---
+
+## Phase 1: Foundation — Routing Skeleton + Domain Schemas + Theme
+
+> **목표**: PRD에 정의된 모든 라우트의 빈 모듈을 만들고, Domain layer의 콘텐츠 스키마(Project/Post/AppLegalDoc/ContactSubmission/ThemePreference)를 Zod로 확정한다. F010 다크모드(`[data-theme]`) 전략을 root layout에 심는다.
+>
+> **진입 조건**: Phase 0 완료
+> **완료 조건 (DoD)**: 모든 PRD 페이지에 해당하는 빈 라우트 파일이 존재하여 `wrangler dev`로 직접 URL 입력 시 404가 아닌 placeholder 응답. Domain `__tests__/` 안 Zod 스키마 테스트가 모두 Green. `[data-theme]` 토글이 시스템/localStorage 추종으로 동작.
+
+- [ ] **Task 004: 라우트 스켈레톤 13개 + chrome / chrome-free 레이아웃**
+  - blockedBy: Task 002, Task 003
+  - blocks: Task 010, Task 011, Task 012, Task 013, Task 014, Task 015
+  - Layer: Presentation (routes + layouts)
+  - 관련 Feature: F014(chrome-free), F018/F019(root layout meta 자리), F004 splat fallback 위치
+  - 관련 AC: AC-F016-1/2 단축키 스코프(향후), AC-F018 sitemap 자리(향후)
+  - 검증: 각 URL을 직접 입력 시 placeholder 페이지가 렌더, App Terms/Privacy는 Topbar/Footer가 노출되지 않음, splat 라우트는 터미널 메시지 placeholder
+  - 산출물 (`app/presentation/routes/`):
+    - `_index.tsx` (Home), `about.tsx`, `projects._index.tsx`, `projects.$slug.tsx`
+    - `blog._index.tsx`, `blog.$slug.tsx`, `contact.tsx`
+    - `legal._index.tsx`, `legal.$app.terms.tsx`, `legal.$app.privacy.tsx`
+    - `rss[.xml].tsx`, `sitemap[.xml].tsx`, `robots[.txt].tsx`
+    - `og.projects.$slug[.png].tsx`, `og.blog.$slug[.png].tsx`
+    - `$.tsx` (splat → Not Found Fallback placeholder)
+  - 레이아웃: `app/presentation/layouts/{ChromeLayout.tsx, ChromeFreeLayout.tsx}`
+  - 검증 가정 A004 해소 (splat 라우트 채택 — F018/F019의 차등 인덱싱 정책 지원)
+  - PR 1개 / 브랜치: `feature/issue-N-route-skeleton`
+
+- [ ] **Task 005: 디자인 토큰 이식 + Tailwind v4 `@theme` + `[data-theme]` dark variant + 다크모드 (F010)**
+  - blockedBy: Task 003
+  - blocks: Task 010, Task 011, Task 012, Task 013, Task 014, Task 015
+  - Layer: Presentation (components/chrome, hooks, app.css)
+  - 관련 Feature: **F010** (다크모드 토글)
+  - 관련 AC: 없음 (UI 표시 위주, Page-by-Page Key Features로 검증)
+  - 검증: 시스템 dark/light 추종 확인, 토글 클릭 시 `[data-theme]` 속성 전환, localStorage `proto-theme` 저장, 새로고침 시 강제 모드 복원, FOIT 없이 첫 렌더부터 정확한 테마
+  - 산출물:
+    - `app/app.css` — `@theme { --color-*, --font-* }` 토큰 (`docs/design-system/styles.css`의 oklch 토큰 이식), `@variant dark (&:where([data-theme='dark'], [data-theme='dark'] *))`
+    - `app/presentation/hooks/useTheme.ts` — system 추종 + localStorage `proto-theme` 강제 전환
+    - `app/presentation/components/chrome/{Topbar.tsx, Footer.tsx, ThemeToggle.tsx}` 골격
+    - `app/root.tsx` — `<html data-theme={...}>` SSR-safe blocking script로 첫 렌더 깜빡임 방지
+    - `public/fonts/JetBrainsMono-{Regular,Medium,Bold}.woff2` self-host + `@font-face`
+  - TDD: `useTheme.test.ts` (system 추종 / 강제 전환 / localStorage persist) — `__tests__/`
+  - PR 1개 / 브랜치: `feature/issue-N-theme-tokens`
+
+- [ ] **Task 006: Domain Schemas — Project / Post / AppLegalDoc / ContactSubmission / ThemePreference**
+  - blockedBy: Task 002
+  - blocks: Task 007, Task 008, Task 009
+  - Layer: **Domain** (innermost)
+  - 관련 Feature: F002(About 데이터), F004(Project), F005(Project Detail), F006/F007(Post), F008(Contact), F010(Theme), F014(AppLegalDoc), F017(featured/recent)
+  - 관련 AC: AC-F008-2/3 (이메일/메시지 검증 규칙은 ContactSubmission schema에 정의)
+  - 검증: Domain `__tests__/` 안 Zod 스키마 테스트 (정상값 통과 / 이상값 reject) 100% Green
+  - 산출물:
+    - `app/domain/project/{project.entity.ts, project.schema.ts, project.errors.ts}` + `__tests__/project.schema.test.ts`
+    - `app/domain/post/{post.entity.ts, post.schema.ts}` + `__tests__/post.schema.test.ts`
+    - `app/domain/legal/{app-legal-doc.entity.ts, app-legal-doc.schema.ts}` + `__tests__/`
+    - `app/domain/contact/{contact-submission.vo.ts, contact-submission.schema.ts, contact.errors.ts}` + `__tests__/contact-submission.schema.test.ts`
+    - `app/domain/theme/theme-preference.vo.ts`
+  - 가정 해소: A001(About 자격증 카드는 frontmatter optional 필드로 미리 자리만), A003(AppLegalDoc 표준 메타: `version`, `effective_date`)
+  - PR 1개 / 브랜치: `feature/issue-N-domain-schemas`
+
+---
+
+## Phase 2: Content Pipeline — velite + MDX + shiki + Repository 어댑터
+
+> **목표**: velite로 `content/{projects,posts,legal/apps}/**/*.mdx`를 빌드하여 `.velite/` JSON으로 출력하고, Infrastructure layer의 Repository 어댑터로 Domain Entity에 매핑한다. Application layer의 콘텐츠 유스케이스(list/detail/featured/recent/related)를 TDD로 구현한다.
+>
+> **진입 조건**: Phase 1 완료 (Domain schema 확정)
+> **완료 조건 (DoD)**: `bunx velite build` 성공 → `.velite/{projects,posts,legal}.json` 생성 → Infrastructure Repository가 Domain Entity 배열 반환 → Application service `__tests__/` 모두 Green. seed 콘텐츠 (프로젝트 1개, 포스트 1개, legal/apps/moai 1쌍) 작성.
+
+- [ ] **Task 007: velite 설치 + 컬렉션 정의 + seed 콘텐츠 + shiki 코드블록**
+  - blockedBy: Task 006
+  - blocks: Task 008
+  - Layer: Infrastructure (build-time ETL) + content/
+  - 관련 Feature: F004, F005, F006, F007, F014 (콘텐츠 정본)
+  - 관련 AC: 없음 (빌드 산출물 검증은 정상 build로 충분)
+  - 검증: `bunx velite build` 성공, `.velite/projects.json` `.velite/posts.json` `.velite/legal.json` 생성, frontmatter Zod 위반 콘텐츠 추가 시 build 실패
+  - 산출물:
+    - `velite.config.ts` — Domain `*.schema.ts`를 그대로 import하여 컬렉션 정의 (스키마 1개 정본)
+    - rehype 플러그인: `rehype-slug` (헤딩 anchor — A002 해소 1단계), shiki(code highlight)
+    - `content/projects/example-project.mdx` (seed)
+    - `content/posts/2026-04-shipping-solo.mdx` (seed)
+    - `content/legal/apps/moai/{terms.mdx, privacy.mdx}` (seed, 빈 본문 + frontmatter만)
+    - `app/presentation/components/content/{MdxRenderer.tsx, CodeBlock.tsx}` (shiki 결과 외곽 컨테이너)
+  - 가정 해소: A006(velite/shiki 설치), A002 1단계(rehype-slug), A007(검색 인덱스는 별도 라이브러리 미사용 — Task 016에서 확정)
+  - PR 1개 / 브랜치: `feature/issue-N-velite-content-pipeline`
+
+- [ ] **Task 008: Application Ports + Content Repositories (Infrastructure 구현)**
+  - blockedBy: Task 002, Task 006, Task 007
+  - blocks: Task 009, Task 010, Task 011, Task 012, Task 013, Task 014, Task 015, Task 016, Task 017
+  - Layer: Application (ports/services) + Infrastructure (velite repos)
+  - 관련 Feature: F004, F005, F006, F007, F014, F017
+  - 관련 AC: 없음 (read-side 정확성 → unit test로 충분)
+  - 검증: Application `__tests__/` 안 mock-repository 기반 service 테스트 + Infrastructure `__tests__/` 안 `.velite` fixture 기반 repository 테스트 모두 Green
+  - 산출물:
+    - **Ports** (`app/application/content/ports/`):
+      - `project-repository.port.ts` — `findAll, findBySlug, findFeatured, findRelated(slug) → {prev,next}, findByTag(tag)`
+      - `post-repository.port.ts` — `findAll, findBySlug, findRecent(n), findByTag(tag), findRelated(slug)`
+      - `legal-repository.port.ts` — `findAppDoc(app_slug, doc_type), listApps()`
+    - **Services** (`app/application/content/services/`):
+      - `list-projects.service.ts` (+ tag filter)
+      - `get-project-detail.service.ts` (prev/next 포함)
+      - `get-featured-project.service.ts` (F017)
+      - `list-posts.service.ts`
+      - `get-post-detail.service.ts`
+      - `get-recent-posts.service.ts` (F017)
+    - **Infrastructure 어댑터** (`app/infrastructure/content/`):
+      - `velite-project.repository.ts`, `velite-post.repository.ts`, `velite-legal.repository.ts`
+      - `mappers/{project,post,legal}.mapper.ts` (velite raw → Domain Entity)
+    - 각 모듈에 `__tests__/` colocated
+  - PR 1개 / 브랜치: `feature/issue-N-content-ports-repos`
+
+- [ ] **Task 009: DI Container (Composition Root) + workers/app.ts wiring + getLoadContext**
+  - blockedBy: Task 008
+  - blocks: Task 010, Task 011, Task 012, Task 013, Task 014, Task 015, Task 016, Task 017
+  - Layer: Infrastructure (config) + Platform Adapter (workers/)
+  - 관련 Feature: 전반 (모든 유스케이스 주입 통로)
+  - 관련 AC: 없음 (유스케이스 주입 정확성 → Phase 3 라우트 테스트로 간접 검증)
+  - 검증: `app/infrastructure/config/__tests__/container.test.ts` — 모든 등록 service가 의도한 인터페이스를 만족함을 type-level + runtime으로 확인. `wrangler dev`에서 페이지 loader가 container 호출 성공.
+  - 산출물:
+    - `app/infrastructure/config/container.ts` — `type Container = {...}` + `function buildContainer(env): Container` (수제 Plain object)
+    - `workers/app.ts` — `getLoadContext: () => ({ container: buildContainer(env) })`
+    - `app/env.d.ts` — `interface AppLoadContext { container: Container }`
+  - 가정 해소: D2 확인 (수제 DI 채택)
+  - PR 1개 / 브랜치: `feature/issue-N-di-container`
+
+---
+
+## Phase 3: Core Pages UI — Home / About / Projects / Blog / Legal (실 데이터 연결)
+
+> **목표**: Phase 1의 빈 라우트에 Phase 2의 콘텐츠 유스케이스를 연결하여 실제 페이지를 완성한다. F003 PDF 인쇄 스타일, F017 Featured/Recent까지 포함.
+>
+> **진입 조건**: Phase 2 완료 (Repository + DI 가동)
+> **완료 조건 (DoD)**: `wrangler dev`로 7개 콘텐츠 페이지(Home/About/Projects/Project Detail/Blog/Blog Detail/Legal Index)가 seed 데이터로 정상 렌더. Project Detail/Blog Detail 데스크탑 880px+ sticky sidebar 동작. About `[⎙ PDF]` 버튼 → `window.print()` AC-F003-1/2/3 통과.
+
+- [ ] **Task 010: Home Page (F001 Hero + F017 Featured/Recent)**
+  - blockedBy: Task 005, Task 008, Task 009
+  - blocks: Task 016
+  - Layer: Presentation (route + components)
+  - 관련 Feature: **F001**, **F017**
+  - 관련 AC: 없음 (Page-by-Page Key Features로 검증)
+  - 검증:
+    - **자동 (RTL + Vitest)**: Home loader가 `getFeaturedProject` + `getRecentPosts(3)` 유스케이스를 호출 (mock container) / `<HeroWhoami />` 렌더 + 3-버튼 클러스터 ARIA role 검증 / `<RecentPostsList />` 컴포넌트가 정확히 3개의 `<PostRow>`를 렌더 (RTL `getAllByRole('article').toHaveLength(3)`) / Featured 미존재 시 fallback (해당 섹션 미렌더) 처리 검증 / DOM 구조 snapshot (또는 명시적 selector 기반 assertion)으로 Hero / Featured / Recent 3 섹션 순서 보장
+    - **수동**: `wrangler dev`에서 [검색해서 이동] 버튼 클릭 시 Command Palette 트리거 (Task 016 마운트 후 통합 동작), [/about] [/projects] 빠른 링크 동작
+  - 산출물:
+    - `app/presentation/routes/_index.tsx` — loader: `getFeaturedProject` + `getRecentPosts(3)`
+    - `app/presentation/components/home/{HeroWhoami.tsx, FeaturedProjectCard.tsx, RecentPostsList.tsx}`
+  - PR 1개 / 브랜치: `feature/issue-N-home-page`
+
+- [ ] **Task 011: About Page + F003 PDF 인쇄 스타일**
+  - blockedBy: Task 005, Task 008, Task 009
+  - Layer: Presentation
+  - 관련 Feature: **F002**, **F003**
+  - 관련 AC: **AC-F003-1**, **AC-F003-2**, **AC-F003-3**
+  - 검증:
+    - Vitest + jsdom: `[⎙ PDF]` 버튼 클릭 시 `window.print` mock 호출 (1회)
+    - 시각 검증 (수동): Chrome 인쇄 미리보기에서 Topbar/Footer/검색트리거/토글 숨김, 색상 유지, h2가 페이지 하단 고립 안됨
+    - Snapshot 테스트: `@media print` CSS 적용된 HTML 스냅샷 비교
+  - 산출물:
+    - `app/presentation/routes/about.tsx`
+    - `app/presentation/components/about/{AboutHeader.tsx, StackCards.tsx, CareerTimeline.tsx, EducationCard.tsx, AwardsCard.tsx}`
+    - `app/presentation/lib/print.ts` — `triggerPrint()` 래퍼 (테스트 가능)
+    - `app/app.css`에 `@media print { ... }` 블록 (Topbar/Footer/검색트리거/토글 `display: none`, `@page { size: A4; margin: 0 }`, `print-color-adjust: exact`, `break-after: avoid` for h2)
+  - 가정 해소: A001 (자격증 데이터는 frontmatter optional 필드로 자리만, Phase 3 외에서 콘텐츠 추가 가능)
+  - PR 1개 / 브랜치: `feature/issue-N-about-page-print`
+
+- [ ] **Task 012: Projects Page (F004 ls-style 행 리스트 + 태그 필터)**
+  - blockedBy: Task 005, Task 008, Task 009
+  - Layer: Presentation
+  - 관련 Feature: **F004**
+  - 관련 AC: 없음 (UI 표시 위주)
+  - 검증:
+    - **자동 (RTL + Vitest)**: Projects loader가 `listProjects(tag?)` 유스케이스를 URLSearchParam(`?tag=xxx`)에서 추출한 인자로 호출 (mock container) / `<ProjectRow />` 행 구조 렌더 — `slug/ + title + date(YYYY-MM)` / `summary` / `stack pills` 각 노드가 RTL queries(`getByText`)로 검색 가능 / `<TagFilterChips />` 칩 클릭 시 `useSearchParams`가 `?tag=<tag>`로 변경됨 (RTL `userEvent.click` + `memoryRouter`) / 행 클릭 시 `/projects/:slug`로 네비게이션 (RTL `userEvent.click` + history mock) / DOM 구조 snapshot 또는 명시적 selector assertion으로 ls-style 행 레이아웃 보장 (카드 그리드가 아님을 `display: grid-template-columns`가 아닌 flat row 구조로 확인)
+    - **수동**: 태그 필터 적용 결과가 시각적으로 정렬되는지 확인
+  - 산출물:
+    - `app/presentation/routes/projects._index.tsx` — loader: `listProjects()`
+    - `app/presentation/components/project/{ProjectRow.tsx, TagFilterChips.tsx}`
+    - `app/presentation/lib/format.ts` — `formatYearMonth(date)` (Domain VO 또는 lib?  — 읽기 전용 포맷이므로 Presentation lib 채택)
+  - PR 1개 / 브랜치: `feature/issue-N-projects-list`
+
+- [ ] **Task 013: Project Detail Page (F005 + sticky sidebar + on-this-page TOC)**
+  - blockedBy: Task 005, Task 007 (rehype-slug), Task 008, Task 009
+  - blocks: Task 018 (OG)
+  - Layer: Presentation + Application(`getProjectDetail`)
+  - 관련 Feature: **F005**
+  - 관련 AC: 없음 (UI 표시 위주, OG는 Phase 5 F011)
+  - 검증: 본문 problem/approach/results 섹션 렌더, 데스크탑 880px+에서 sticky sidebar(meta + TOC) 표시, 모바일에서는 sidebar inline, `← prev` / `의뢰하기 →` / `next →` 3분할 푸터, prev/next는 collection 인접 항목
+  - 산출물:
+    - `app/presentation/routes/projects.$slug.tsx` — loader: `getProjectDetail(slug)` (404 시 throw → splat 처리)
+    - `app/presentation/components/project/{ProjectMetaSidebar.tsx, OnThisPageToc.tsx, ProjectFooterNav.tsx}`
+    - velite afterBuild 또는 빌드 후 처리: 본문 h2 헤딩 추출 → frontmatter `toc` 필드로 주입 (A002 해소 2단계 — velite 후처리 채택)
+  - 가정 해소: A002 완료
+  - PR 1개 / 브랜치: `feature/issue-N-project-detail`
+
+- [ ] **Task 014a: Blog Page (F006) — 목록 + 태그 필터 + RSS Resource Route (F012)**
+  - blockedBy: Task 005, Task 007, Task 008, Task 009
+  - blocks: Task 014b, Task 018 (OG)
+  - Layer: Presentation + Application(`build-rss-feed.service.ts`) + Resource Route
+  - 관련 Feature: **F006**, **F012**
+  - 관련 AC: 없음 (UI 표시 + RSS XML well-formed 검증)
+  - 검증:
+    - **자동 (RTL + Vitest)**: Blog loader가 `listPosts(tag?)`를 호출 / 발행일 역순으로 `<PostRow>` 정렬 (RTL `getAllByRole` 순서 비교) / 태그 칩 클릭 시 `?tag=<tag>` URLSearchParam 변경 / RSS service unit test가 RSS 2.0 well-formed XML 생성 (`<title>`, `<link>`, `<description>`, `<item>` 포함, `xml-validator` 또는 정규식 검증) / `/rss.xml` 통합: `Content-Type: application/xml`, item 수 = collection 수
+    - **수동**: 태그 필터 + 정렬 시각 확인
+  - 산출물:
+    - `app/presentation/routes/{blog._index.tsx, rss[.xml].tsx}`
+    - `app/presentation/components/post/PostRow.tsx`
+    - `app/application/feed/services/build-rss-feed.service.ts` + `__tests__/`
+  - PR 1개 / 브랜치: `feature/issue-N-blog-list-rss`
+
+- [ ] **Task 014b: Blog Detail Page (F007) — 본문 + sticky sidebar + share**
+  - blockedBy: Task 014a
+  - blocks: Task 018 (OG)
+  - Layer: Presentation
+  - 관련 Feature: **F007**
+  - 관련 AC: 없음 (UI 표시 위주)
+  - 검증:
+    - **자동 (RTL + Vitest)**: Blog Detail loader가 `getPostDetail(slug)` 호출 + 미존재 slug 시 throw → splat 처리 / MDX 본문 + shiki 코드블록 렌더 / `<ShareTools />` copy link 버튼 클릭 시 `navigator.clipboard.writeText` mock 호출 (RTL `userEvent`) / X 공유 링크 `https://x.com/intent/post?...` 형식 검증 / 데스크탑 880px+에서 sticky sidebar(`<OnThisPageToc>`) 노출 / 하단 3분할 (`← prev` / `[모든 글]` / `next →`) 렌더 + prev/next는 collection 인접 항목
+    - **수동**: 모바일에서 sidebar inline 표시 확인
+  - 산출물:
+    - `app/presentation/routes/blog.$slug.tsx`
+    - `app/presentation/components/post/ShareTools.tsx`
+  - PR 1개 / 브랜치: `feature/issue-N-blog-detail`
+
+- [ ] **Task 015: Legal Index + App Terms + App Privacy (F014, chrome-free)**
+  - blockedBy: Task 005, Task 007, Task 008, Task 009
+  - Layer: Presentation
+  - 관련 Feature: **F014**
+  - 관련 AC: 없음 (Page-by-Page Key Features + F018 차등 인덱싱은 Phase 5)
+  - 검증:
+    - **자동 (RTL + Vitest)**: Legal Index loader가 `listApps()` 호출 / 등록된 앱 카드(`<AppCard />`) 갯수 = `listApps()` 결과 길이 / `appCount === 0`이면 `<Footer />`의 Legal 링크가 미렌더 (RTL `queryByRole('link', { name: /legal/i })`로 null 검증) / `appCount > 0`이면 Legal 링크 노출 / `<ChromeFreeLayout />` 마운트 시 `<Topbar />` / `<Footer />`가 미렌더 + 컨테이너 `max-width: 680px` 스타일 적용 (RTL + computed style 또는 className assertion) / App Terms/Privacy 라우트가 `<ChromeFreeLayout />`을 사용하는지 layout id assertion / DOM 구조 snapshot으로 chrome-free 본문 영역 보장
+    - **수동**: `wrangler dev`에서 `/legal/moai/terms` / `/legal/moai/privacy`를 직접 접속하여 chrome-free 시각 확인
+  - 산출물:
+    - `app/presentation/routes/{legal._index.tsx, legal.$app.terms.tsx, legal.$app.privacy.tsx}`
+    - `app/presentation/components/legal/{AppCard.tsx, LegalDocLayout.tsx}`
+    - `app/presentation/components/chrome/Footer.tsx` — `appCount > 0`일 때 Legal 링크 조건부
+  - PR 1개 / 브랜치: `feature/issue-N-legal-pages`
+
+---
+
+## Phase 4: Forms / Email — Contact Form + Turnstile + Resend (F008 + F009)
+
+> **목표**: Contact 페이지의 폼 검증, Turnstile 클라이언트 위젯 + 서버 검증, Resend 발신 + React Email 자동응답까지 완성한다. F008/F009의 모든 AC를 TDD로 구현.
+>
+> **진입 조건**: Phase 3 완료 (DI 가동, 라우트 동작 확인)
+> **완료 조건 (DoD)**: AC-F008-1/2/3/4, AC-F009-1/2/3 모두 자동 테스트 통과. 실제 hello@tkstar.dev → 본인 메일 + 제출자 자동응답이 staging에서 발송 확인.
+
+- [ ] **Task 016: F016 Cmd+K Command Palette (글로벌 검색 네비)**
+  - blockedBy: Task 003, Task 008, Task 009, Task 010 (Home에서 트리거)
+  - Layer: Application(`build-search-index.service.ts`) + Presentation(palette UI/hook)
+  - 관련 Feature: **F016**
+  - 관련 AC: **AC-F016-1**, **AC-F016-2**, **AC-F016-3**, **AC-F016-4**, **AC-F016-5**
+  - 검증:
+    - `useCommandPalette.test.ts`: 단축키 토글 → AC-F016-1/2 (cross-platform 분기 명시)
+      - **macOS (⌘K)**: RTL `userEvent.keyboard('{Meta>}k{/Meta}')` → palette open. `event.metaKey === true` 분기를 hook 내부에서 검증
+      - **Windows·Linux (Ctrl+K)**: RTL `userEvent.keyboard('{Control>}k{/Control}')` → palette open. `event.ctrlKey === true` 분기
+      - **공통 (`/`)**: RTL `userEvent.keyboard('/')` → palette open (입력 포커스 외)
+      - **포커스 가드**: `<input>` / `<textarea>` / `[contenteditable]`에 포커스가 있으면 위 3개 모두 palette를 열지 않고 기본 입력 동작 유지 (AC-F016-2)
+    - 토큰 기반 다중 키워드 필터 ("rou nav" → "rou"+"nav" 모두 포함만) → AC-F016-3
+    - 키보드 네비 (↑↓/↵/Esc) + 마우스 호버 인덱스 동기화 → AC-F016-4
+    - `public/search-index.json` size ≤ gzip 100KB + body 미포함 + lazy fetch 1회 → AC-F016-5
+  - 산출물:
+    - `app/application/search/services/build-search-index.service.ts` — velite afterBuild 훅 또는 별도 스크립트가 `.velite/{projects,posts}.json`에서 `{slug, title, summary, tags}`만 추출 + 정적 라우트 머지 → `public/search-index.json`
+    - `app/presentation/hooks/useCommandPalette.ts` — 단축키 + 토큰 검색 + 키보드 네비
+    - `app/presentation/components/palette/CommandPalette.tsx` — 모달 + 그룹 헤더(pages/projects/posts) + lazy fetch
+    - `app/root.tsx` — `<CommandPalette />` 마운트
+  - 가정 해소: A007 (단순 includes/score 검색 채택, 데이터 규모 100+ 도달 시 재검토)
+  - PR 1개 / 브랜치: `feature/issue-N-command-palette`
+
+- [ ] **Task 017: Contact Form + Turnstile + Resend + 자동응답 메일 (F008 + F009)**
+  - blockedBy: Task 002, Task 006 (ContactSubmission schema), Task 008/009 (DI), Task 017-pre (PROJECT-STRUCTURE 갱신 — docs PR)
+  - Layer: Application(submit-contact-form.service) + Infrastructure(Resend, Turnstile, React Email, Workers KV rate-limit) + Presentation(Form, Turnstile widget)
+  - 관련 Feature: **F008**, **F009**
+  - 관련 AC: **AC-F008-1**, **AC-F008-2**, **AC-F008-3**, **AC-F008-4**, **AC-F009-1**, **AC-F009-2**, **AC-F009-3**
+  - 사전 단계 (PR 본 작업 전 1회):
+    - `bunx wrangler kv namespace create RATE_LIMIT_KV` 실행 (production용) → 반환 `id` 기록
+    - `bunx wrangler kv namespace create RATE_LIMIT_KV --preview` (preview/dev용) → 반환 `preview_id` 기록
+    - `wrangler.toml`에 `[[kv_namespaces]] binding = "RATE_LIMIT_KV"`, `id = "..."`, `preview_id = "..."` 블록 등록
+    - `app/env.d.ts`의 `interface AppLoadContext`(또는 `Env`)에 `RATE_LIMIT_KV: KVNamespace` 추가
+  - 검증:
+    - `submit-contact-form.service.test.ts` — mock email-sender + captcha-verifier + rate-limiter로 모든 AC 분기
+    - `contact-submission.schema.test.ts` — RFC 5322 위반 / 메시지 10자 미만 / 5000자 초과 reject (AC-F008-2/3)
+    - `turnstile-verifier.test.ts` — `https://challenges.cloudflare.com/turnstile/v0/siteverify` mock, success: false → 400 (AC-F009-2)
+    - `resend-email-sender.test.ts` — Resend 5xx → throw → action에서 fallback 응답 (AC-F008-4)
+    - `kv-rate-limiter.test.ts` (`AC-F009-3`): KV mock(`miniflare`/`@cloudflare/workers-types` 호환), 동일 IP 1시간 5회 OK + 6번째 429
+    - Action 통합 테스트: 폼 제출 → mailto fallback 응답 (AC-F008-4: prefill body 포함)
+  - 산출물:
+    - **Application**:
+      - `app/application/contact/ports/{email-sender.port.ts, captcha-verifier.port.ts, rate-limiter.port.ts}`
+      - `app/application/contact/services/submit-contact-form.service.ts`
+    - **Infrastructure**:
+      - `app/infrastructure/email/resend-email-sender.ts` (env.RESEND_API_KEY)
+      - `app/infrastructure/email/templates/AutoReplyEmail.tsx` (React Email)
+      - `app/infrastructure/captcha/turnstile-verifier.ts` (env.TURNSTILE_SECRET)
+      - `app/infrastructure/ratelimit/kv-rate-limiter.ts` (Workers KV 기반, `env.RATE_LIMIT_KV` 주입) — **PROJECT-STRUCTURE.md 미등록 모듈** (Task 017-pre로 사전 등록)
+    - **Presentation**:
+      - `app/presentation/routes/contact.tsx` (loader + action)
+      - `app/presentation/components/contact/{ContactForm.tsx, TurnstileWidget.tsx, SuccessScreen.tsx, MailtoFallback.tsx}`
+      - `app/presentation/hooks/useTurnstile.ts`
+    - **wrangler.toml**: secrets `RESEND_API_KEY` / `TURNSTILE_SECRET`, vars `CONTACT_TO_EMAIL`, KV namespace `RATE_LIMIT_KV` (`id` + `preview_id`)
+  - 가정 해소: A009 완료 (React Email/Resend/Turnstile 도입 + env 추가)
+  - PR 1개 / 브랜치: `feature/issue-N-contact-form-email`
+
+- [ ] **Task 017-pre: PROJECT-STRUCTURE.md 갱신 — `app/infrastructure/ratelimit/` 모듈 등록 (docs)**
+  - blockedBy: none (Task 017보다 선행)
+  - blocks: Task 017
+  - Layer: docs (구조 정합성)
+  - 관련 Feature: F009 (rate-limit 보강)
+  - 관련 AC: 없음
+  - 검증: `docs/PROJECT-STRUCTURE.md`의 `app/infrastructure/` 트리에 `ratelimit/` 항목 추가 + Cross-cutting Concerns Mapping 표에 rate-limit 행 추가
+  - 산출물:
+    - `docs/PROJECT-STRUCTURE.md` — `app/infrastructure/` 트리(line 213~238 부근)에 `├── ratelimit/` + `│   ├── kv-rate-limiter.ts` + `│   └── __tests__/` 항목, Cross-cutting Concerns Mapping(line 549~560 부근) 표에 `Contact rate-limit (F009 보강) | Application Port + Infrastructure 구현 | application/contact/ports/rate-limiter.port.ts + infrastructure/ratelimit/kv-rate-limiter.ts` 행
+  - PR 1개 / 브랜치: `docs/update-project-structure-ratelimit`
+
+---
+
+## Phase 5: SEO / OG / Indexing — Satori OG + Sitemap + Robots + JSON-LD + 검색엔진 등록
+
+> **목표**: F011 동적 OG 이미지(Project/Blog), F018 SEO 메타 + sitemap/robots + JSON-LD, F019 Google/Naver 검색엔진 등록을 완성한다. 차등 인덱싱 정책(App Terms/Privacy `noindex,follow`, 404 `noindex,nofollow`)을 적용.
+>
+> **진입 조건**: Phase 4 완료 (모든 페이지가 콘텐츠로 가동)
+> **완료 조건 (DoD)**: AC-F011-1/2/3 통과. `/sitemap.xml`, `/robots.txt`가 well-formed. 페이지별 meta export(title/description/canonical/OG/Twitter) + JSON-LD 정합. Google Search Console / Naver Search Advisor 도메인 인증 완료 (배포 단계).
+
+- [ ] **Task 018: F011 Satori 동적 OG 이미지 (Project + Blog) — Workers Asset Binding**
+  - blockedBy: Task 013, Task 014a, Task 014b
+  - Layer: Application(`render-*-og.service`, port) + Infrastructure(Satori standalone + Asset Binding) + Resource Route
+  - 관련 Feature: **F011**
+  - 관련 AC: **AC-F011-1**, **AC-F011-2**, **AC-F011-3**
+  - 검증:
+    - `render-project-og.service.test.ts` / `render-post-og.service.test.ts` — frontmatter → PNG bytes (mock renderer)
+    - `satori-og-renderer.test.ts` — env.ASSETS mock으로 ttf/yoga.wasm 로드, fallback PNG 경로
+    - 통합: `/og/projects/:slug.png` 응답 1200×630 PNG + `Cache-Control: public, max-age=31536000, immutable` (AC-F011-1)
+    - 미존재 slug → fallback PNG (AC-F011-2)
+    - 폰트 누락 시 정적 fallback + Workers logs 에러 (AC-F011-3)
+  - 산출물:
+    - `app/application/og/ports/og-image-renderer.port.ts`
+    - `app/application/og/services/{render-project-og.service.ts, render-post-og.service.ts}`
+    - `app/infrastructure/og/satori-og-renderer.ts` — `satori/standalone` + `env.ASSETS.fetch("https://x.local/fonts/JetBrainsMono-Regular.ttf")` + `env.ASSETS.fetch("https://x.local/wasm/yoga.wasm")`
+    - `public/fonts/JetBrainsMono-Regular.ttf`, `public/wasm/yoga.wasm`
+    - `app/presentation/routes/{og.projects.$slug[.png].tsx, og.blog.$slug[.png].tsx}` — loader만 export
+    - 정적 fallback PNG asset
+  - 가정 해소: A005 (env.ASSETS Fetcher 채택)
+  - PR 1개 / 브랜치: `feature/issue-N-satori-og`
+
+- [ ] **Task 019: F018 SEO Meta + Sitemap + Robots + JSON-LD (차등 인덱싱)**
+  - blockedBy: Task 008, Task 010~Task 013, Task 014a, Task 014b, Task 015 (페이지별 meta 추가), Task 018 (OG URL)
+  - Layer: Application(`build-sitemap.service`) + Resource Route + Presentation(meta export)
+  - 관련 Feature: **F018**
+  - 관련 AC: 없음 (정합성 검증 — sitemap 포함 페이지 / robots 정책 / JSON-LD schema.org 표준)
+  - 검증:
+    - `build-sitemap.service.test.ts` — index 가능 페이지(Home/About/Projects/Project Detail/Blog/Blog Detail/Contact/Legal Index)만 포함, App Terms/Privacy + 404 + OG resource route 제외
+    - `/robots.txt` 응답: `User-agent: *`, `Allow: /`, `Sitemap: https://tkstar.dev/sitemap.xml`
+    - 페이지별 meta export 통합 테스트: title/description/canonical/og:*/twitter:*
+    - JSON-LD 통합 테스트:
+      - Home/About → `Person`
+      - Blog Detail → `BlogPosting`
+      - Project Detail → `CreativeWork` (또는 `SoftwareSourceCode`)
+      - 모든 페이지 → `BreadcrumbList`
+    - 차등 인덱싱: App Terms/Privacy meta `noindex, follow` + canonical 유지, 404(splat) meta `noindex, nofollow`
+  - 산출물:
+    - `app/application/seo/services/build-sitemap.service.ts` + `__tests__/`
+    - `app/presentation/routes/{sitemap[.xml].tsx, robots[.txt].tsx}` — loader만 export
+    - 페이지별 `meta` export 추가 (`_index.tsx`, `about.tsx`, `projects._index.tsx`, `projects.$slug.tsx`, `blog._index.tsx`, `blog.$slug.tsx`, `contact.tsx`, `legal._index.tsx`, `legal.$app.terms.tsx`, `legal.$app.privacy.tsx`, `$.tsx`)
+    - `app/presentation/lib/jsonld.ts` — schema.org 빌더 헬퍼 (Person/BlogPosting/CreativeWork/BreadcrumbList)
+  - PR 1개 / 브랜치: `feature/issue-N-seo-sitemap-jsonld`
+
+- [ ] **Task 020: F019 검색엔진 등록 (Google + Naver) + Cloudflare Web Analytics (F013)**
+  - blockedBy: Task 019
+  - Layer: Presentation(root layout) + Infrastructure(analytics 스니펫)
+  - 관련 Feature: **F019**, **F013**
+  - 관련 AC: 없음 (배포 후 `site:tkstar.dev` 인덱싱 확인)
+  - 검증: `wrangler dev`에서 `GOOGLE_SITE_VERIFICATION` / `NAVER_SITE_VERIFICATION` env 설정 시 root `<head>`에 `<meta name="google-site-verification" ...>` / `<meta name="naver-site-verification" ...>` 조건부 렌더. Cloudflare Web Analytics 스니펫 삽입 (쿠키 없음).
+  - 산출물:
+    - `app/root.tsx` — env 기반 조건부 verification meta + Cloudflare Web Analytics `<script>` 스니펫
+    - `app/infrastructure/analytics/cloudflare-web-analytics.ts` — 스니펫 헬퍼
+    - `wrangler.toml` — `GOOGLE_SITE_VERIFICATION`, `NAVER_SITE_VERIFICATION`, `CLOUDFLARE_ANALYTICS_TOKEN` (vars)
+  - 가정 해소: A008 (wrangler vars로 토큰 주입), A011은 잔존 (Bing은 MVP 후)
+  - PR 1개 / 브랜치: `feature/issue-N-search-engine-verification`
+
+---
+
+## Phase 6: Polish & Deploy — QA + 배포 + 도메인 연결
+
+> **목표**: 전체 플로우 QA, Lighthouse / Axe 접근성 점검, Cloudflare Workers 첫 배포 + `tkstar.dev` 도메인 연결 + Email Routing 설정 + Search Console 인증 완료.
+>
+> **진입 조건**: Phase 5 완료 (모든 F001~F019 자동 테스트 Green)
+> **완료 조건 (DoD)**: 프로덕션 도메인 `https://tkstar.dev` 접속 시 모든 페이지 정상, OG 미리보기가 SNS에서 정상 노출, Contact Form이 실제 메일 발송, Search Console에서 sitemap 제출 및 indexing 확인.
+
+- [ ] **Task 021: 통합 QA + Lighthouse + Axe 접근성 점검 + 모든 PRD AC 통과 매트릭스**
+  - blockedBy: Task 020
+  - Layer: 전 layer (회귀 테스트)
+  - 관련 Feature: F001~F019 전체
+  - 관련 AC: AC-F003-1/2/3, AC-F008-1/2/3/4, AC-F009-1/2/3, AC-F011-1/2/3, AC-F016-1/2/3/4/5
+  - 검증:
+    - `bun run test:coverage` 전체 100% Green + threshold 통과
+    - Lighthouse: Performance ≥ 90, Accessibility ≥ 95, Best Practices ≥ 95, SEO ≥ 100
+    - Axe: 위반 0건
+    - 키보드 only 네비게이션 (Cmd+K → palette → 결과 진입 → Esc) 수동 검증
+    - 다크/라이트 모드 시각 회귀 (스냅샷 또는 수동)
+  - 산출물:
+    - `docs/reports/qa-{date}.md` (수동 결과 기록 — 정본은 ROADMAP 체크박스)
+    - 발견된 결함은 `fix/issue-N-*` PR로 분리 처리
+  - PR 1개 / 브랜치: `chore/qa-pass-mvp`
+
+- [ ] **Task 022: Cloudflare Workers 배포 + 도메인 연결 + Email Routing + 검색엔진 인증 완료**
+  - blockedBy: Task 021
+  - Layer: 운영
+  - 관련 Feature: F019 (인증 완료), 운영 (도메인/이메일)
+  - 관련 AC: 없음 (운영 검증)
+  - 검증:
+    - `bunx wrangler deploy` 성공 → workers.dev 우선 동작
+    - `tkstar.dev` 도메인 등록 + Cloudflare DNS 연결 + Workers Custom Domain 매핑
+    - Cloudflare Email Routing: `hello@tkstar.dev` → 개인 Gmail forward 동작 확인 (실제 메일 송수신)
+    - Resend domain verification 완료 (DKIM/SPF DNS record 설정)
+    - `wrangler secret put RESEND_API_KEY` / `TURNSTILE_SECRET` / vars `GOOGLE_SITE_VERIFICATION` / `NAVER_SITE_VERIFICATION` 주입
+    - Google Search Console 도메인 소유권 인증 + `https://tkstar.dev/sitemap.xml` 제출
+    - Naver Search Advisor `naver-site-verification` meta 검증 + sitemap 제출
+    - 배포 후 `site:tkstar.dev` 검색으로 indexing 확인 (수일 ~ 수주 소요)
+  - 가정 해소: A010 (도메인 등록 채널 결정 시 기록), A008 완료 (실제 토큰 주입)
+  - 잔존 가정: A011(Bing 등록 보류), A012(Motion 라이브러리 보류)
+  - PR 1개 / 브랜치: `chore/deploy-production`
+
+---
+
+## PRD Feature → Task Coverage Matrix
+
+> 모든 PRD Feature가 최소 1개 task에 매핑됨을 검증한다.
+
+| Feature ID | Feature 이름 | 1차 구현 Task | 보조/연계 Task |
+|------------|--------------|---------------|-----------------|
+| F001 | Hero (whoami + 검색 + 빠른 링크) | Task 010 | Task 016 (검색 트리거 연결) |
+| F002 | About (사이트 자체 이력서) | Task 011 | Task 006 (스키마) |
+| F003 | PDF 저장 (CSS print) | Task 011 | — |
+| F004 | Projects 목록 (ls-style) | Task 012 | Task 006/008 (스키마/repo) |
+| F005 | Project Case Study | Task 013 | Task 006/008 (스키마/repo), Task 007 (rehype-slug) |
+| F006 | Blog 목록 | Task 014a | Task 006/008 |
+| F007 | Blog 상세 | Task 014b | Task 006/008, Task 007 (shiki) |
+| F008 | Contact Form | Task 017 | Task 006 (ContactSubmission schema) |
+| F009 | Contact 스팸 방지 (Turnstile) | Task 017 | — |
+| F010 | 다크모드 토글 (`[data-theme]`) | Task 005 | Task 004 (chrome layout) |
+| F011 | SSR + 동적 OG 이미지 (Satori) | Task 018 | Task 003 (SSR), Task 013/014a/014b (페이지별 OG meta는 Task 019) |
+| F012 | RSS 피드 | Task 014a | — |
+| F013 | 분석 (Cloudflare Web Analytics) | Task 020 | — |
+| F014 | 앱 약관 라우팅 (스켈레톤) | Task 015 | Task 004 (chrome-free layout), Task 006 (AppLegalDoc), Task 007 (seed) |
+| F016 | Cmd+K Command Palette | Task 016 | Task 004 (라우트 인덱스), Task 008 (slug 인덱스) |
+| F017 | Home Featured + Recent Posts | Task 010 | Task 008 (`getFeatured`/`getRecent`) |
+| F018 | SEO 메타데이터 & Sitemap | Task 019 | Task 010~Task 015 (페이지별 meta export), Task 018 (OG URL) |
+| F019 | 검색엔진 등록 (Google + Naver) | Task 020 | Task 022 (배포 후 인증 완료) |
+
+> **F015**(청중 분기 기억) 및 청중 분기 split CTA는 PRD에서 Removed — task 미할당.
+> 모든 Core/Support Feature가 최소 1개 task에 매핑되며, F018 차등 인덱싱은 Task 019에서 페이지별 meta export로 분산 적용.
+
+---
+
+## Assumption Resolution Gate Matrix
+
+> PRD `Assumptions Register`(A001~A012)의 해소 게이트와 본 ROADMAP의 phase가 일치하는지 검증한다.
+
+| ID | 가정 내용 | PRD 명시 게이트 | ROADMAP 해소 Task | Phase |
+|----|-----------|------------------|--------------------|-------|
+| A001 | About 자격증 데이터 카드 | F002 구현 PR | Task 011 (frontmatter optional 필드로 자리 확보 + 011 PR에서 데이터 모델 확정) | Phase 3 |
+| A002 | on-this-page TOC 자동 추출 (rehype-toc 또는 velite 후처리) | F005 구현 PR | Task 007 (rehype-slug 1단계) + Task 013 (velite 후처리로 TOC 추출 — 채택) | Phase 2 + 3 |
+| A003 | 약관/처리방침 표준 메타 (version/effective_date 등) | F014 구현 PR | Task 006 (스키마 확정 — `version`, `effective_date` 채택) | Phase 1 |
+| A004 | Not Found Fallback (splat `*` vs ErrorBoundary) | F018/F019 구현 시 | Task 004 (splat 라우트 채택) | Phase 1 |
+| A005 | Satori 폰트 binary fetch 경로 | F011 구현 PR | Task 018 (Workers Asset Binding `env.ASSETS` 채택) | Phase 5 |
+| A006 | velite/shiki/Satori/Zod 미설치 | velite 도입 PR (Phase 2) | Task 007 (velite + shiki 설치) + Task 018 (Satori 설치) | Phase 2 + 5 |
+| A007 | 검색 라이브러리 vs 단순 includes/score | F016 구현 PR | Task 016 (단순 토큰 검색 채택, 100+ 도달 시 재검토) | Phase 4 |
+| A008 | 검색엔진 verification 토큰 주입 | F019 구현 PR | Task 020 (wrangler vars 사용) + Task 022 (배포 후 실제 토큰) | Phase 5 + 6 |
+| A009 | React Email/Resend/Turnstile 미설치 + env 필요 | F008/F009 구현 PR | Task 017 | Phase 4 |
+| A010 | 도메인 등록 채널 (CF Registrar / Porkbun) | 배포 PR 직전 | Task 022 (배포 단계에서 결정 후 기록) | Phase 6 |
+| A011 | Bing Webmaster Tools (MVP 후) | MVP 완료 후 | **MVP 범위 외** (Phase 6 이후 운영 task) | Post-MVP |
+| A012 | Motion 라이브러리 도입 보류 | MVP 완료 후 | **MVP 범위 외** (사용자 피드백 수집 후) | Post-MVP |
+
+> **운용 규칙**: 각 phase 완료 시점에 본 표를 점검하여 해당 phase가 게이트인 항목이 모두 [FACT]로 전환됐는지 확인하고 PRD 본문을 업데이트한다. A011/A012는 MVP 범위 외이므로 본 ROADMAP의 22 task 완료 후 별도 issue로 트래킹한다.
+
+---
+
+## Dependency Graph (요약)
+
+```
+Phase 0: Task 001 → Task 002 → (Task 003 || Task 002)
+                     ↓             ↓
+Phase 1: Task 006 (Domain)    Task 004 (Routes) + Task 005 (Theme/Tokens)
+                ↓                                    ↓
+Phase 2: Task 007 (velite) → Task 008 (Ports + Repos) → Task 009 (DI + workers wiring)
+                                                              ↓
+Phase 3:        Task 010 (Home) || Task 011 (About) || Task 012 (Projects)
+                || Task 013 (Project Detail) || Task 014a (Blog List + RSS) → Task 014b (Blog Detail) || Task 015 (Legal)
+                                                              ↓
+Phase 4: Task 016 (Cmd+K — Task 010 후) + Task 017-pre (docs) → Task 017 (Contact Form)
+                                                              ↓
+Phase 5: Task 018 (Satori OG) → Task 019 (SEO/Sitemap/JSON-LD) → Task 020 (검색엔진/Analytics)
+                                                              ↓
+Phase 6: Task 021 (QA) → Task 022 (Deploy)
+```
+
+> **병렬 가능 task** (`||` 표시): Phase 3의 Task 010, 011, 012, 013, 014a, 015는 콘텐츠 페이지 단위로 병렬 PR 가능 (T014b는 T014a 이후). Phase 1의 Task 004(Routes)와 Task 005(Theme/Tokens)는 의존성이 분리되어 병렬 가능. Phase 2 이후의 task는 순차. T017-pre(docs)는 T017보다 선행되어야 하나 다른 Phase 4 작업과는 무관.
+
+---
+
+## 진행 현황 요약
+
+- [ ] Phase 0: Setup & Toolchain (Task 001~003)
+- [ ] Phase 1: Foundation — Routing Skeleton + Domain Schemas + Theme (Task 004~006)
+- [ ] Phase 2: Content Pipeline — velite + MDX + shiki + Repository (Task 007~009)
+- [ ] Phase 3: Core Pages UI (Task 010~013, 014a, 014b, 015)
+- [ ] Phase 4: Forms / Email — Command Palette + Contact (Task 016, 017-pre, 017)
+- [ ] Phase 5: SEO / OG / Indexing (Task 018~020)
+- [ ] Phase 6: Polish & Deploy (Task 021~022)
+
+**총 24개 task (T014 분리 + T017-pre 추가) / 6개 phase / 100% PRD Feature(F001~F019, F015 제외) coverage / 100% Assumption(A001~A012) 해소 게이트 매핑.**
+
+> **검증 리포트(2026-04-28) 반영 이력**:
+> - Issue #1 (High): T010/T012/T015 자동 테스트(RTL + DOM assertion) 항목 보강
+> - Issue #2 (Medium): T008 `blockedBy`에 Task 002 명시 추가
+> - Issue #3 (Medium): T017-pre 신규 추가 — `app/infrastructure/ratelimit/` 모듈을 PROJECT-STRUCTURE.md에 사전 등록
+> - Issue #4 (Medium): T014 → T014a(Blog List + RSS) / T014b(Blog Detail) 분리
+> - Issue #5 (Medium): T017 사전 단계로 `wrangler kv namespace create RATE_LIMIT_KV` + wrangler.toml binding 등록 명시
+> - Issue #6 (Low): T003 산출물에 vitest coverage threshold 구체 수치(`lines:80, branches:75, functions:80, statements:80`) 명시
+> - Issue #7 (Low): T016 cross-platform 단축키 검증(macOS ⌘K / Windows·Linux Ctrl+K / `/`) 분기 명시

--- a/docs/design-system/components/about.jsx
+++ b/docs/design-system/components/about.jsx
@@ -1,0 +1,152 @@
+/* global React, TermWindow, Prompt, Out, Caret, Sep, Hint, KBD, TermList, Annot */
+
+// About v1 — `cat resume.md` style readout (섹션 카드형 정보 보존)
+function AboutV1({ lang = 'ko' }) {
+  return (
+    <TermWindow path="~/about" status="resume.md · 4.2k">
+      <Prompt>cat resume.md</Prompt>
+      <Sep />
+      <div className="section-bar">// HEAD <span className="line" /></div>
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-end' }}>
+        <div>
+          <h2 className="term-h2">김태곤 <span className="faint" style={{ fontSize: 13 }}>· solo developer</span></h2>
+          <Out>풀스택 · 제품 설계 · 운영까지 / hello@tkstar.dev</Out>
+        </div>
+        <button className="wf-btn accent">⎙ ./resume --pdf</button>
+      </div>
+
+      <div className="section-bar">// STACK <span className="line" /></div>
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: 10 }}>
+        {[['frontend',['ts','react','tw','vite']],['edge / be',['cf workers','d1','do','rsc']],['quality',['vitest','biome','tdd','clean-arch']]].map(([cat, list])=>(
+          <div key={cat} className="wf-card" style={{ padding: 12 }}>
+            <span className="pill on">{cat}</span>
+            <div style={{ display: 'flex', flexWrap: 'wrap', gap: 4, marginTop: 8 }}>
+              {list.map(t => <span key={t} className="pill">{t}</span>)}
+            </div>
+          </div>
+        ))}
+      </div>
+
+      <div className="section-bar">// EXPERIENCE <span className="line" /></div>
+      {[
+        ['2024 — now','회사 A · 시니어 개발자','● 결제 인프라 마이그레이션 · -40% 비용 ● DS 통합 · 컴포넌트 80→24'],
+        ['2022 — 2024','회사 B · 풀스택 개발자','● 0→1 SaaS 출시 · 8주 ● 운영 자동화로 on-call 0건/주'],
+        ['2020 — 2022','회사 C · 주니어','● 신규 프론트엔드 채택 · React 18 도입'],
+      ].map(([y,t,b],i)=>(
+        <div key={i} style={{ display: 'grid', gridTemplateColumns: '120px 1fr', gap: 12, padding: '8px 0', borderBottom: '1.5px dashed var(--line)' }}>
+          <span className="faint" style={{ fontSize: 11 }}>{y}</span>
+          <div>
+            <span className="strong" style={{ fontSize: 13 }}>{t}</span>
+            <Out>{b}</Out>
+          </div>
+        </div>
+      ))}
+
+      <div className="section-bar">// EDUCATION · AWARDS <span className="line" /></div>
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(2,1fr)', gap: 10 }}>
+        <div className="wf-card" style={{ padding: 12 }}><span className="pill">edu</span><Out>○○대학교 컴퓨터공학 · 2016—2020</Out></div>
+        <div className="wf-card" style={{ padding: 12 }}><span className="pill">awards</span><Out>○○ 해커톤 1위 · 2024<br/>오픈소스 컨트리뷰터 · 2023</Out></div>
+      </div>
+
+      <div style={{ marginTop: 14 }}>
+        <Prompt dim>./resume --pdf</Prompt>
+        <Hint>F003 · @media print 단순화 (헤더·토글·터미널 chrome 숨김)</Hint>
+      </div>
+
+      <Annot x={'auto'} y={20} rot={2}>섹션 = 마크다운 파일 / cat 출력</Annot>
+    </TermWindow>
+  );
+}
+
+// About v2 — `git log --career` 타임라인
+function AboutV2({ lang = 'ko' }) {
+  const log = [
+    { h: 'a3f12b', d: '2026-04', t: 'feat(career): solo studio launched', tags: ['solo','tkstar.dev'] },
+    { h: '7c2901', d: '2024-08', t: 'feat: senior @ company A', tags: ['ts','cf','d1'] },
+    { h: '5b8e44', d: '2022-03', t: 'feat: fullstack @ company B', tags: ['react','rails'] },
+    { h: '2a17ee', d: '2020-06', t: 'init: junior @ company C', tags: ['js','vue'] },
+    { h: '0001cf', d: '2020-02', t: 'init: B.S. computer science', tags: ['edu'] },
+  ];
+  return (
+    <TermWindow path="~/about" status="git log --career --graph">
+      <div style={{ display: 'grid', gridTemplateColumns: '1fr 220px', gap: 22 }}>
+        <div>
+          <Prompt>git log --career --graph</Prompt>
+          <Sep />
+          {log.map((c,i) => (
+            <div key={c.h} style={{ display: 'grid', gridTemplateColumns: '20px 90px 80px 1fr', gap: 8, fontSize: 12, padding: '8px 0', borderBottom: '1.5px dashed var(--line)', alignItems: 'baseline' }}>
+              <span className="green">{i===0?'●':'│'}</span>
+              <span className="amber" style={{ fontFamily: 'var(--mono)' }}>{c.h}</span>
+              <span className="faint">{c.d}</span>
+              <div>
+                <span className="strong">{c.t}</span>
+                <div style={{ display: 'flex', gap: 4, marginTop: 4 }}>
+                  {c.tags.map(t => <span key={t} className="pill">{t}</span>)}
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+        <aside className="col" style={{ gap: 10 }}>
+          <div className="wf-card" style={{ padding: 12 }}>
+            <div className="ph-img" style={{ height: 80 }}>avatar</div>
+            <div style={{ marginTop: 8 }}>
+              <span className="strong">김태곤</span>
+              <Out>solo · seoul</Out>
+            </div>
+          </div>
+          <button className="wf-btn accent">⎙ ./resume --pdf</button>
+          <div className="wf-card" style={{ padding: 10 }}>
+            <span className="pill">refs</span>
+            <div className="muted" style={{ fontSize: 11, marginTop: 6, lineHeight: 1.85 }}>
+              · HEAD → main<br/>· tag: v0.1.0<br/>· branch: tkstar/dev
+            </div>
+          </div>
+        </aside>
+      </div>
+      <Annot x={'auto'} y={60} rot={-2}>커리어 = git log · 한 눈에 흐름</Annot>
+    </TermWindow>
+  );
+}
+
+// About v3 — 화면용 / 인쇄용 split
+function AboutV3({ lang = 'ko' }) {
+  return (
+    <TermWindow path="~/about" status="screen ⇆ print preview">
+      <Prompt>./resume --preview --split=screen,print</Prompt>
+      <Sep />
+      <div className="split" style={{ border: '1.5px dashed var(--line-strong)', borderRadius: 6, minHeight: 360 }}>
+        <div className="split-pane">
+          <span className="pill on">screen · dark</span>
+          <h2 className="term-h2">김태곤 <span className="faint">· solo</span></h2>
+          <Out>풍부한 시각, 다크모드, hover 인터랙션 ─────</Out>
+          <Hint>이력서 콘텐츠는 동일 — 스타일만 분기</Hint>
+          <Sep />
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+            <Out>● intro</Out>
+            <Out>● stack (categorized)</Out>
+            <Out>● experience (3 entries)</Out>
+            <Out>● education · awards</Out>
+          </div>
+        </div>
+        <div className="split-pane" style={{ background: '#f4f1ea', color: '#1a1c20' }}>
+          <span style={{ fontSize: 10, letterSpacing: '0.1em', color: '#5a6068' }}>PRINT · A4 · @media print</span>
+          <h2 style={{ fontFamily: 'var(--mono)', fontSize: 18, margin: 0, color: '#1a1c20' }}>김태곤</h2>
+          <div style={{ fontSize: 10, color: '#5a6068' }}>solo developer · hello@tkstar.dev</div>
+          <div style={{ height: 1, background: '#c8c2b3', margin: '6px 0' }} />
+          <div style={{ fontSize: 10, lineHeight: 1.7, color: '#1a1c20', fontFamily: 'var(--mono)' }}>
+            <strong>EXPERIENCE</strong><br/>
+            ─ Company A · 2024-now<br/>
+            ─ Company B · 2022-2024<br/>
+            ─ Company C · 2020-2022<br/><br/>
+            <strong>STACK</strong> TypeScript, React, Cloudflare, MDX...
+          </div>
+          <Hint>hide: header, toggles, terminal chrome, hand annotations</Hint>
+        </div>
+      </div>
+      <Annot x={'auto'} y={20} rot={1}>F003 · 듀얼 출력</Annot>
+    </TermWindow>
+  );
+}
+
+Object.assign(window, { AboutV1, AboutV2, AboutV3 });

--- a/docs/design-system/components/blog-detail.jsx
+++ b/docs/design-system/components/blog-detail.jsx
@@ -1,0 +1,88 @@
+/* global React, TermWindow, Prompt, Out, Caret, Sep, Hint, KBD, Annot */
+
+// Blog Detail v1 — `cat post.mdx`
+function BlogDetailV1({ lang = 'ko' }) {
+  return (
+    <TermWindow path="~/blog/cf-rsc-running" status="post.mdx · 8 min · shiki ✓">
+      <Prompt>cat cf-rsc-running.mdx</Prompt>
+      <Sep />
+      <span className="pill">2026.04.20 · 8 min</span>
+      <h1 className="term-h1" style={{ marginTop: 8 }}>Cloudflare Workers + RSC,<br/>한 달 운영기</h1>
+      <Out>{['rsc','cf','workers'].map(t=>'#'+t).join(' ')}</Out>
+      <div className="ph-img" style={{ height: 150, marginTop: 10 }}>satori og · 1200×630</div>
+
+      <Out style={{ marginTop: 14 }}>───── lede 단락. MDX 본문 + shiki 코드 블록 ─────</Out>
+      <div className="code">
+        <span className="c">{'// shiki highlighted'}</span>{'\n'}
+        <span className="k">async function</span> <span className="f">handler</span>(req) {`{`}{'\n'}
+        {'  '}<span className="k">const</span> rsc = <span className="k">await</span> <span className="f">render</span>(...){'\n'}
+        {'  '}<span className="k">return new</span> <span className="f">Response</span>(rsc){'\n'}
+        {`}`}
+      </div>
+      <Out>───── 추가 본문 ─────</Out>
+      <Sep />
+      <div style={{ display: 'flex', justifyContent: 'space-between' }}>
+        <button className="wf-btn ghost">← prev post</button>
+        <button className="wf-btn ghost">next post →</button>
+      </div>
+      <Annot x={'auto'} y={20} rot={2}>F007 · F011 · shiki + Satori</Annot>
+    </TermWindow>
+  );
+}
+
+// Blog Detail v2 — TOC sidebar
+function BlogDetailV2({ lang = 'ko' }) {
+  return (
+    <TermWindow path="~/blog/velite-mdx" status="TOC scroll-spy">
+      <div style={{ display: 'grid', gridTemplateColumns: '1fr 200px', gap: 22 }}>
+        <article>
+          <Prompt>cat velite-mdx.mdx</Prompt>
+          <Sep />
+          <span className="pill">2026.03.11 · 6 min</span>
+          <h1 className="term-h1" style={{ marginTop: 8 }}>velite로 MDX 컬렉션 다루기</h1>
+          <Out>frontmatter Zod 검증 + 빌드타임 인덱스</Out>
+          <div className="section-bar">## 1. velite란? <span className="line" /></div>
+          <Out>───── 본문 ─────</Out>
+          <div className="section-bar">## 2. Zod 스키마 <span className="line" /></div>
+          <Out>───── 본문 ─────</Out>
+          <div className="section-bar">## 3. 빌드 인덱스 <span className="line" /></div>
+          <Out>───── 본문 ─────</Out>
+        </article>
+        <aside style={{ position: 'sticky', top: 0, alignSelf: 'flex-start' }}>
+          <div className="wf-card" style={{ padding: 10 }}>
+            <span className="pill">on this page</span>
+            <Out style={{ lineHeight: 2 }}>
+              · velite란?<br/>· Zod 스키마<br/>· <span className="green">빌드 인덱스</span><br/>· 결론
+            </Out>
+          </div>
+          <div className="wf-card" style={{ padding: 10, marginTop: 8 }}>
+            <span className="pill">share</span>
+            <Out>copy · x · in</Out>
+          </div>
+        </aside>
+      </div>
+      <Annot x={'auto'} y={20} rot={-2}>scroll-spy TOC</Annot>
+    </TermWindow>
+  );
+}
+
+// Blog Detail v3 — minimal reader (centered)
+function BlogDetailV3({ lang = 'ko' }) {
+  return (
+    <TermWindow path="~/blog/solo-ops" status="reader · 720 measure">
+      <div style={{ maxWidth: 720, margin: '0 auto' }}>
+        <Prompt>./reader solo-ops.mdx</Prompt>
+        <Sep />
+        <span className="pill" style={{ borderColor: 'var(--accent-2)', color: 'var(--accent-2)' }}>essay</span>
+        <h1 className="term-h1" style={{ fontSize: 36, marginTop: 8, lineHeight: 1.15 }}>1인 개발자의<br/>운영 자동화</h1>
+        <Out>2026.02.02 · 5 min</Out>
+        <Sep />
+        <p style={{ fontSize: 14, lineHeight: 1.95, color: 'var(--ink)' }}>───── 첫 단락. 큰 measure, 풍부한 line-height ─────</p>
+        <Out>───── 본문 단락 ─────</Out>
+      </div>
+      <Annot x={'auto'} y={20} rot={2}>읽기 전용 · 720</Annot>
+    </TermWindow>
+  );
+}
+
+Object.assign(window, { BlogDetailV1, BlogDetailV2, BlogDetailV3 });

--- a/docs/design-system/components/blog.jsx
+++ b/docs/design-system/components/blog.jsx
@@ -1,0 +1,119 @@
+/* global React, TermWindow, Prompt, Out, Caret, Sep, Hint, KBD, TermList, Annot */
+
+// Blog v1 — `ls posts/` 리스트
+function BlogV1({ lang = 'ko' }) {
+  const posts = [
+    ['2026-04-20','cf-rsc-running','Cloudflare Workers + RSC, 한 달 운영기','8 min',['rsc','cf']],
+    ['2026-03-11','velite-mdx','velite로 MDX 컬렉션 다루기','6 min',['mdx','velite']],
+    ['2026-02-02','solo-ops','1인 개발자의 운영 자동화','5 min',['ops']],
+    ['2026-01-05','tw4-migrate','Tailwind 4 마이그레이션 메모','7 min',['tw']],
+    ['2025-12-08','vitest-tdd','Vitest로 TDD 워크플로 만들기','9 min',['tdd']],
+  ];
+  return (
+    <TermWindow path="~/blog" status={`${posts.length} posts · /rss.xml`}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8, justifyContent: 'space-between' }}>
+        <Prompt>ls posts/ --sort=date</Prompt>
+        <span className="pill on">📡 /rss.xml</span>
+      </div>
+      <Sep />
+      <div style={{ display: 'flex', gap: 6, margin: '8px 0' }}>
+        {['all','rsc','cf','mdx','tw','ops','tdd'].map((t,i)=>(
+          <span key={t} className={i===0?'pill on':'pill'}>#{t}</span>
+        ))}
+      </div>
+      {posts.map((p,i)=>(
+        <div key={i} style={{ display: 'grid', gridTemplateColumns: '110px 180px 1fr 60px 30px', gap: 12, padding: '10px 0', borderBottom: '1.5px dashed var(--line)', alignItems: 'center', fontSize: 12 }}>
+          <span className="faint">{p[0]}</span>
+          <span className="amber">{p[1]}.mdx</span>
+          <div>
+            <span className="strong">{p[2]}</span>
+            <div style={{ display: 'flex', gap: 4, marginTop: 2 }}>{p[4].map(t=><span key={t} className="pill">#{t}</span>)}</div>
+          </div>
+          <span className="faint" style={{ fontSize: 11 }}>{p[3]}</span>
+          <span className="green">→</span>
+        </div>
+      ))}
+      <Annot x={'auto'} y={20} rot={2}>F006 · F012 RSS</Annot>
+    </TermWindow>
+  );
+}
+
+// Blog v2 — year archive (history)
+function BlogV2({ lang = 'ko' }) {
+  return (
+    <TermWindow path="~/blog" status="history --year">
+      <Prompt>history --by=year</Prompt>
+      <Sep />
+      <h1 className="term-h1" style={{ fontSize: 32, marginTop: 8 }}>writing<span className="muted">.log</span></h1>
+      <Out>월 1편 · 기술/회고</Out>
+      {[
+        ['2026',[
+          ['04','Cloudflare Workers + RSC, 한 달 운영기'],
+          ['03','velite로 MDX 컬렉션 다루기'],
+          ['02','1인 개발자의 운영 자동화'],
+          ['01','Tailwind 4 마이그레이션 메모'],
+        ]],
+        ['2025',[
+          ['12','Vitest로 TDD 워크플로 만들기'],
+          ['11','Resend로 1인 메일 인프라 만들기'],
+        ]],
+      ].map(([y, items])=>(
+        <div key={y} style={{ marginTop: 14 }}>
+          <div className="section-bar">{y} <span className="line" /></div>
+          {items.map((it,i)=>(
+            <div key={i} style={{ display: 'grid', gridTemplateColumns: '50px 1fr 30px', gap: 10, padding: '8px 0', borderBottom: '1.5px dashed var(--line)', fontSize: 12, alignItems: 'center' }}>
+              <span className="faint">.{it[0]}</span>
+              <span className="strong">{it[1]}</span>
+              <span className="green">→</span>
+            </div>
+          ))}
+        </div>
+      ))}
+      <Annot x={'auto'} y={50} rot={-2}>history · year-grouped</Annot>
+    </TermWindow>
+  );
+}
+
+// Blog v3 — card grid w/ OG preview
+function BlogV3({ lang = 'ko' }) {
+  return (
+    <TermWindow path="~/blog" status="grid --og-preview">
+      <div style={{ display: 'grid', gridTemplateColumns: '1fr 200px', gap: 18 }}>
+        <div>
+          <Prompt>./blog --grid --og</Prompt>
+          <Sep />
+          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(2, 1fr)', gap: 12, marginTop: 10 }}>
+            {[1,2,3,4].map(i=>(
+              <div key={i} className="wf-card" style={{ padding: 10 }}>
+                <div className="ph-img" style={{ height: 80 }}>satori og · 1200×630</div>
+                <Out style={{ marginTop: 6 }}><span className="faint">2026.0{i}.11 · 6 min</span></Out>
+                <span className="strong" style={{ fontSize: 13 }}>포스트 제목 {i}</span>
+                <Out>한 줄 요약 ─────</Out>
+                <div style={{ display: 'flex', gap: 4 }}>{['rsc','cf'].map(t=><span key={t} className="pill">#{t}</span>)}</div>
+              </div>
+            ))}
+          </div>
+        </div>
+        <aside className="col" style={{ gap: 10 }}>
+          <div className="wf-card" style={{ padding: 10 }}>
+            <span className="pill">tags</span>
+            <div style={{ display: 'flex', flexWrap: 'wrap', gap: 4, marginTop: 8 }}>
+              {['rsc','cf','mdx','tw','ops','tdd'].map(t=><span key={t} className="pill">#{t}</span>)}
+            </div>
+          </div>
+          <div className="wf-card" style={{ padding: 10 }}>
+            <span className="pill">archive</span>
+            <Out>2026 · 4<br/>2025 · 2</Out>
+          </div>
+          <div className="wf-card" style={{ padding: 10 }}>
+            <span className="pill">📡 rss</span>
+            <Out>/rss.xml</Out>
+          </div>
+        </aside>
+      </div>
+      <Annot x={'auto'} y={20} rot={2}>OG 미리보기 강조</Annot>
+    </TermWindow>
+  );
+}
+
+Object.assign(window, { BlogV1, BlogV2, BlogV3 });

--- a/docs/design-system/components/contact-legal.jsx
+++ b/docs/design-system/components/contact-legal.jsx
@@ -1,0 +1,192 @@
+/* global React, TermWindow, Prompt, Out, Caret, Sep, Hint, KBD, Annot */
+
+// Contact v1 — terminal form (표준 + sidebar info)
+function ContactV1({ lang = 'ko' }) {
+  return (
+    <TermWindow path="~/contact" status="./contact --new">
+      <Prompt>./contact --new</Prompt>
+      <Out>{'> 메시지를 작성하세요. 평균 회신 24h 이내. hello@tkstar.dev'}</Out>
+      <Sep />
+      <div style={{ display: 'grid', gridTemplateColumns: '1fr 220px', gap: 22, marginTop: 10 }}>
+        <div className="col" style={{ gap: 10 }}>
+          <div className="input-line"><span className="lbl">name *</span><span className="val ph">_</span></div>
+          <div className="input-line"><span className="lbl">company</span><span className="val ph">(선택)</span></div>
+          <div className="input-line"><span className="lbl">email *</span><span className="val ph">you@company.com</span></div>
+          <div style={{ marginTop: 4 }}>
+            <span className="faint" style={{ fontSize: 11 }}>의뢰 유형 *</span>
+            <div style={{ display: 'flex', gap: 8, marginTop: 4 }}>
+              <span className="pill">[ ] B2B 채용·제안</span>
+              <span className="pill on">[●] B2C 의뢰</span>
+              <span className="pill">[ ] 기타</span>
+            </div>
+          </div>
+          <div className="input-line" style={{ alignItems: 'flex-start', minHeight: 90 }}>
+            <span className="lbl">message *</span>
+            <span className="val ph">프로젝트 개요, 일정, 예산 범위 등<Caret /></span>
+          </div>
+          <div className="wf-box center" style={{ height: 50, color: 'var(--ink-faint)', fontSize: 11 }}>
+            ☐ Cloudflare Turnstile (F009)
+          </div>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+            <button className="wf-btn accent">↵ send</button>
+            <Hint>Resend → hello@tkstar.dev · 자동응답 메일 발송</Hint>
+          </div>
+        </div>
+        <aside className="col" style={{ gap: 10 }}>
+          <div className="wf-card" style={{ padding: 10 }}>
+            <span className="pill">direct</span>
+            <Out style={{ marginTop: 4 }}>hello@tkstar.dev<br/>gh · @tkstar<br/>x · @tkstar</Out>
+          </div>
+          <div className="wf-card" style={{ padding: 10 }}>
+            <span className="pill">expect</span>
+            <Out style={{ lineHeight: 1.85 }}>● 24h 회신<br/>● 30분 무료 통화<br/>● 가격은 메일 협의</Out>
+          </div>
+        </aside>
+      </div>
+      <Annot x={'auto'} y={20} rot={2}>F008 · F009 · Turnstile</Annot>
+    </TermWindow>
+  );
+}
+
+// Contact v2 — REPL conversational
+function ContactV2({ lang = 'ko' }) {
+  return (
+    <TermWindow path="~/contact" status="interactive REPL">
+      <Prompt>./contact --interactive</Prompt>
+      <Out>{'> 어떤 분이신가요? 1/2/3 중 선택'}</Out>
+      <div style={{ marginLeft: 16, marginTop: 4 }}>
+        {['[1] B2B 기업 담당자','[2] B2C 의뢰 클라이언트','[3] 기타'].map((o,i)=>(
+          <Out key={i} color={i===0?'var(--accent)':null}>{i===0?'▶':' '} {o}</Out>
+        ))}
+      </div>
+      <Out style={{ marginTop: 8 }}>{'> 이름?'}</Out>
+      <div className="input-line"><span className="lbl">↳</span><span className="val ph">_<Caret /></span></div>
+      <Out>{'> 이메일?'}</Out>
+      <div className="input-line"><span className="lbl">↳</span><span className="val ph">_</span></div>
+      <Out>{'> 메시지를 입력하세요. ──── 끝나면 빈 줄.'}</Out>
+      <div className="input-line" style={{ alignItems: 'flex-start', minHeight: 70 }}><span className="lbl">↳</span><span className="val ph">_</span></div>
+      <Sep />
+      <Out><span className="green">[ Turnstile ✓ ]</span> <KBD>↵</KBD> send · <KBD>esc</KBD> cancel</Out>
+      <Annot x={'auto'} y={20} rot={-2}>대화형 REPL · 한 필드씩</Annot>
+    </TermWindow>
+  );
+}
+
+// Contact v3 — exit-code states (idle/success/error)
+function ContactV3({ lang = 'ko' }) {
+  return (
+    <TermWindow path="~/contact" status="exit codes preview">
+      <Prompt>./contact --states-preview</Prompt>
+      <Sep />
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3,1fr)', gap: 12, marginTop: 10 }}>
+        <div className="wf-card" style={{ padding: 12 }}>
+          <span className="pill">[ idle · 0 ]</span>
+          <div className="input-line"><span className="lbl">name</span><span className="val ph">_</span></div>
+          <div className="input-line"><span className="lbl">email</span><span className="val ph">_</span></div>
+          <div className="input-line" style={{ minHeight: 50 }}><span className="lbl">msg</span><span className="val ph">_</span></div>
+          <button className="wf-btn accent" style={{ marginTop: 6 }}>↵ send</button>
+        </div>
+        <div className="wf-card" style={{ padding: 12, borderColor: 'var(--accent)', display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', gap: 6 }}>
+          <span className="pill on">[ success · 0 ]</span>
+          <div className="green" style={{ fontSize: 32 }}>✓</div>
+          <span className="strong">메시지 전송됨</span>
+          <Out>자동응답 메일 발송 ✓</Out>
+          <button className="wf-btn ghost">새 메시지</button>
+        </div>
+        <div className="wf-card" style={{ padding: 12, borderColor: 'var(--warn)' }}>
+          <span className="pill" style={{ color: 'var(--warn)', borderColor: 'var(--warn)' }}>[ error · 1 ]</span>
+          <Out>resend.send() failed</Out>
+          <Out className="faint">Error: 503 upstream</Out>
+          <button className="wf-btn">재시도</button>
+          <Out style={{ fontSize: 11 }}>또는 직접 메일 보내기:</Out>
+          <a className="green" style={{ fontSize: 11 }}>mailto:hello@tkstar.dev</a>
+        </div>
+      </div>
+      <Annot x={'auto'} y={20} rot={2}>3 상태 · exit code 메타포</Annot>
+    </TermWindow>
+  );
+}
+
+// App Terms v1 — `cat legal/apps/moai/terms.mdx`
+function AppTermsV1({ lang = 'ko' }) {
+  return (
+    <TermWindow path="~/legal/apps/moai" status="terms.mdx · v1.0">
+      <Prompt>cat terms.mdx</Prompt>
+      <Sep />
+      <span className="pill">app: moai · v1.0 · effective 2026.04.01</span>
+      <h1 className="term-h1" style={{ marginTop: 8, fontSize: 24 }}>Moai 이용약관</h1>
+      <div className="wf-box" style={{ padding: 10, marginTop: 8, fontSize: 11, color: 'var(--ink-faint)' }}>
+        ⚠ MVP skeleton · velite collection legal/apps/moai/terms.mdx — 앱 출시 시 채움
+      </div>
+      <div className="section-bar">## 1. 목적 <span className="line" /></div>
+      <Out>───── 본문 ─────</Out>
+      <div className="section-bar">## 2. 용어의 정의 <span className="line" /></div>
+      <Out>───── 본문 ─────</Out>
+      <div className="section-bar">## 3. 서비스 제공 <span className="line" /></div>
+      <Out>───── 본문 ─────</Out>
+      <Annot x={'auto'} y={20} rot={2}>F014 · 앱별 라우팅</Annot>
+    </TermWindow>
+  );
+}
+
+// App Privacy v1 — split with meta
+function AppPrivacyV1({ lang = 'ko' }) {
+  return (
+    <TermWindow path="~/legal/apps/moai" status="privacy.mdx · v1.0">
+      <Prompt>cat privacy.mdx</Prompt>
+      <Sep />
+      <h1 className="term-h1" style={{ fontSize: 22, marginTop: 8 }}>개인정보처리방침</h1>
+      <div style={{ display: 'grid', gridTemplateColumns: '1fr 200px', gap: 22, marginTop: 8 }}>
+        <div>
+          <div className="section-bar">## 1. 수집 항목 <span className="line" /></div>
+          <Out>───── 본문 ─────</Out>
+          <div className="section-bar">## 2. 이용 목적 <span className="line" /></div>
+          <Out>───── 본문 ─────</Out>
+          <div className="section-bar">## 3. 보관 기간 <span className="line" /></div>
+          <Out>───── 본문 ─────</Out>
+        </div>
+        <aside className="wf-card" style={{ padding: 10 }}>
+          <span className="pill">meta</span>
+          <Out style={{ lineHeight: 1.95 }}>
+            app ─ moai<br/>version ─ 1.0<br/>시행일 ─ 2026.04.01<br/>문의 ─ hello@tkstar.dev
+          </Out>
+          <button className="wf-btn ghost" style={{ marginTop: 8 }}>cd ../terms →</button>
+        </aside>
+      </div>
+      <Annot x={'auto'} y={20} rot={-2}>앱 출시 시 채움</Annot>
+    </TermWindow>
+  );
+}
+
+// Legal skeleton — 라우팅 상태
+function LegalSkeleton({ lang = 'ko' }) {
+  return (
+    <TermWindow path="~/legal" status="MVP · pending fill">
+      <Prompt>find legal/apps/ -name '*.mdx'</Prompt>
+      <Sep />
+      <h1 className="term-h1" style={{ fontSize: 22, marginTop: 8 }}>Legal — 앱별 약관 / 처리방침</h1>
+      <Out>출시 앱마다 자동 노출 · MVP는 라우팅 + 빈 템플릿만</Out>
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(2,1fr)', gap: 10, marginTop: 12 }}>
+        {[
+          ['moai',['pending','pending']],
+          ['(slug)',['—','—']],
+        ].map(([app, st], i)=>(
+          <div key={i} className="wf-card" style={{ padding: 12 }}>
+            <span className="pill on">{app}</span>
+            <Out style={{ marginTop: 6 }}>
+              /legal/apps/{app}/terms <span className="amber">{st[0]}</span><br/>
+              /legal/apps/{app}/privacy <span className="amber">{st[1]}</span>
+            </Out>
+          </div>
+        ))}
+      </div>
+      <div className="wf-box" style={{ padding: 10, marginTop: 14, fontSize: 11, color: 'var(--ink-faint)' }}>
+        velite collection: <span className="green">legal/apps/[slug]/(terms|privacy).mdx</span><br/>
+        Zod schema: app_slug · doc_type · version · effective_date · body
+      </div>
+      <Annot x={'auto'} y={20} rot={2}>F014 · 점진적 채움</Annot>
+    </TermWindow>
+  );
+}
+
+Object.assign(window, { ContactV1, ContactV2, ContactV3, AppTermsV1, AppPrivacyV1, LegalSkeleton });

--- a/docs/design-system/components/home.jsx
+++ b/docs/design-system/components/home.jsx
@@ -1,0 +1,118 @@
+/* global React, TermWindow, Prompt, Out, Caret, Sep, Hint, KBD, TermList, Annot */
+
+// ─────────────────────────────────────────────────────
+// HOME — every variant uses TermWindow
+// ─────────────────────────────────────────────────────
+
+// v1 · 부팅 시퀀스 + 자동 추천 (재방문 분기 강조)
+function HomeV1({ lang = 'ko' }) {
+  return (
+    <TermWindow path="~" status="home.tsx · returning visitor">
+      <Prompt>./tkstar --boot</Prompt>
+      <Out>booting tkstar.dev v0.1.0 ...</Out>
+      <Out><span className="green">✓</span> theme loaded</Out>
+      <Out><span className="green">✓</span> mdx collections indexed (5 projects, 6 posts)</Out>
+      <Out><span className="green">✓</span> localStorage: <span className="amber">audience=B2B</span> (last visit 2d ago)</Out>
+      <Sep />
+      <Prompt>./tkstar --who-are-you</Prompt>
+      <Out style={{ marginTop: 6 }}>
+        <span className="strong" style={{ fontSize: 16 }}>안녕하세요, 1인 개발자 김태곤입니다.</span>
+      </Out>
+      <Out>웹/앱 제품을 처음부터 끝까지 혼자 설계·구현·운영합니다.</Out>
+
+      <div style={{ marginTop: 18 }} />
+      <Out><span className="amber">✦ recommend</span> — 지난번 동선을 이어가시겠어요?</Out>
+      <div style={{ display: 'flex', gap: 10, marginTop: 8, flexWrap: 'wrap' }}>
+        <button className="wf-btn accent">▶ /about · 이력서 이어보기</button>
+        <button className="wf-btn">/projects</button>
+        <button className="wf-btn ghost">/contact</button>
+      </div>
+      <Hint>F015 · localStorage 분기 기억 · <KBD>tab</KBD> 으로 이동 <KBD>enter</KBD> 진입</Hint>
+      <div style={{ marginTop: 16 }}><Prompt><Caret /></Prompt></div>
+
+      <Annot x={'auto'} y={20} color="var(--accent-2)" rot={2}>
+        터미널 부팅 시퀀스가 곧<br/>self-introduction
+      </Annot>
+    </TermWindow>
+  );
+}
+
+// v2 · 분기 split — 두 명령어가 동시에
+function HomeV2({ lang = 'ko' }) {
+  return (
+    <TermWindow path="~" status="audience split · F001">
+      <Prompt>./tkstar --who-are-you</Prompt>
+      <Out>{'> 두 가지 입구로 안내합니다. 한 쪽을 골라주세요.'}</Out>
+      <div style={{ height: 12 }} />
+      <div className="split" style={{ border: '1.5px dashed var(--line-strong)', borderRadius: 6, minHeight: 280 }}>
+        <div className="split-pane">
+          <span className="pill on">[1] HIRING · B2B</span>
+          <h2 className="term-h2">기업 담당자이신가요?</h2>
+          <Out>$ cat resume.md  →  이력 · 스택 · 경력</Out>
+          <Out>$ ./resume --pdf  →  window.print()</Out>
+          <Out>$ ls projects/   →  심화 검토</Out>
+          <div style={{ flex: 1 }} />
+          <button className="wf-btn accent" style={{ alignSelf: 'flex-start' }}>▶ enter /about</button>
+        </div>
+        <div className="split-pane">
+          <span className="pill" style={{ borderColor: 'var(--accent-2)', color: 'var(--accent-2)' }}>[2] COMMISSION · B2C</span>
+          <h2 className="term-h2">프로젝트 의뢰가<br/>필요하신가요?</h2>
+          <Out>$ ls projects/   →  케이스 스터디</Out>
+          <Out>$ open ./case  →  문제→접근→결과</Out>
+          <Out>$ ./contact --new →  메일 협의</Out>
+          <div style={{ flex: 1 }} />
+          <button className="wf-btn" style={{ alignSelf: 'flex-start' }}>▶ enter /projects</button>
+        </div>
+      </div>
+      <Hint>그냥 둘러보고 싶으세요? <span className="green" style={{ borderBottom: '1px dashed' }}>./explore --all</span></Hint>
+      <Annot x={'auto'} y={70} rot={-3}>
+        F001 · 첫 방문엔<br/>두 명령어 동등하게
+      </Annot>
+    </TermWindow>
+  );
+}
+
+// v3 · whoami 한 줄 큰 타입 + cmd palette 미리보기
+function HomeV3({ lang = 'ko' }) {
+  return (
+    <TermWindow path="~" status="press ⌘K to navigate">
+      <Prompt>whoami</Prompt>
+      <div style={{ margin: '14px 0 8px' }}>
+        <h1 className="term-h1" style={{ fontSize: 44 }}>
+          ship <span className="green">solo</span>.<br/>
+          <span className="muted">ship </span>fast<span className="muted">.</span>
+        </h1>
+      </div>
+      <Out>1명의 개발자. 풀스택. 제품 설계부터 운영까지. <Caret /></Out>
+      <div style={{ marginTop: 22 }}>
+        <Prompt>⌘K</Prompt>
+        <div className="wf-card" style={{ padding: 0, marginTop: 6, background: 'var(--bg-elev)' }}>
+          <div style={{ padding: '8px 14px', borderBottom: '1.5px dashed var(--line)', fontSize: 12 }}>
+            <span className="green">›</span> <span className="strong">go to ─ </span><span className="faint">_</span>
+          </div>
+          {[
+            ['/about','이력서 · 채용 검토',' B2B'],
+            ['/projects','포트폴리오 · 케이스 스터디',' B2C'],
+            ['/blog','월 1편 기록',''],
+            ['/contact','의뢰 · 제안',''],
+          ].map(([p,d,b],i)=>(
+            <div key={i} style={{ display: 'flex', alignItems: 'center', gap: 10, padding: '8px 14px', borderBottom: '1.5px dashed var(--line)', fontSize: 12, color: i===0?'var(--accent)':'var(--ink-dim)' }}>
+              <span style={{ width: 14 }}>{i===0?'▶':' '}</span>
+              <span className="strong" style={{ minWidth: 100 }}>{p}</span>
+              <span className="faint">{d}</span>
+              {b && <span className="pill" style={{ marginLeft: 'auto' }}>{b.trim()}</span>}
+            </div>
+          ))}
+          <div style={{ padding: '6px 14px', fontSize: 10, color: 'var(--ink-faint)' }}>
+            <KBD>↑↓</KBD> 이동 <KBD>↵</KBD> 진입 <KBD>esc</KBD> 닫기
+          </div>
+        </div>
+      </div>
+      <Annot x={'auto'} y={60} rot={3}>
+        커맨드 팔레트가<br/>주 네비게이션
+      </Annot>
+    </TermWindow>
+  );
+}
+
+window.HomeV1 = HomeV1; window.HomeV2 = HomeV2; window.HomeV3 = HomeV3;

--- a/docs/design-system/components/project-detail.jsx
+++ b/docs/design-system/components/project-detail.jsx
@@ -1,0 +1,114 @@
+/* global React, TermWindow, Prompt, Out, Caret, Sep, Hint, KBD, TermList, Annot */
+
+// Project Detail v1 — `cat case.mdx` 선형 narrative
+function ProjectDetailV1({ lang = 'ko' }) {
+  return (
+    <TermWindow path="~/projects/whiteboard-rt" status="case.mdx · 6 min read">
+      <Prompt>cat case.mdx</Prompt>
+      <Out>{`> frontmatter ✓  shiki ✓  satori-og ✓`}</Out>
+      <Sep />
+      <span className="pill on">case study · 2026.03</span>
+      <h1 className="term-h1" style={{ marginTop: 8 }}>실시간 협업 화이트보드</h1>
+      <Out>WebSocket → Durable Objects 마이그레이션, p99 -80%</Out>
+      <div style={{ display: 'flex', gap: 4, marginTop: 6 }}>{['ts','do','wss','vitest'].map(t=><span key={t} className="pill">{t}</span>)}</div>
+      <div className="ph-img" style={{ height: 180, marginTop: 12 }}>cover · 1200×600 · satori OG</div>
+
+      <div className="section-bar">## 01 · problem <span className="line" /></div>
+      <Out>기존 단일 WS 서버 구조에서 동시접속 100+ 시 p99 지연 2초 초과. 룸 단위 격리 안됨.</Out>
+
+      <div className="section-bar">## 02 · approach <span className="line" /></div>
+      <Out>Durable Objects로 룸 단위 샤딩 + Hibernation API로 idle 비용 절감.</Out>
+      <div className="code">
+        <span className="c">{'// shiki highlighted'}</span>{'\n'}
+        <span className="k">export class</span> <span className="f">Whiteboard</span> <span className="k">extends</span> DurableObject {`{`}{'\n'}
+        {'  '}<span className="k">async</span> <span className="f">fetch</span>(req: Request) {`{`}{'\n'}
+        {'    '}<span className="k">const</span> id = <span className="k">this</span>.state.id.toString(){'\n'}
+        {'    '}<span className="k">return</span> <span className="s">'ok'</span>{'\n'}
+        {'  }'}{'\n'}
+        {`}`}
+      </div>
+
+      <div className="section-bar">## 03 · results <span className="line" /></div>
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3,1fr)', gap: 10 }}>
+        {[['p99 지연','-80%'],['Idle 비용','-90%'],['MAU','+3.2k']].map(([k,v])=>(
+          <div key={k} className="metric"><span className="v">{v}</span><span className="k">{k}</span></div>
+        ))}
+      </div>
+      <div className="ph-img" style={{ height: 130, marginTop: 12 }}>screenshots · 3-up</div>
+
+      <Sep />
+      <div style={{ display: 'flex', justifyContent: 'space-between', marginTop: 12 }}>
+        <button className="wf-btn ghost">← cd ../sales-saas</button>
+        <button className="wf-btn accent">$ ./contact --inquiry</button>
+        <button className="wf-btn ghost">cd ../mini-cms →</button>
+      </div>
+      <Annot x={'auto'} y={20} rot={2}>F005 · 문제→접근→결과 / F011 · OG</Annot>
+    </TermWindow>
+  );
+}
+
+// Project Detail v2 — sticky meta + TOC sidebar
+function ProjectDetailV2({ lang = 'ko' }) {
+  return (
+    <TermWindow path="~/projects/sales-saas" status="case study · sticky TOC">
+      <div style={{ display: 'grid', gridTemplateColumns: '1fr 220px', gap: 24 }}>
+        <div>
+          <Prompt>cat case.mdx</Prompt>
+          <Sep />
+          <h1 className="term-h1">매출 분석 SaaS</h1>
+          <Out>소상공인 대상 · 결제 → 인사이트 · 8주 단독 출시</Out>
+          <div className="ph-img" style={{ height: 170, marginTop: 12 }}>hero · 16:9</div>
+
+          <div className="section-bar">## P · problem <span className="line" /></div>
+          <Out>───── 3-5줄 ─────</Out>
+          <div className="section-bar">## A · approach <span className="line" /></div>
+          <Out>───── 3-5줄 ─────</Out>
+          <div className="section-bar">## R · results <span className="line" /></div>
+          <Out>───── 수치 + 스크린샷 ─────</Out>
+        </div>
+        <aside style={{ position: 'sticky', top: 0, alignSelf: 'flex-start' }}>
+          <div className="wf-card" style={{ padding: 12 }}>
+            <span className="pill">meta</span>
+            <div className="muted" style={{ fontSize: 11, lineHeight: 2, marginTop: 6, fontFamily: 'var(--mono)' }}>
+              year ─ 2025<br/>role ─ solo<br/>stack ─ ts · d1<br/>links ─ live · gh
+            </div>
+          </div>
+          <div className="wf-card" style={{ padding: 12, marginTop: 8 }}>
+            <span className="pill">toc</span>
+            <div className="muted" style={{ fontSize: 11, lineHeight: 1.95, marginTop: 6 }}>
+              · problem<br/>· <span className="green">approach</span><br/>· results<br/>· reflection
+            </div>
+          </div>
+          <button className="wf-btn accent" style={{ marginTop: 8 }}>./contact --inquiry</button>
+        </aside>
+      </div>
+      <Annot x={'auto'} y={50} rot={-2}>sticky meta · TOC scroll-spy</Annot>
+    </TermWindow>
+  );
+}
+
+// Project Detail v3 — editorial / large type / man page
+function ProjectDetailV3({ lang = 'ko' }) {
+  return (
+    <TermWindow path="~/projects/mini-cms" status="man mini-cms">
+      <Prompt>man mini-cms</Prompt>
+      <Sep />
+      <span className="pill" style={{ borderColor: 'var(--accent-2)', color: 'var(--accent-2)' }}>OSS · 003</span>
+      <h1 className="term-h1" style={{ fontSize: 48, lineHeight: 1.05, margin: '8px 0' }}>
+        Mini CMS,<br/><span className="muted">in 200 lines.</span>
+      </h1>
+      <Out>velite + MDX 만으로 헤드리스 CMS를 만들 수 있을까?</Out>
+      <Sep />
+      <div style={{ display: 'grid', gridTemplateColumns: '120px 1fr', gap: 16, fontSize: 12, marginTop: 8 }}>
+        <span className="pill">NAME</span><Out>mini-cms — minimal headless content collection</Out>
+        <span className="pill">SYNOPSIS</span><Out>velite + zod + mdx. no db. build-time index.</Out>
+        <span className="pill">PROBLEM</span><Out>───── 3-5줄 ─────</Out>
+        <span className="pill">APPROACH</span><Out>───── 3-5줄 + code ─────</Out>
+        <span className="pill">RESULTS</span><Out>★200 · 12 contrib · 4 prod use</Out>
+      </div>
+      <Annot x={'auto'} y={20} rot={2}>man page 메타포 · 두꺼운 타입</Annot>
+    </TermWindow>
+  );
+}
+
+Object.assign(window, { ProjectDetailV1, ProjectDetailV2, ProjectDetailV3 });

--- a/docs/design-system/components/projects.jsx
+++ b/docs/design-system/components/projects.jsx
@@ -1,0 +1,115 @@
+/* global React, TermWindow, Prompt, Out, Caret, Sep, Hint, KBD, TermList, Annot */
+
+// Projects v1 — `ls -la projects/` 리스트
+function ProjectsV1({ lang = 'ko' }) {
+  const items = [
+    ['drwxr-x','2026-03','whiteboard-rt','실시간 협업 화이트보드','ts · do · wss','3.2k'],
+    ['drwxr-x','2025-11','sales-saas','매출 분석 SaaS','react · d1 · stripe','8wk'],
+    ['drwxr-x','2025-06','mini-cms','velite + MDX 헤드리스 CMS','mdx · velite','★200'],
+    ['drwxr-x','2024-09','ds-migration','styled → tailwind 4 마이그레이션','tw 4 · rtk',''],
+    ['-rw-r--','2024-02','react-edge-rsc','Workers RSC streaming PoC','rsc · workers','oss'],
+  ];
+  return (
+    <TermWindow path="~/projects" status={`ls -la · ${items.length} entries`}>
+      <Prompt>ls -la projects/</Prompt>
+      <Out>total {items.length} · velite collection · sorted by published_at desc</Out>
+      <Sep />
+      <div style={{ display: 'grid', gridTemplateColumns: '70px 80px 160px 1fr 200px 60px', fontSize: 11, color: 'var(--ink-faint)', padding: '4px 0', letterSpacing: '0.08em', borderBottom: '1.5px solid var(--line-strong)' }}>
+        <span>perm</span><span>date</span><span>slug</span><span>title · summary</span><span>stack</span><span>meta</span>
+      </div>
+      {items.map((r,i)=>(
+        <div key={i} style={{ display: 'grid', gridTemplateColumns: '70px 80px 160px 1fr 200px 60px', gap: 4, padding: '10px 0', borderBottom: '1.5px dashed var(--line)', fontSize: 12, alignItems: 'center' }}>
+          <span className="faint">{r[0]}</span>
+          <span className="faint">{r[1]}</span>
+          <span className="amber">{r[2]}/</span>
+          <div>
+            <span className="strong">{r[3]}</span>
+          </div>
+          <span className="faint" style={{ fontSize: 11 }}>{r[4]}</span>
+          <span className="faint" style={{ fontSize: 11 }}>{r[5]}</span>
+        </div>
+      ))}
+      <Hint>$ cd whiteboard-rt — 케이스 스터디로 진입</Hint>
+      <Annot x={'auto'} y={20} rot={2}>F004 · ls 메타포 / MDX collection</Annot>
+    </TermWindow>
+  );
+}
+
+// Projects v2 — featured + grep filter
+function ProjectsV2({ lang = 'ko' }) {
+  return (
+    <TermWindow path="~/projects" status="grep --tag · featured pinned">
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 8 }}>
+        <Prompt>grep --tag</Prompt>
+        <span className="input-line" style={{ flex: 1, padding: '2px 0' }}>
+          <span className="val ph">all · saas · oss · client · solo</span>
+        </span>
+      </div>
+      <Sep />
+      <span className="pill on" style={{ marginTop: 8 }}>★ featured</span>
+      <div className="wf-card" style={{ marginTop: 6, padding: 16, borderColor: 'var(--accent)', display: 'grid', gridTemplateColumns: '1.2fr 1fr', gap: 18 }}>
+        <div>
+          <h2 className="term-h2">whiteboard-rt</h2>
+          <Out>실시간 협업 화이트보드 · WebSocket → Durable Objects 마이그레이션</Out>
+          <Out className="green">p99 -80% · idle cost -90% · MAU +3.2k</Out>
+          <div style={{ display: 'flex', gap: 4, margin: '10px 0' }}>
+            {['ts','do','wss','vitest'].map(t=><span key={t} className="pill">{t}</span>)}
+          </div>
+          <button className="wf-btn accent">$ cd whiteboard-rt</button>
+        </div>
+        <div className="ph-img" style={{ height: 160 }}>cover · 16:9</div>
+      </div>
+
+      <div className="section-bar">// other projects <span className="line" /></div>
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(2, 1fr)', gap: 10 }}>
+        {['sales-saas','mini-cms','ds-migration','react-edge-rsc'].map(s => (
+          <div key={s} className="wf-card" style={{ display: 'grid', gridTemplateColumns: '60px 1fr', gap: 10, padding: 10 }}>
+            <div className="ph-img" style={{ height: 56 }}>thumb</div>
+            <div>
+              <span className="amber" style={{ fontSize: 12 }}>{s}/</span>
+              <Out>한 줄 요약 ─────</Out>
+              <div style={{ display: 'flex', gap: 4 }}>{['ts','react'].map(t=><span key={t} className="pill">{t}</span>)}</div>
+            </div>
+          </div>
+        ))}
+      </div>
+      <Annot x={'auto'} y={50} rot={-2}>대표작 1 + 2-up · 태그 grep</Annot>
+    </TermWindow>
+  );
+}
+
+// Projects v3 — tree view (filesystem index)
+function ProjectsV3({ lang = 'ko' }) {
+  return (
+    <TermWindow path="~/projects" status="tree -L 2 · 5 dirs">
+      <Prompt>tree -L 2 projects/</Prompt>
+      <Sep />
+      <div className="tree" style={{ marginTop: 8 }}>
+        <div className="row on">projects/</div>
+        {[
+          ['├──','whiteboard-rt/','ts · do · wss','2026-03'],
+          ['│   ├──','case.mdx','',''],
+          ['│   └──','assets/','',''],
+          ['├──','sales-saas/','react · d1','2025-11'],
+          ['├──','mini-cms/','mdx · velite','2025-06'],
+          ['├──','ds-migration/','tw 4','2024-09'],
+          ['└──','react-edge-rsc/','rsc · workers','2024-02'],
+        ].map((r,i)=>(
+          <div key={i} className="row" style={{ display: 'grid', gridTemplateColumns: '60px 1fr 160px 80px', alignItems: 'baseline' }}>
+            <span className="tk">{r[0]}</span>
+            <span className={r[1].endsWith('/') && !r[1].includes('.') ? 'amber' : 'faint'}>{r[1]}</span>
+            <span className="faint" style={{ fontSize: 11 }}>{r[2]}</span>
+            <span className="faint" style={{ fontSize: 11 }}>{r[3]}</span>
+          </div>
+        ))}
+      </div>
+      <div style={{ marginTop: 18 }}>
+        <Out>5 directories, 1 file</Out>
+        <Prompt dim>cd <span className="amber">whiteboard-rt</span> && cat case.mdx<Caret /></Prompt>
+      </div>
+      <Annot x={'auto'} y={40} rot={3}>tree · 파일시스템 메타포</Annot>
+    </TermWindow>
+  );
+}
+
+Object.assign(window, { ProjectsV1, ProjectsV2, ProjectsV3 });

--- a/docs/design-system/components/shared.jsx
+++ b/docs/design-system/components/shared.jsx
@@ -1,0 +1,148 @@
+/* global React */
+// Shared wireframe primitives + chrome shells
+
+// Top bar with terminal prompt feel
+function TopBar({ active = 'home', lang = 'ko' }) {
+  const items = lang === 'ko'
+    ? [['home','Home'],['about','About'],['projects','Projects'],['blog','Blog'],['contact','Contact']]
+    : [['home','Home'],['about','About'],['projects','Projects'],['blog','Blog'],['contact','Contact']];
+  return (
+    <div className="between" style={{ padding: '12px 22px', borderBottom: '1.5px dashed var(--line)', background: 'var(--bg-elev)' }}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
+        <span className="green prompt" style={{ fontWeight: 700 }}>tkstar.dev</span>
+        <span className="faint" style={{ fontSize: 10 }}>v0.1 ─ wireframe</span>
+      </div>
+      <nav style={{ display: 'flex', gap: 18, fontSize: 12 }}>
+        {items.map(([k, l]) => (
+          <span key={k} className={active === k ? 'green' : 'muted'} style={{ borderBottom: active === k ? '1.5px solid var(--accent)' : 'none', paddingBottom: 2 }}>
+            {l}
+          </span>
+        ))}
+        <span className="faint">[ ☾ ]</span>
+      </nav>
+    </div>
+  );
+}
+
+// Side bar (Brittany-inspired but our own)
+function SideBar({ active = 'home', lang = 'ko' }) {
+  const items = [
+    ['home', 'HOME', '00'],
+    ['about', 'ABOUT', '01'],
+    ['projects', 'PROJECTS', '02'],
+    ['blog', 'BLOG', '03'],
+    ['contact', 'CONTACT', '04'],
+  ];
+  return (
+    <aside>
+      <div>
+        <div className="green" style={{ fontWeight: 700, fontSize: 18 }}>tkstar.dev</div>
+        <div className="faint" style={{ fontSize: 10, marginTop: 2 }}>{'// solo dev studio'}</div>
+      </div>
+      <div className="col" style={{ gap: 8, marginTop: 6 }}>
+        {items.map(([k, l, n]) => (
+          <div key={k} style={{ display: 'flex', alignItems: 'center', gap: 10, fontSize: 12, color: active === k ? 'var(--ink)' : 'var(--ink-dim)' }}>
+            <span className="faint" style={{ fontFamily: 'var(--mono)', fontSize: 10 }}>{n}</span>
+            <span style={{ width: active === k ? 28 : 14, height: 1.5, background: active === k ? 'var(--accent)' : 'var(--line-strong)', transition: 'width .2s' }} />
+            <span className={active === k ? 'green' : ''}>{l}</span>
+          </div>
+        ))}
+      </div>
+      <div style={{ flex: 1 }} />
+      <div className="col" style={{ gap: 6 }}>
+        <span className="label">socials</span>
+        <div className="row" style={{ gap: 6 }}>
+          <span className="wf-tag">gh</span>
+          <span className="wf-tag">in</span>
+          <span className="wf-tag">x</span>
+          <span className="wf-tag">@</span>
+        </div>
+        <span className="faint" style={{ fontSize: 10, marginTop: 8 }}>● dark · auto</span>
+      </div>
+    </aside>
+  );
+}
+
+// Footer — shows on every artboard's main shell
+function Footer() {
+  return (
+    <div className="between" style={{ padding: '10px 22px', borderTop: '1.5px dashed var(--line)', fontSize: 10, color: 'var(--ink-faint)' }}>
+      <span>© 2026 tkstar.dev</span>
+      <div style={{ display: 'flex', gap: 14 }}>
+        <span>RSS</span>
+        <span>Legal</span>
+        <span className="faint">analytics ● cf-no-cookie</span>
+      </div>
+    </div>
+  );
+}
+
+// CTA button
+function CTA({ children, accent, size = 'md', dim }) {
+  const cls = ['wf-btn', accent ? 'accent' : '', dim ? 'ghost' : ''].join(' ');
+  const pad = size === 'lg' ? '14px 22px' : size === 'sm' ? '6px 10px' : '10px 16px';
+  return (
+    <button className={cls} style={{ padding: pad, fontSize: size === 'lg' ? 14 : 12 }}>
+      {children}
+    </button>
+  );
+}
+
+// Crossed-out box label
+function PlaceholderImg({ label, h = 120, w }) {
+  return (
+    <div className="wf-img" style={{ height: h, width: w || '100%' }}>{label || 'image'}</div>
+  );
+}
+
+// Annotated arrow (uses absolute pos, parent must be relative)
+function Arrow({ from, to, label, color = 'var(--accent-2)' }) {
+  // from/to: {x,y} in px relative to artboard
+  const dx = to.x - from.x, dy = to.y - from.y;
+  return (
+    <svg className="arrow" style={{ left: 0, top: 0, width: '100%', height: '100%' }}>
+      <defs>
+        <marker id="arr" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="6" markerHeight="6" orient="auto">
+          <path d="M0,0 L10,5 L0,10 z" fill={color} />
+        </marker>
+      </defs>
+      <path
+        d={`M${from.x},${from.y} Q${(from.x+to.x)/2 + 20},${(from.y+to.y)/2 - 20} ${to.x},${to.y}`}
+        stroke={color}
+        strokeWidth="1.5"
+        fill="none"
+        strokeDasharray="3 4"
+        markerEnd="url(#arr)"
+      />
+      {label && (
+        <text x={(from.x + to.x)/2 + 8} y={(from.y + to.y)/2 - 6} fill={color} fontFamily="var(--hand)" fontSize="14">
+          {label}
+        </text>
+      )}
+    </svg>
+  );
+}
+
+// Section header with terminal prefix
+function SectionH({ num, title, sub }) {
+  return (
+    <div style={{ display: 'flex', alignItems: 'baseline', gap: 10, margin: '6px 0 12px' }}>
+      <span className="faint" style={{ fontFamily: 'var(--mono)', fontSize: 11 }}>{num || '//'}</span>
+      <span style={{ fontWeight: 600, fontSize: 14 }}>{title}</span>
+      {sub && <span className="faint" style={{ fontSize: 11 }}>— {sub}</span>}
+      <span style={{ flex: 1, height: 1, background: 'var(--line)', marginLeft: 10 }} />
+    </div>
+  );
+}
+
+// Annotation line w/ caret on left
+function Note({ children, color }) {
+  return (
+    <div className="annot" style={{ color: color || 'var(--ink-dim)', display: 'flex', alignItems: 'flex-start', gap: 6 }}>
+      <span style={{ fontFamily: 'var(--mono)' }}>↳</span>
+      <span>{children}</span>
+    </div>
+  );
+}
+
+Object.assign(window, { TopBar, SideBar, Footer, CTA, PlaceholderImg, Arrow, SectionH, Note });

--- a/docs/design-system/components/terminal.jsx
+++ b/docs/design-system/components/terminal.jsx
@@ -1,0 +1,98 @@
+/* global React */
+
+// ─────────────────────────────────────────────
+// Terminal window chrome — every page lives in one
+// ─────────────────────────────────────────────
+function TermWindow({ path = '~', children, status, onTab, tabs, footer }) {
+  return (
+    <div className="term-win">
+      <div className="term-titlebar">
+        <div className="term-dots">
+          <span className="d red" /><span className="d yel" /><span className="d grn" />
+        </div>
+        <div className="term-title"><span className="faint">tkstar@dev</span> : <span className="green">{path}</span></div>
+        <div className="term-meta faint">⌘K</div>
+      </div>
+
+      {tabs && (
+        <div className="term-tabs">
+          {tabs.map((tb, i) => (
+            <span key={i} className={tb.active ? 'tab on' : 'tab'} onClick={() => onTab && onTab(tb.id)}>
+              <span className="faint">{String(i).padStart(2,'0')}</span> {tb.label}
+            </span>
+          ))}
+          <span className="tab-spacer" />
+          <span className="faint" style={{ fontSize: 10 }}>⎚ split · ☾ theme</span>
+        </div>
+      )}
+
+      <div className="term-body">{children}</div>
+
+      <div className="term-statusbar">
+        <span className="status-cell green">● ready</span>
+        <span className="status-cell faint">{status || 'idle'}</span>
+        <span className="status-cell faint" style={{ marginLeft: 'auto' }}>UTF-8 · ko-KR · LF</span>
+      </div>
+      {footer}
+    </div>
+  );
+}
+
+// ─────────────────────────────────────────────
+// Generic helpers
+// ─────────────────────────────────────────────
+function Prompt({ children, dim }) {
+  return (
+    <div className={dim ? 'tline dim' : 'tline'}>
+      <span className="green">tkstar@dev</span>
+      <span className="faint">:</span>
+      <span className="amber">~</span>
+      <span className="faint">$ </span>
+      <span className="strong">{children}</span>
+    </div>
+  );
+}
+function Out({ children, color }) {
+  return <div className="tline out" style={color ? { color } : null}>{children}</div>;
+}
+function Caret() {
+  return <span className="caret">▍</span>;
+}
+function Sep({ ch = '─', n = 60 }) {
+  return <div className="faint" style={{ letterSpacing: '0.15em', fontSize: 11 }}>{ch.repeat(n)}</div>;
+}
+function Hint({ children }) {
+  return <span className="faint" style={{ fontSize: 10 }}>{children}</span>;
+}
+function KBD({ children }) {
+  return <span className="kbd">{children}</span>;
+}
+function TermList({ items }) {
+  return (
+    <div className="termlist">
+      {items.map((it, i) => (
+        <div key={i} className="termlist-row">
+          <span className="faint">{String(i+1).padStart(2,'0')}</span>
+          {it.icon && <span className="amber">{it.icon}</span>}
+          <span className="strong">{it.title}</span>
+          {it.tags && <span className="faint" style={{ marginLeft: 'auto', display: 'flex', gap: 6 }}>
+            {it.tags.map(t => <span key={t} className="wf-tag" style={{ fontSize: 10 }}>{t}</span>)}
+          </span>}
+          {it.meta && <span className="faint" style={{ marginLeft: it.tags?12:'auto' }}>{it.meta}</span>}
+          <span className="green" style={{ marginLeft: 12 }}>→</span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+// Annotation / hand label for wireframe
+function Annot({ children, x, y, color = 'var(--accent-2)', rot = 0 }) {
+  return (
+    <span className="hand" style={{ position: 'absolute', left: x, top: y, color, transform: `rotate(${rot}deg)`, fontSize: 14, lineHeight: 1.2, pointerEvents: 'none' }}>
+      {children}
+    </span>
+  );
+}
+
+Object.assign(window, { TermWindow, Prompt, Out, Caret, Sep, Hint, KBD, TermList, Annot });

--- a/docs/design-system/design-canvas.jsx
+++ b/docs/design-system/design-canvas.jsx
@@ -1,0 +1,622 @@
+
+// DesignCanvas.jsx — Figma-ish design canvas wrapper
+// Warm gray grid bg + Sections + Artboards + PostIt notes.
+// Artboards are reorderable (grip-drag), labels/titles are inline-editable,
+// and any artboard can be opened in a fullscreen focus overlay (←/→/Esc).
+// State persists to a .design-canvas.state.json sidecar via the host
+// bridge. No assets, no deps.
+//
+// Usage:
+//   <DesignCanvas>
+//     <DCSection id="onboarding" title="Onboarding" subtitle="First-run variants">
+//       <DCArtboard id="a" label="A · Dusk" width={260} height={480}>…</DCArtboard>
+//       <DCArtboard id="b" label="B · Minimal" width={260} height={480}>…</DCArtboard>
+//     </DCSection>
+//   </DesignCanvas>
+
+const DC = {
+  bg: '#f0eee9',
+  grid: 'rgba(0,0,0,0.06)',
+  label: 'rgba(60,50,40,0.7)',
+  title: 'rgba(40,30,20,0.85)',
+  subtitle: 'rgba(60,50,40,0.6)',
+  postitBg: '#fef4a8',
+  postitText: '#5a4a2a',
+  font: '-apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif',
+};
+
+// One-time CSS injection (classes are dc-prefixed so they don't collide with
+// the hosted design's own styles).
+if (typeof document !== 'undefined' && !document.getElementById('dc-styles')) {
+  const s = document.createElement('style');
+  s.id = 'dc-styles';
+  s.textContent = [
+    '.dc-editable{cursor:text;outline:none;white-space:nowrap;border-radius:3px;padding:0 2px;margin:0 -2px}',
+    '.dc-editable:focus{background:#fff;box-shadow:0 0 0 1.5px #c96442}',
+    '[data-dc-slot]{transition:transform .18s cubic-bezier(.2,.7,.3,1)}',
+    '[data-dc-slot].dc-dragging{transition:none;z-index:10;pointer-events:none}',
+    '[data-dc-slot].dc-dragging .dc-card{box-shadow:0 12px 40px rgba(0,0,0,.25),0 0 0 2px #c96442;transform:scale(1.02)}',
+    '.dc-card{transition:box-shadow .15s,transform .15s}',
+    '.dc-card *{scrollbar-width:none}',
+    '.dc-card *::-webkit-scrollbar{display:none}',
+    '.dc-labelrow{display:flex;align-items:center;gap:4px;height:24px}',
+    '.dc-grip{cursor:grab;display:flex;align-items:center;padding:5px 4px;border-radius:4px;transition:background .12s}',
+    '.dc-grip:hover{background:rgba(0,0,0,.08)}',
+    '.dc-grip:active{cursor:grabbing}',
+    '.dc-labeltext{cursor:pointer;border-radius:4px;padding:3px 6px;display:flex;align-items:center;transition:background .12s}',
+    '.dc-labeltext:hover{background:rgba(0,0,0,.05)}',
+    '.dc-expand{position:absolute;bottom:100%;right:0;margin-bottom:5px;z-index:2;opacity:0;transition:opacity .12s,background .12s;',
+    '  width:22px;height:22px;border-radius:5px;border:none;cursor:pointer;padding:0;',
+    '  background:transparent;color:rgba(60,50,40,.7);display:flex;align-items:center;justify-content:center}',
+    '.dc-expand:hover{background:rgba(0,0,0,.06);color:#2a251f}',
+    '[data-dc-slot]:hover .dc-expand{opacity:1}',
+  ].join('\n');
+  document.head.appendChild(s);
+}
+
+const DCCtx = React.createContext(null);
+
+// ─────────────────────────────────────────────────────────────
+// DesignCanvas — stateful wrapper around the pan/zoom viewport.
+// Owns runtime state (per-section order, renamed titles/labels, focused
+// artboard). Order/titles/labels persist to a .design-canvas.state.json
+// sidecar next to the HTML. Reads go via plain fetch() so the saved
+// arrangement is visible anywhere the HTML + sidecar are served together
+// (omelette preview, direct link, downloaded zip). Writes go through the
+// host's window.omelette bridge — editing requires the omelette runtime.
+// Focus is ephemeral.
+// ─────────────────────────────────────────────────────────────
+const DC_STATE_FILE = '.design-canvas.state.json';
+
+function DesignCanvas({ children, minScale, maxScale, style }) {
+  const [state, setState] = React.useState({ sections: {}, focus: null });
+  // Hold rendering until the sidecar read settles so the saved order/titles
+  // appear on first paint (no source-order flash). didRead gates writes until
+  // the read settles so the empty initial state can't clobber a slow read;
+  // skipNextWrite suppresses the one echo-write that would otherwise follow
+  // hydration.
+  const [ready, setReady] = React.useState(false);
+  const didRead = React.useRef(false);
+  const skipNextWrite = React.useRef(false);
+
+  React.useEffect(() => {
+    let off = false;
+    fetch('./' + DC_STATE_FILE)
+      .then((r) => (r.ok ? r.json() : null))
+      .then((saved) => {
+        if (off || !saved || !saved.sections) return;
+        skipNextWrite.current = true;
+        setState((s) => ({ ...s, sections: saved.sections }));
+      })
+      .catch(() => {})
+      .finally(() => { didRead.current = true; if (!off) setReady(true); });
+    const t = setTimeout(() => { if (!off) setReady(true); }, 150);
+    return () => { off = true; clearTimeout(t); };
+  }, []);
+
+  React.useEffect(() => {
+    if (!didRead.current) return;
+    if (skipNextWrite.current) { skipNextWrite.current = false; return; }
+    const t = setTimeout(() => {
+      window.omelette?.writeFile(DC_STATE_FILE, JSON.stringify({ sections: state.sections })).catch(() => {});
+    }, 250);
+    return () => clearTimeout(t);
+  }, [state.sections]);
+
+  // Build registries synchronously from children so FocusOverlay can read
+  // them in the same render. Only direct DCSection > DCArtboard children are
+  // walked — wrapping them in other elements opts out of focus/reorder.
+  const registry = {};     // slotId -> { sectionId, artboard }
+  const sectionMeta = {};  // sectionId -> { title, subtitle, slotIds[] }
+  const sectionOrder = [];
+  React.Children.forEach(children, (sec) => {
+    if (!sec || sec.type !== DCSection) return;
+    const sid = sec.props.id ?? sec.props.title;
+    if (!sid) return;
+    sectionOrder.push(sid);
+    const persisted = state.sections[sid] || {};
+    const srcIds = [];
+    React.Children.forEach(sec.props.children, (ab) => {
+      if (!ab || ab.type !== DCArtboard) return;
+      const aid = ab.props.id ?? ab.props.label;
+      if (!aid) return;
+      registry[`${sid}/${aid}`] = { sectionId: sid, artboard: ab };
+      srcIds.push(aid);
+    });
+    const kept = (persisted.order || []).filter((k) => srcIds.includes(k));
+    sectionMeta[sid] = {
+      title: persisted.title ?? sec.props.title,
+      subtitle: sec.props.subtitle,
+      slotIds: [...kept, ...srcIds.filter((k) => !kept.includes(k))],
+    };
+  });
+
+  const api = React.useMemo(() => ({
+    state,
+    section: (id) => state.sections[id] || {},
+    patchSection: (id, p) => setState((s) => ({
+      ...s,
+      sections: { ...s.sections, [id]: { ...s.sections[id], ...(typeof p === 'function' ? p(s.sections[id] || {}) : p) } },
+    })),
+    setFocus: (slotId) => setState((s) => ({ ...s, focus: slotId })),
+  }), [state]);
+
+  // Esc exits focus; any outside pointerdown commits an in-progress rename.
+  React.useEffect(() => {
+    const onKey = (e) => { if (e.key === 'Escape') api.setFocus(null); };
+    const onPd = (e) => {
+      const ae = document.activeElement;
+      if (ae && ae.isContentEditable && !ae.contains(e.target)) ae.blur();
+    };
+    document.addEventListener('keydown', onKey);
+    document.addEventListener('pointerdown', onPd, true);
+    return () => {
+      document.removeEventListener('keydown', onKey);
+      document.removeEventListener('pointerdown', onPd, true);
+    };
+  }, [api]);
+
+  return (
+    <DCCtx.Provider value={api}>
+      <DCViewport minScale={minScale} maxScale={maxScale} style={style}>{ready && children}</DCViewport>
+      {state.focus && registry[state.focus] && (
+        <DCFocusOverlay entry={registry[state.focus]} sectionMeta={sectionMeta} sectionOrder={sectionOrder} />
+      )}
+    </DCCtx.Provider>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────
+// DCViewport — transform-based pan/zoom (internal)
+//
+// Input mapping (Figma-style):
+//   • trackpad pinch  → zoom   (ctrlKey wheel; Safari gesture* events)
+//   • trackpad scroll → pan    (two-finger)
+//   • mouse wheel     → zoom   (notched; distinguished from trackpad scroll)
+//   • middle-drag / primary-drag-on-bg → pan
+//
+// Transform state lives in a ref and is written straight to the DOM
+// (translate3d + will-change) so wheel ticks don't go through React —
+// keeps pans at 60fps on dense canvases.
+// ─────────────────────────────────────────────────────────────
+function DCViewport({ children, minScale = 0.1, maxScale = 8, style = {} }) {
+  const vpRef = React.useRef(null);
+  const worldRef = React.useRef(null);
+  const tf = React.useRef({ x: 0, y: 0, scale: 1 });
+
+  const apply = React.useCallback(() => {
+    const { x, y, scale } = tf.current;
+    const el = worldRef.current;
+    if (el) el.style.transform = `translate3d(${x}px, ${y}px, 0) scale(${scale})`;
+  }, []);
+
+  React.useEffect(() => {
+    const vp = vpRef.current;
+    if (!vp) return;
+
+    const zoomAt = (cx, cy, factor) => {
+      const r = vp.getBoundingClientRect();
+      const px = cx - r.left, py = cy - r.top;
+      const t = tf.current;
+      const next = Math.min(maxScale, Math.max(minScale, t.scale * factor));
+      const k = next / t.scale;
+      // keep the world point under the cursor fixed
+      t.x = px - (px - t.x) * k;
+      t.y = py - (py - t.y) * k;
+      t.scale = next;
+      apply();
+    };
+
+    // Mouse-wheel vs trackpad-scroll heuristic. A physical wheel sends
+    // line-mode deltas (Firefox) or large integer pixel deltas with no X
+    // component (Chrome/Safari, typically multiples of 100/120). Trackpad
+    // two-finger scroll sends small/fractional pixel deltas, often with
+    // non-zero deltaX. ctrlKey is set by the browser for trackpad pinch.
+    const isMouseWheel = (e) =>
+      e.deltaMode !== 0 ||
+      (e.deltaX === 0 && Number.isInteger(e.deltaY) && Math.abs(e.deltaY) >= 40);
+
+    const onWheel = (e) => {
+      e.preventDefault();
+      if (isGesturing) return; // Safari: gesture* owns the pinch — discard concurrent wheels
+      if (e.ctrlKey) {
+        // trackpad pinch (or explicit ctrl+wheel)
+        zoomAt(e.clientX, e.clientY, Math.exp(-e.deltaY * 0.01));
+      } else if (isMouseWheel(e)) {
+        // notched mouse wheel — fixed-ratio step per click
+        zoomAt(e.clientX, e.clientY, Math.exp(-Math.sign(e.deltaY) * 0.18));
+      } else {
+        // trackpad two-finger scroll — pan
+        tf.current.x -= e.deltaX;
+        tf.current.y -= e.deltaY;
+        apply();
+      }
+    };
+
+    // Safari sends native gesture* events for trackpad pinch with a smooth
+    // e.scale; preferring these over the ctrl+wheel fallback gives a much
+    // better feel there. No-ops on other browsers. Safari also fires
+    // ctrlKey wheel events during the same pinch — isGesturing makes
+    // onWheel drop those entirely so they neither zoom nor pan.
+    let gsBase = 1;
+    let isGesturing = false;
+    const onGestureStart = (e) => { e.preventDefault(); isGesturing = true; gsBase = tf.current.scale; };
+    const onGestureChange = (e) => {
+      e.preventDefault();
+      zoomAt(e.clientX, e.clientY, (gsBase * e.scale) / tf.current.scale);
+    };
+    const onGestureEnd = (e) => { e.preventDefault(); isGesturing = false; };
+
+    // Drag-pan: middle button anywhere, or primary button on canvas
+    // background (anything that isn't an artboard or an inline editor).
+    let drag = null;
+    const onPointerDown = (e) => {
+      const onBg = !e.target.closest('[data-dc-slot], .dc-editable');
+      if (!(e.button === 1 || (e.button === 0 && onBg))) return;
+      e.preventDefault();
+      vp.setPointerCapture(e.pointerId);
+      drag = { id: e.pointerId, lx: e.clientX, ly: e.clientY };
+      vp.style.cursor = 'grabbing';
+    };
+    const onPointerMove = (e) => {
+      if (!drag || e.pointerId !== drag.id) return;
+      tf.current.x += e.clientX - drag.lx;
+      tf.current.y += e.clientY - drag.ly;
+      drag.lx = e.clientX; drag.ly = e.clientY;
+      apply();
+    };
+    const onPointerUp = (e) => {
+      if (!drag || e.pointerId !== drag.id) return;
+      vp.releasePointerCapture(e.pointerId);
+      drag = null;
+      vp.style.cursor = '';
+    };
+
+    vp.addEventListener('wheel', onWheel, { passive: false });
+    vp.addEventListener('gesturestart', onGestureStart, { passive: false });
+    vp.addEventListener('gesturechange', onGestureChange, { passive: false });
+    vp.addEventListener('gestureend', onGestureEnd, { passive: false });
+    vp.addEventListener('pointerdown', onPointerDown);
+    vp.addEventListener('pointermove', onPointerMove);
+    vp.addEventListener('pointerup', onPointerUp);
+    vp.addEventListener('pointercancel', onPointerUp);
+    return () => {
+      vp.removeEventListener('wheel', onWheel);
+      vp.removeEventListener('gesturestart', onGestureStart);
+      vp.removeEventListener('gesturechange', onGestureChange);
+      vp.removeEventListener('gestureend', onGestureEnd);
+      vp.removeEventListener('pointerdown', onPointerDown);
+      vp.removeEventListener('pointermove', onPointerMove);
+      vp.removeEventListener('pointerup', onPointerUp);
+      vp.removeEventListener('pointercancel', onPointerUp);
+    };
+  }, [apply, minScale, maxScale]);
+
+  const gridSvg = `url("data:image/svg+xml,%3Csvg width='120' height='120' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M120 0H0v120' fill='none' stroke='${encodeURIComponent(DC.grid)}' stroke-width='1'/%3E%3C/svg%3E")`;
+  return (
+    <div
+      ref={vpRef}
+      className="design-canvas"
+      style={{
+        height: '100vh', width: '100vw',
+        background: DC.bg,
+        overflow: 'hidden',
+        overscrollBehavior: 'none',
+        touchAction: 'none',
+        position: 'relative',
+        fontFamily: DC.font,
+        boxSizing: 'border-box',
+        ...style,
+      }}
+    >
+      <div
+        ref={worldRef}
+        style={{
+          position: 'absolute', top: 0, left: 0,
+          transformOrigin: '0 0',
+          willChange: 'transform',
+          width: 'max-content', minWidth: '100%',
+          minHeight: '100%',
+          padding: '60px 0 80px',
+        }}
+      >
+        <div style={{ position: 'absolute', inset: -6000, backgroundImage: gridSvg, backgroundSize: '120px 120px', pointerEvents: 'none', zIndex: -1 }} />
+        {children}
+      </div>
+    </div>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────
+// DCSection — editable title + h-row of artboards in persisted order
+// ─────────────────────────────────────────────────────────────
+function DCSection({ id, title, subtitle, children, gap = 48 }) {
+  const ctx = React.useContext(DCCtx);
+  const sid = id ?? title;
+  const all = React.Children.toArray(children);
+  const artboards = all.filter((c) => c && c.type === DCArtboard);
+  const rest = all.filter((c) => !(c && c.type === DCArtboard));
+  const srcOrder = artboards.map((a) => a.props.id ?? a.props.label);
+  const sec = (ctx && sid && ctx.section(sid)) || {};
+
+  const order = React.useMemo(() => {
+    const kept = (sec.order || []).filter((k) => srcOrder.includes(k));
+    return [...kept, ...srcOrder.filter((k) => !kept.includes(k))];
+  }, [sec.order, srcOrder.join('|')]);
+
+  const byId = Object.fromEntries(artboards.map((a) => [a.props.id ?? a.props.label, a]));
+
+  return (
+    <div data-dc-section={sid} style={{ marginBottom: 80, position: 'relative' }}>
+      <div style={{ padding: '0 60px 56px' }}>
+        <DCEditable tag="div" value={sec.title ?? title}
+          onChange={(v) => ctx && sid && ctx.patchSection(sid, { title: v })}
+          style={{ fontSize: 28, fontWeight: 600, color: DC.title, letterSpacing: -0.4, marginBottom: 6, display: 'inline-block' }} />
+        {subtitle && <div style={{ fontSize: 16, color: DC.subtitle }}>{subtitle}</div>}
+      </div>
+      <div style={{ display: 'flex', gap, padding: '0 60px', alignItems: 'flex-start', width: 'max-content' }}>
+        {order.map((k) => (
+          <DCArtboardFrame key={k} sectionId={sid} artboard={byId[k]} order={order}
+            label={(sec.labels || {})[k] ?? byId[k].props.label}
+            onRename={(v) => ctx && ctx.patchSection(sid, (x) => ({ labels: { ...x.labels, [k]: v } }))}
+            onReorder={(next) => ctx && ctx.patchSection(sid, { order: next })}
+            onFocus={() => ctx && ctx.setFocus(`${sid}/${k}`)} />
+        ))}
+      </div>
+      {rest}
+    </div>
+  );
+}
+
+// DCArtboard — marker; rendered by DCArtboardFrame via DCSection.
+function DCArtboard() { return null; }
+
+function DCArtboardFrame({ sectionId, artboard, label, order, onRename, onReorder, onFocus }) {
+  const { id: rawId, label: rawLabel, width = 260, height = 480, children, style = {} } = artboard.props;
+  const id = rawId ?? rawLabel;
+  const ref = React.useRef(null);
+
+  // Live drag-reorder: dragged card sticks to cursor; siblings slide into
+  // their would-be slots in real time via transforms. DOM order only
+  // changes on drop.
+  const onGripDown = (e) => {
+    e.preventDefault(); e.stopPropagation();
+    const me = ref.current;
+    // translateX is applied in local (pre-scale) space but pointer deltas and
+    // getBoundingClientRect().left are screen-space — divide by the viewport's
+    // current scale so the dragged card tracks the cursor at any zoom level.
+    const scale = me.getBoundingClientRect().width / me.offsetWidth || 1;
+    const peers = Array.from(document.querySelectorAll(`[data-dc-section="${sectionId}"] [data-dc-slot]`));
+    const homes = peers.map((el) => ({ el, id: el.dataset.dcSlot, x: el.getBoundingClientRect().left }));
+    const slotXs = homes.map((h) => h.x);
+    const startIdx = order.indexOf(id);
+    const startX = e.clientX;
+    let liveOrder = order.slice();
+    me.classList.add('dc-dragging');
+
+    const layout = () => {
+      for (const h of homes) {
+        if (h.id === id) continue;
+        const slot = liveOrder.indexOf(h.id);
+        h.el.style.transform = `translateX(${(slotXs[slot] - h.x) / scale}px)`;
+      }
+    };
+
+    const move = (ev) => {
+      const dx = ev.clientX - startX;
+      me.style.transform = `translateX(${dx / scale}px)`;
+      const cur = homes[startIdx].x + dx;
+      let nearest = 0, best = Infinity;
+      for (let i = 0; i < slotXs.length; i++) {
+        const d = Math.abs(slotXs[i] - cur);
+        if (d < best) { best = d; nearest = i; }
+      }
+      if (liveOrder.indexOf(id) !== nearest) {
+        liveOrder = order.filter((k) => k !== id);
+        liveOrder.splice(nearest, 0, id);
+        layout();
+      }
+    };
+
+    const up = () => {
+      document.removeEventListener('pointermove', move);
+      document.removeEventListener('pointerup', up);
+      const finalSlot = liveOrder.indexOf(id);
+      me.classList.remove('dc-dragging');
+      me.style.transform = `translateX(${(slotXs[finalSlot] - homes[startIdx].x) / scale}px)`;
+      // After the settle transition, kill transitions + clear transforms +
+      // commit the reorder in the same frame so there's no visual snap-back.
+      setTimeout(() => {
+        for (const h of homes) { h.el.style.transition = 'none'; h.el.style.transform = ''; }
+        if (liveOrder.join('|') !== order.join('|')) onReorder(liveOrder);
+        requestAnimationFrame(() => requestAnimationFrame(() => {
+          for (const h of homes) h.el.style.transition = '';
+        }));
+      }, 180);
+    };
+    document.addEventListener('pointermove', move);
+    document.addEventListener('pointerup', up);
+  };
+
+  return (
+    <div ref={ref} data-dc-slot={id} style={{ position: 'relative', flexShrink: 0 }}>
+      <div className="dc-labelrow" style={{ position: 'absolute', bottom: '100%', left: -4, marginBottom: 4, color: DC.label }}>
+        <div className="dc-grip" onPointerDown={onGripDown} title="Drag to reorder">
+          <svg width="9" height="13" viewBox="0 0 9 13" fill="currentColor"><circle cx="2" cy="2" r="1.1"/><circle cx="7" cy="2" r="1.1"/><circle cx="2" cy="6.5" r="1.1"/><circle cx="7" cy="6.5" r="1.1"/><circle cx="2" cy="11" r="1.1"/><circle cx="7" cy="11" r="1.1"/></svg>
+        </div>
+        <div className="dc-labeltext" onClick={onFocus} title="Click to focus">
+          <DCEditable value={label} onChange={onRename} onClick={(e) => e.stopPropagation()}
+            style={{ fontSize: 15, fontWeight: 500, color: DC.label, lineHeight: 1 }} />
+        </div>
+      </div>
+      <button className="dc-expand" onClick={onFocus} onPointerDown={(e) => e.stopPropagation()} title="Focus">
+        <svg width="12" height="12" viewBox="0 0 12 12" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round"><path d="M7 1h4v4M5 11H1V7M11 1L7.5 4.5M1 11l3.5-3.5"/></svg>
+      </button>
+      <div className="dc-card"
+        style={{ borderRadius: 2, boxShadow: '0 1px 3px rgba(0,0,0,.08),0 4px 16px rgba(0,0,0,.06)', overflow: 'hidden', width, height, background: '#fff', ...style }}>
+        {children || <div style={{ height: '100%', display: 'flex', alignItems: 'center', justifyContent: 'center', color: '#bbb', fontSize: 13, fontFamily: DC.font }}>{id}</div>}
+      </div>
+    </div>
+  );
+}
+
+// Inline rename — commits on blur or Enter.
+function DCEditable({ value, onChange, style, tag = 'span', onClick }) {
+  const T = tag;
+  return (
+    <T className="dc-editable" contentEditable suppressContentEditableWarning
+      onClick={onClick}
+      onPointerDown={(e) => e.stopPropagation()}
+      onBlur={(e) => onChange && onChange(e.currentTarget.textContent)}
+      onKeyDown={(e) => { if (e.key === 'Enter') { e.preventDefault(); e.currentTarget.blur(); } }}
+      style={style}>{value}</T>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────
+// Focus mode — overlay one artboard; ←/→ within section, ↑/↓ across
+// sections, Esc or backdrop click to exit.
+// ─────────────────────────────────────────────────────────────
+function DCFocusOverlay({ entry, sectionMeta, sectionOrder }) {
+  const ctx = React.useContext(DCCtx);
+  const { sectionId, artboard } = entry;
+  const sec = ctx.section(sectionId);
+  const meta = sectionMeta[sectionId];
+  const peers = meta.slotIds;
+  const aid = artboard.props.id ?? artboard.props.label;
+  const idx = peers.indexOf(aid);
+  const secIdx = sectionOrder.indexOf(sectionId);
+
+  const go = (d) => { const n = peers[(idx + d + peers.length) % peers.length]; if (n) ctx.setFocus(`${sectionId}/${n}`); };
+  const goSection = (d) => {
+    const ns = sectionOrder[(secIdx + d + sectionOrder.length) % sectionOrder.length];
+    const first = sectionMeta[ns] && sectionMeta[ns].slotIds[0];
+    if (first) ctx.setFocus(`${ns}/${first}`);
+  };
+
+  React.useEffect(() => {
+    const k = (e) => {
+      if (e.key === 'ArrowLeft') { e.preventDefault(); go(-1); }
+      if (e.key === 'ArrowRight') { e.preventDefault(); go(1); }
+      if (e.key === 'ArrowUp') { e.preventDefault(); goSection(-1); }
+      if (e.key === 'ArrowDown') { e.preventDefault(); goSection(1); }
+    };
+    document.addEventListener('keydown', k);
+    return () => document.removeEventListener('keydown', k);
+  });
+
+  const { width = 260, height = 480, children } = artboard.props;
+  const [vp, setVp] = React.useState({ w: window.innerWidth, h: window.innerHeight });
+  React.useEffect(() => { const r = () => setVp({ w: window.innerWidth, h: window.innerHeight }); window.addEventListener('resize', r); return () => window.removeEventListener('resize', r); }, []);
+  const scale = Math.max(0.1, Math.min((vp.w - 200) / width, (vp.h - 260) / height, 2));
+
+  const [ddOpen, setDd] = React.useState(false);
+  const Arrow = ({ dir, onClick }) => (
+    <button onClick={(e) => { e.stopPropagation(); onClick(); }}
+      style={{ position: 'absolute', top: '50%', [dir]: 28, transform: 'translateY(-50%)',
+        border: 'none', background: 'rgba(255,255,255,.08)', color: 'rgba(255,255,255,.9)',
+        width: 44, height: 44, borderRadius: 22, fontSize: 18, cursor: 'pointer',
+        display: 'flex', alignItems: 'center', justifyContent: 'center', transition: 'background .15s' }}
+      onMouseEnter={(e) => (e.currentTarget.style.background = 'rgba(255,255,255,.18)')}
+      onMouseLeave={(e) => (e.currentTarget.style.background = 'rgba(255,255,255,.08)')}>
+      <svg width="18" height="18" viewBox="0 0 18 18" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
+        <path d={dir === 'left' ? 'M11 3L5 9l6 6' : 'M7 3l6 6-6 6'} /></svg>
+    </button>
+  );
+
+  // Portal to body so position:fixed is the real viewport regardless of any
+  // transform on DesignCanvas's ancestors (including the canvas zoom itself).
+  return ReactDOM.createPortal(
+    <div onClick={() => ctx.setFocus(null)}
+      onWheel={(e) => e.preventDefault()}
+      style={{ position: 'fixed', inset: 0, zIndex: 100, background: 'rgba(24,20,16,.6)', backdropFilter: 'blur(14px)',
+        fontFamily: DC.font, color: '#fff' }}>
+
+      {/* top bar: section dropdown (left) · close (right) */}
+      <div onClick={(e) => e.stopPropagation()}
+        style={{ position: 'absolute', top: 0, left: 0, right: 0, height: 72, display: 'flex', alignItems: 'flex-start', padding: '16px 20px 0', gap: 16 }}>
+        <div style={{ position: 'relative' }}>
+          <button onClick={() => setDd((o) => !o)}
+            style={{ border: 'none', background: 'transparent', color: '#fff', cursor: 'pointer', padding: '6px 8px',
+              borderRadius: 6, textAlign: 'left', fontFamily: 'inherit' }}>
+            <span style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+              <span style={{ fontSize: 18, fontWeight: 600, letterSpacing: -0.3 }}>{meta.title}</span>
+              <svg width="11" height="11" viewBox="0 0 11 11" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" style={{ opacity: .7 }}><path d="M2 4l3.5 3.5L9 4"/></svg>
+            </span>
+            {meta.subtitle && <span style={{ display: 'block', fontSize: 13, opacity: .6, fontWeight: 400, marginTop: 2 }}>{meta.subtitle}</span>}
+          </button>
+          {ddOpen && (
+            <div style={{ position: 'absolute', top: '100%', left: 0, marginTop: 4, background: '#2a251f', borderRadius: 8,
+              boxShadow: '0 8px 32px rgba(0,0,0,.4)', padding: 4, minWidth: 200, zIndex: 10 }}>
+              {sectionOrder.map((sid) => (
+                <button key={sid} onClick={() => { setDd(false); const f = sectionMeta[sid].slotIds[0]; if (f) ctx.setFocus(`${sid}/${f}`); }}
+                  style={{ display: 'block', width: '100%', textAlign: 'left', border: 'none', cursor: 'pointer',
+                    background: sid === sectionId ? 'rgba(255,255,255,.1)' : 'transparent', color: '#fff',
+                    padding: '8px 12px', borderRadius: 5, fontSize: 14, fontWeight: sid === sectionId ? 600 : 400, fontFamily: 'inherit' }}>
+                  {sectionMeta[sid].title}
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+        <div style={{ flex: 1 }} />
+        <button onClick={() => ctx.setFocus(null)}
+          onMouseEnter={(e) => (e.currentTarget.style.background = 'rgba(255,255,255,.12)')}
+          onMouseLeave={(e) => (e.currentTarget.style.background = 'transparent')}
+          style={{ border: 'none', background: 'transparent', color: 'rgba(255,255,255,.7)', width: 32, height: 32,
+            borderRadius: 16, fontSize: 20, cursor: 'pointer', lineHeight: 1, transition: 'background .12s' }}>×</button>
+      </div>
+
+      {/* card centered, label + index below — only the card itself stops
+          propagation so any backdrop click (including the margins around
+          the card) exits focus */}
+      <div
+        style={{ position: 'absolute', top: 64, bottom: 56, left: 100, right: 100, display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', gap: 16 }}>
+        <div onClick={(e) => e.stopPropagation()} style={{ width: width * scale, height: height * scale, position: 'relative' }}>
+          <div style={{ width, height, transform: `scale(${scale})`, transformOrigin: 'top left', background: '#fff', borderRadius: 2, overflow: 'hidden',
+            boxShadow: '0 20px 80px rgba(0,0,0,.4)' }}>
+            {children || <div style={{ height: '100%', display: 'flex', alignItems: 'center', justifyContent: 'center', color: '#bbb' }}>{aid}</div>}
+          </div>
+        </div>
+        <div onClick={(e) => e.stopPropagation()} style={{ fontSize: 14, fontWeight: 500, opacity: .85, textAlign: 'center' }}>
+          {(sec.labels || {})[aid] ?? artboard.props.label}
+          <span style={{ opacity: .5, marginLeft: 10, fontVariantNumeric: 'tabular-nums' }}>{idx + 1} / {peers.length}</span>
+        </div>
+      </div>
+
+      <Arrow dir="left" onClick={() => go(-1)} />
+      <Arrow dir="right" onClick={() => go(1)} />
+
+      {/* dots */}
+      <div onClick={(e) => e.stopPropagation()}
+        style={{ position: 'absolute', bottom: 20, left: '50%', transform: 'translateX(-50%)', display: 'flex', gap: 8 }}>
+        {peers.map((p, i) => (
+          <button key={p} onClick={() => ctx.setFocus(`${sectionId}/${p}`)}
+            style={{ border: 'none', padding: 0, cursor: 'pointer', width: 6, height: 6, borderRadius: 3,
+              background: i === idx ? '#fff' : 'rgba(255,255,255,.3)' }} />
+        ))}
+      </div>
+    </div>,
+    document.body,
+  );
+}
+
+// ─────────────────────────────────────────────────────────────
+// Post-it — absolute-positioned sticky note
+// ─────────────────────────────────────────────────────────────
+function DCPostIt({ children, top, left, right, bottom, rotate = -2, width = 180 }) {
+  return (
+    <div style={{
+      position: 'absolute', top, left, right, bottom, width,
+      background: DC.postitBg, padding: '14px 16px',
+      fontFamily: '"Comic Sans MS", "Marker Felt", "Segoe Print", cursive',
+      fontSize: 14, lineHeight: 1.4, color: DC.postitText,
+      boxShadow: '0 2px 8px rgba(0,0,0,0.12), 0 1px 2px rgba(0,0,0,0.08)',
+      transform: `rotate(${rotate}deg)`,
+      zIndex: 5,
+    }}>{children}</div>
+  );
+}
+
+Object.assign(window, { DesignCanvas, DCSection, DCArtboard, DCPostIt });
+

--- a/docs/design-system/proto/data.jsx
+++ b/docs/design-system/proto/data.jsx
@@ -1,0 +1,118 @@
+/* global React */
+(() => {
+const { useState, useEffect, useMemo, useRef, useCallback } = React;
+
+// ─────────────────────────────────────────────────────
+// Sample data — used by all pages
+// ─────────────────────────────────────────────────────
+const PROJECTS = [
+  {
+    slug: 'whiteboard-rt',
+    title: '실시간 협업 화이트보드',
+    summary: 'WebSocket → Durable Objects 마이그레이션, p99 -80%',
+    date: '2026-03',
+    stack: ['ts', 'do', 'wss', 'vitest'],
+    tags: ['solo', 'saas'],
+    metrics: [['p99 지연', '-80%'], ['Idle 비용', '-90%'], ['MAU', '+3.2k']],
+    problem: '기존 단일 WS 서버 구조에서 동시접속 100+ 시 p99 지연 2초 초과. 룸 단위 격리 안됨.',
+    approach: 'Durable Objects로 룸 단위 샤딩 + Hibernation API로 idle 비용 절감.',
+    code: `export class Whiteboard extends DurableObject {
+  async fetch(req) {
+    const id = this.state.id.toString()
+    return new Response('ok')
+  }
+}`,
+    featured: true,
+  },
+  {
+    slug: 'sales-saas',
+    title: '매출 분석 SaaS',
+    summary: '소상공인 대상 결제 → 인사이트, 8주 단독 출시',
+    date: '2025-11',
+    stack: ['react', 'd1', 'stripe'],
+    tags: ['solo', 'saas'],
+    metrics: [['활성 매장', '120+'], ['결제 성공률', '99.4%'], ['출시', '8wk']],
+    problem: '소상공인이 결제 대시보드를 직접 만들 수 없어 데이터를 활용 못함.',
+    approach: 'Stripe Connect + D1 단일 스키마로 매장당 분석 자동 생성.',
+    code: `const stats = await db.query(SQL.matview)`,
+  },
+  {
+    slug: 'mini-cms',
+    title: 'Mini CMS, in 200 lines',
+    summary: 'velite + MDX 만으로 헤드리스 CMS, OSS ★200',
+    date: '2025-06',
+    stack: ['mdx', 'velite', 'zod'],
+    tags: ['oss'],
+    metrics: [['GitHub ★', '200+'], ['Contrib', '12'], ['Prod 사용', '4곳']],
+    problem: 'CMS는 무겁고 marketing-MDX는 스키마가 약함. 그 사이의 도구가 없음.',
+    approach: 'Zod 스키마 + 빌드타임 인덱스. 200줄 안에서 끝.',
+    code: `defineCollection({
+  name: 'Post',
+  pattern: 'posts/**/*.mdx',
+  schema: s.object({ title: s.string() }),
+})`,
+  },
+  {
+    slug: 'ds-migration',
+    title: 'styled-components → Tailwind 4',
+    summary: 'DS 통합 + 컴포넌트 80→24개로 축소',
+    date: '2024-09',
+    stack: ['tw 4', 'rtk'],
+    tags: ['client'],
+    metrics: [['컴포넌트', '80→24'], ['빌드 시간', '-44%'], ['CSS', '-72%']],
+    problem: '4년 누적된 styled-components가 빌드 캐시를 망가뜨리고 일관성도 잃음.',
+    approach: 'Tailwind 4 + 디자인 토큰. 컴포넌트 inventory부터.',
+    code: `<button class="btn primary"></button>`,
+  },
+];
+
+const POSTS = [
+  { slug: 'cf-rsc-running', title: 'Cloudflare Workers + RSC, 한 달 운영기', date: '2026-04-20', read: '8 min', tags: ['rsc', 'cf'], lede: 'Workers의 cold start, RSC streaming, 캐싱까지 한 달 굴려본 기록.' },
+  { slug: 'velite-mdx', title: 'velite로 MDX 컬렉션 다루기', date: '2026-03-11', read: '6 min', tags: ['mdx', 'velite'], lede: 'frontmatter Zod 검증 + 빌드타임 인덱스로 단순한 CMS 만들기.' },
+  { slug: 'solo-ops', title: '1인 개발자의 운영 자동화', date: '2026-02-02', read: '5 min', tags: ['ops'], lede: '온콜 0건/주를 만든 작은 자동화 모음.' },
+  { slug: 'tw4-migrate', title: 'Tailwind 4 마이그레이션 메모', date: '2026-01-05', read: '7 min', tags: ['tw'], lede: 'styled-components에서 Tailwind 4로 옮긴 단계별 기록.' },
+  { slug: 'vitest-tdd', title: 'Vitest로 TDD 워크플로 만들기', date: '2025-12-08', read: '9 min', tags: ['tdd'], lede: '빠른 피드백 루프를 위한 Vitest 셋업과 협업 규칙.' },
+  { slug: 'resend-mail', title: 'Resend로 1인 메일 인프라 만들기', date: '2025-11-02', read: '5 min', tags: ['ops'], lede: '도메인 인증, 자동 응답, 발송 관찰까지 30분.' },
+];
+
+const APPS = [
+  { slug: 'moai', name: 'Moai' },
+];
+
+// ─────────────────────────────────────────────────────
+// Routing — minimal hash router
+// ─────────────────────────────────────────────────────
+const ROUTES = {
+  '/': { title: 'home', kind: 'home' },
+  '/about': { title: 'about', kind: 'about' },
+  '/projects': { title: 'projects', kind: 'projects' },
+  '/blog': { title: 'blog', kind: 'blog' },
+  '/contact': { title: 'contact', kind: 'contact' },
+  '/legal': { title: 'legal', kind: 'legal-index' },
+};
+
+function parseHash() {
+  const h = (window.location.hash || '#/').slice(1) || '/';
+  return h;
+}
+
+function useRoute() {
+  const [route, setRoute] = useState(parseHash());
+  useEffect(() => {
+    const f = () => { setRoute(parseHash()); window.scrollTo(0, 0); };
+    window.addEventListener('hashchange', f);
+    return () => window.removeEventListener('hashchange', f);
+  }, []);
+  const nav = useCallback((to) => {
+    if (to.startsWith('http')) { window.location.href = to; return; }
+    window.location.hash = to.startsWith('#') ? to : '#' + to;
+  }, []);
+  return [route, nav];
+}
+
+window.useRoute = useRoute;
+window.PROJECTS = PROJECTS;
+window.POSTS = POSTS;
+window.APPS = APPS;
+window.ROUTES = ROUTES;
+})();

--- a/docs/design-system/proto/legal.jsx
+++ b/docs/design-system/proto/legal.jsx
@@ -1,0 +1,204 @@
+/* global React, APPS, PromptLine */
+
+// ─────────────────────────────────────────────────────
+// LEGAL — index page (라우팅 전체 보기)
+//   sober mode 시작 전에는 일반 chrome 안에 있어도 OK
+// ─────────────────────────────────────────────────────
+function LegalIndexPage({ nav }) {
+  return (
+    <>
+      <PromptLine cmd="ls legal/apps/" />
+      <h1 className="h2">앱별 약관 / 개인정보 처리방침</h1>
+      <p className="body dim">각 앱은 자체 약관과 처리방침을 가집니다. 모바일 웹뷰 친화적 정갈한 마크업으로 제공합니다.</p>
+
+      {APPS.map(a => (
+        <div key={a.slug} className="card" style={{ padding: 14 }}>
+          <div className="between" style={{ alignItems: 'flex-start' }}>
+            <div>
+              <div className="cluster" style={{ marginBottom: 6 }}>
+                <span className="pill2 on">app</span>
+                <span className="pill2">v1.0</span>
+              </div>
+              <div className="h3">{a.name}</div>
+              <div className="dim" style={{ fontSize: 12, marginTop: 4 }}>/legal/apps/{a.slug}</div>
+            </div>
+          </div>
+          <hr className="hr" style={{ margin: '12px 0' }} />
+          <div className="stack" style={{ gap: 8 }}>
+            <a className="row-link" href={`#/legal/apps/${a.slug}/terms`} onClick={(e)=>{e.preventDefault();nav(`/legal/apps/${a.slug}/terms`);}}>
+              <span className="date">terms.mdx</span>
+              <span className="title">이용약관</span>
+              <span className="meta">→</span>
+            </a>
+            <a className="row-link" href={`#/legal/apps/${a.slug}/privacy`} onClick={(e)=>{e.preventDefault();nav(`/legal/apps/${a.slug}/privacy`);}}>
+              <span className="date">privacy.mdx</span>
+              <span className="title">개인정보 처리방침</span>
+              <span className="meta">→</span>
+            </a>
+          </div>
+        </div>
+      ))}
+      <p className="faint2" style={{ fontSize: 11 }}>
+        velite collection: <code>legal/apps/[slug]/(terms|privacy).mdx</code> · 새 앱 출시 시 파일 추가만으로 라우팅 자동 생성.
+      </p>
+    </>
+  );
+}
+
+// ─────────────────────────────────────────────────────
+// LEGAL DOC — sober, chrome-free, mobile webview ready
+// ─────────────────────────────────────────────────────
+function LegalDoc({ kind, app }) {
+  const a = APPS.find(x => x.slug === app);
+  const appName = a?.name || app;
+
+  if (kind === 'terms') {
+    return (
+      <div className="legal">
+        <header className="legal-head">
+          <h1>{appName} 서비스 이용약관</h1>
+          <div className="meta">
+            <span>버전 1.0</span>
+            <span>·</span>
+            <span>시행일 2026.04.01</span>
+            <span>·</span>
+            <span>최종 수정 2026.03.20</span>
+          </div>
+        </header>
+        <div className="legal-body">
+          <nav className="legal-toc" aria-label="목차">
+            <strong style={{ fontSize: 11, letterSpacing: '0.06em', textTransform: 'uppercase', color: 'var(--proto-faint)' }}>목차</strong>
+            <ol>
+              <li><a href="#t1">1. 목적</a></li>
+              <li><a href="#t2">2. 용어의 정의</a></li>
+              <li><a href="#t3">3. 약관의 효력 및 변경</a></li>
+              <li><a href="#t4">4. 서비스의 제공 및 변경</a></li>
+              <li><a href="#t5">5. 회원의 의무</a></li>
+              <li><a href="#t6">6. 회사의 면책</a></li>
+              <li><a href="#t7">7. 분쟁의 해결</a></li>
+            </ol>
+          </nav>
+
+          <h2 id="t1">제1조 (목적)</h2>
+          <p>본 약관은 tkstar(이하 "회사")가 제공하는 {appName}(이하 "서비스")의 이용과 관련하여 회사와 회원 간의 권리, 의무 및 책임사항, 기타 필요한 사항을 규정함을 목적으로 합니다.</p>
+
+          <h2 id="t2">제2조 (용어의 정의)</h2>
+          <ol>
+            <li>"서비스"란 회사가 {appName} 어플리케이션 또는 웹을 통해 제공하는 모든 기능을 의미합니다.</li>
+            <li>"회원"이란 본 약관에 동의하고 회사와 서비스 이용계약을 체결한 자를 의미합니다.</li>
+            <li>"콘텐츠"란 회원이 서비스를 이용하면서 생성, 게시, 전송하는 모든 데이터를 의미합니다.</li>
+          </ol>
+
+          <h2 id="t3">제3조 (약관의 효력 및 변경)</h2>
+          <p>본 약관은 서비스 화면에 게시하거나 기타의 방법으로 회원에게 공지함으로써 효력이 발생합니다. 회사는 합리적인 사유가 발생한 경우 관련 법령을 위배하지 않는 범위에서 본 약관을 변경할 수 있으며, 변경된 약관은 적용일 7일 전부터 공지합니다.</p>
+
+          <h2 id="t4">제4조 (서비스의 제공 및 변경)</h2>
+          <p>회사는 회원에게 다음과 같은 서비스를 제공합니다.</p>
+          <ul>
+            <li>{appName}의 핵심 기능 제공</li>
+            <li>관련 부가 서비스 및 콘텐츠</li>
+            <li>회사가 추후 개발하거나 다른 회사와 제휴를 통해 제공하는 일체의 서비스</li>
+          </ul>
+
+          <h2 id="t5">제5조 (회원의 의무)</h2>
+          <p>회원은 다음 행위를 하여서는 안됩니다.</p>
+          <ul>
+            <li>타인의 정보 도용</li>
+            <li>회사가 게시한 정보의 변경</li>
+            <li>회사 및 제3자의 저작권 등 지적재산권 침해</li>
+            <li>법령 또는 공공질서에 위배되는 행위</li>
+          </ul>
+
+          <h2 id="t6">제6조 (회사의 면책)</h2>
+          <p>회사는 천재지변, 전쟁, 기간통신사업자의 서비스 중지 등 불가항력적 사유로 인해 서비스를 제공할 수 없는 경우 책임이 면제됩니다.</p>
+
+          <h2 id="t7">제7조 (분쟁의 해결)</h2>
+          <p>본 약관과 관련하여 분쟁이 발생한 경우 회사 소재지를 관할하는 법원을 1심 관할법원으로 합니다.</p>
+
+          <h2>부칙</h2>
+          <p>본 약관은 2026년 4월 1일부터 시행됩니다.</p>
+
+          <hr className="hr" style={{ margin: '24px 0 12px' }} />
+          <p className="faint2" style={{ fontSize: 12 }}>
+            문의: <a href="mailto:hello@tkstar.dev" style={{color:'var(--proto-accent)'}}>hello@tkstar.dev</a>
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  // privacy
+  return (
+    <div className="legal">
+      <header className="legal-head">
+        <h1>{appName} 개인정보 처리방침</h1>
+        <div className="meta">
+          <span>버전 1.0</span>
+          <span>·</span>
+          <span>시행일 2026.04.01</span>
+          <span>·</span>
+          <span>최종 수정 2026.03.20</span>
+        </div>
+      </header>
+      <div className="legal-body">
+        <nav className="legal-toc" aria-label="목차">
+          <strong style={{ fontSize: 11, letterSpacing: '0.06em', textTransform: 'uppercase', color: 'var(--proto-faint)' }}>목차</strong>
+          <ol>
+            <li><a href="#p1">1. 수집하는 개인정보 항목</a></li>
+            <li><a href="#p2">2. 개인정보의 이용 목적</a></li>
+            <li><a href="#p3">3. 개인정보의 보유 및 이용 기간</a></li>
+            <li><a href="#p4">4. 개인정보의 제3자 제공</a></li>
+            <li><a href="#p5">5. 이용자의 권리</a></li>
+            <li><a href="#p6">6. 개인정보 보호책임자</a></li>
+          </ol>
+        </nav>
+
+        <h2 id="p1">1. 수집하는 개인정보 항목</h2>
+        <p>회사는 서비스 제공을 위해 다음의 개인정보를 수집합니다.</p>
+        <table>
+          <thead><tr><th>구분</th><th>수집 항목</th><th>수집 방법</th></tr></thead>
+          <tbody>
+            <tr><td>필수</td><td>이메일, 닉네임</td><td>회원가입 시</td></tr>
+            <tr><td>선택</td><td>프로필 이미지</td><td>설정 시</td></tr>
+            <tr><td>자동</td><td>접속 로그, 디바이스 정보</td><td>서비스 이용 시</td></tr>
+          </tbody>
+        </table>
+
+        <h2 id="p2">2. 개인정보의 이용 목적</h2>
+        <ul>
+          <li>회원 식별 및 가입 의사 확인</li>
+          <li>서비스 제공 및 운영</li>
+          <li>고객 문의 응대</li>
+          <li>서비스 개선을 위한 통계 분석 (식별 정보 제외)</li>
+        </ul>
+
+        <h2 id="p3">3. 개인정보의 보유 및 이용 기간</h2>
+        <p>원칙적으로 개인정보 수집 및 이용 목적이 달성된 후에는 해당 정보를 지체없이 파기합니다. 다만, 관련 법령에 따라 보존이 필요한 경우 다음과 같이 보관합니다.</p>
+        <ul>
+          <li>계약 또는 청약철회 등에 관한 기록: 5년 (전자상거래법)</li>
+          <li>접속 로그: 3개월 (통신비밀보호법)</li>
+        </ul>
+
+        <h2 id="p4">4. 개인정보의 제3자 제공</h2>
+        <p>회사는 이용자의 개인정보를 본 처리방침에서 명시한 범위 내에서만 처리하며, 이용자의 사전 동의 없이는 제3자에게 제공하지 않습니다.</p>
+
+        <h2 id="p5">5. 이용자의 권리</h2>
+        <p>이용자는 언제든지 자신의 개인정보를 조회, 수정, 삭제할 수 있으며, 처리에 대한 동의를 철회할 수 있습니다.</p>
+
+        <h2 id="p6">6. 개인정보 보호책임자</h2>
+        <ul>
+          <li>이름: 김태곤</li>
+          <li>이메일: <a href="mailto:hello@tkstar.dev" style={{color:'var(--proto-accent)'}}>hello@tkstar.dev</a></li>
+        </ul>
+
+        <hr className="hr" style={{ margin: '24px 0 12px' }} />
+        <p className="faint2" style={{ fontSize: 12 }}>
+          본 처리방침은 2026년 4월 1일부터 적용됩니다.
+        </p>
+      </div>
+    </div>
+  );
+}
+
+window.LegalIndexPage = LegalIndexPage;
+window.LegalDoc = LegalDoc;

--- a/docs/design-system/proto/pages-1.jsx
+++ b/docs/design-system/proto/pages-1.jsx
@@ -1,0 +1,232 @@
+/* global React, PROJECTS, POSTS, APPS, PromptLine */
+(() => {
+const { useState, useEffect, useMemo } = React;
+
+// ─────────────────────────────────────────────────────
+// HOME — whoami + featured + quick links
+// ─────────────────────────────────────────────────────
+function HomePage({ nav, onOpenPalette }) {
+  return (
+    <>
+      <PromptLine cmd="whoami" />
+      <h1 className="h1">
+        ship <span style={{ color: 'var(--proto-accent)' }}>solo</span>.<br />
+        <span className="dim">ship </span>fast<span className="dim">.</span>
+      </h1>
+      <p className="body dim" style={{ maxWidth: 540 }}>
+        1인 개발자 김태곤. 풀스택 · 제품 설계부터 운영까지 혼자서.
+        웹/앱을 처음부터 끝까지 짓고 굴립니다.
+      </p>
+      <div className="cluster" style={{ gap: 8 }}>
+        <button className="btn primary" onClick={onOpenPalette}>›  검색해서 이동</button>
+        <a className="btn" href="#/about" onClick={(e)=>{e.preventDefault();nav('/about');}}>/about</a>
+        <a className="btn ghost" href="#/projects" onClick={(e)=>{e.preventDefault();nav('/projects');}}>/projects</a>
+      </div>
+
+      <div className="section-h">featured <span className="grow" /></div>
+      <a className="card hover" href="#/projects/whiteboard-rt" onClick={(e)=>{e.preventDefault();nav('/projects/whiteboard-rt');}} style={{ display: 'block', textDecoration: 'none', color: 'inherit' }}>
+        <div className="cover" style={{ marginBottom: 12 }}>cover · 16:9</div>
+        <div className="cluster" style={{ marginBottom: 6 }}>
+          {PROJECTS[0].stack.map(s => <span key={s} className="pill2">{s}</span>)}
+        </div>
+        <div className="h2">{PROJECTS[0].title}</div>
+        <p className="body dim" style={{ margin: '6px 0 0' }}>{PROJECTS[0].summary}</p>
+      </a>
+
+      <div className="section-h">recent posts <span className="grow" /></div>
+      <div className="stack" style={{ gap: 0 }}>
+        {POSTS.slice(0,3).map(p => (
+          <a key={p.slug} className="row-link" href={`#/blog/${p.slug}`} onClick={(e)=>{e.preventDefault();nav(`/blog/${p.slug}`);}}>
+            <span className="date">{p.date}</span>
+            <span className="title">{p.title}</span>
+            <span className="meta">{p.read}</span>
+          </a>
+        ))}
+      </div>
+      <div>
+        <a className="btn ghost" href="#/blog" onClick={(e)=>{e.preventDefault();nav('/blog');}}>모두 보기 →</a>
+      </div>
+    </>
+  );
+}
+
+// ─────────────────────────────────────────────────────
+// ABOUT — cat resume.md
+// ─────────────────────────────────────────────────────
+function AboutPage({ nav }) {
+  return (
+    <>
+      <PromptLine cmd="cat resume.md" />
+      <div className="between" style={{ alignItems: 'flex-start', flexWrap: 'wrap', gap: 12 }}>
+        <div>
+          <h1 className="h2">김태곤 <span className="dim" style={{ fontWeight: 400, fontSize: 14 }}>· solo developer</span></h1>
+          <div className="dim" style={{ fontSize: 13, marginTop: 4 }}>풀스택 · 제품 설계 · 운영 / hello@tkstar.dev</div>
+        </div>
+        <button className="btn" onClick={() => window.print()}>⎙ PDF</button>
+      </div>
+
+      <div className="section-h">stack <span className="grow" /></div>
+      <div className="stack" style={{ gap: 10 }}>
+        {[
+          ['frontend', ['ts','react','tailwind','vite']],
+          ['edge / be', ['cf workers','d1','do','rsc']],
+          ['quality', ['vitest','biome','tdd','clean-arch']],
+        ].map(([k, list]) => (
+          <div key={k} className="card" style={{ padding: 12 }}>
+            <span className="pill2 on">{k}</span>
+            <div className="cluster" style={{ marginTop: 8 }}>
+              {list.map(t => <span key={t} className="pill2">{t}</span>)}
+            </div>
+          </div>
+        ))}
+      </div>
+
+      <div className="section-h">experience <span className="grow" /></div>
+      {[
+        ['2024 — now', '회사 A · 시니어 개발자', '결제 인프라 마이그레이션 · -40% 비용. DS 통합 · 컴포넌트 80→24.'],
+        ['2022 — 2024', '회사 B · 풀스택 개발자', '0→1 SaaS 출시 · 8주 단독. 운영 자동화로 on-call 0건/주.'],
+        ['2020 — 2022', '회사 C · 주니어', '신규 프론트엔드 채택 · React 18 도입.'],
+      ].map(([y,t,b],i) => (
+        <div key={i} style={{ display: 'grid', gridTemplateColumns: '110px 1fr', gap: 12, padding: '10px 0', borderBottom: '1px solid var(--proto-line)' }}>
+          <span className="faint2" style={{ fontSize: 11, fontFamily: 'var(--mono)' }}>{y}</span>
+          <div>
+            <div className="h3">{t}</div>
+            <div className="body dim" style={{ marginTop: 4 }}>{b}</div>
+          </div>
+        </div>
+      ))}
+
+      <div className="section-h">education · awards <span className="grow" /></div>
+      <div className="stack" style={{ gap: 10 }}>
+        <div className="card" style={{ padding: 12 }}>
+          <span className="pill2">edu</span>
+          <div className="body" style={{ marginTop: 6 }}>○○대학교 컴퓨터공학 · 2016—2020</div>
+        </div>
+        <div className="card" style={{ padding: 12 }}>
+          <span className="pill2">awards</span>
+          <div className="body" style={{ marginTop: 6 }}>○○ 해커톤 1위 · 2024<br/>오픈소스 컨트리뷰터 · 2023</div>
+        </div>
+      </div>
+    </>
+  );
+}
+
+// ─────────────────────────────────────────────────────
+// PROJECTS — ls -la with filter
+// ─────────────────────────────────────────────────────
+function ProjectsPage({ nav }) {
+  const [tag, setTag] = useState('all');
+  const tags = useMemo(() => {
+    const set = new Set();
+    PROJECTS.forEach(p => (p.tags || []).forEach(t => set.add(t)));
+    return ['all', ...set];
+  }, []);
+  const list = useMemo(() => tag === 'all' ? PROJECTS : PROJECTS.filter(p => p.tags?.includes(tag)), [tag]);
+  return (
+    <>
+      <PromptLine cmd="ls -la projects/" />
+      <h1 className="h2">projects <span className="dim" style={{ fontWeight: 400, fontSize: 14 }}>· {PROJECTS.length} entries</span></h1>
+      <div className="cluster">
+        {tags.map(t => (
+          <button key={t} className={'pill2 ' + (tag === t ? 'on' : '')} onClick={() => setTag(t)}>#{t}</button>
+        ))}
+      </div>
+
+      <div className="table-rows">
+        {list.map(p => (
+          <a key={p.slug} className="tr" href={`#/projects/${p.slug}`} onClick={(e)=>{e.preventDefault();nav(`/projects/${p.slug}`);}}>
+            <div className="l1">
+              <span style={{ color: 'var(--proto-accent-2)' }}>{p.slug}/</span>
+              <span className="name">{p.title}</span>
+              <span className="date">{p.date}</span>
+            </div>
+            <div className="l2">{p.summary}</div>
+            <div className="tags">
+              {p.stack.map(s => <span key={s} className="pill2">{s}</span>)}
+            </div>
+          </a>
+        ))}
+      </div>
+    </>
+  );
+}
+
+// ─────────────────────────────────────────────────────
+// PROJECT DETAIL — case study
+// ─────────────────────────────────────────────────────
+function ProjectDetailPage({ slug, nav }) {
+  const idx = PROJECTS.findIndex(p => p.slug === slug);
+  const p = PROJECTS[idx];
+  if (!p) {
+    return (
+      <>
+        <PromptLine cmd={`cd projects/${slug}`} />
+        <p className="body">cd: no such project: <span style={{color:'var(--warn)'}}>{slug}</span></p>
+        <a className="btn" href="#/projects" onClick={(e)=>{e.preventDefault();nav('/projects');}}>← /projects</a>
+      </>
+    );
+  }
+  const prev = PROJECTS[idx - 1];
+  const next = PROJECTS[idx + 1];
+  return (
+    <div className="two-col">
+      <article className="stack-lg">
+        <PromptLine cmd={`cat projects/${p.slug}/case.mdx`} />
+        <div className="cluster">
+          <span className="pill2 on">case · {p.date}</span>
+          {p.tags?.map(t => <span key={t} className="pill2">#{t}</span>)}
+        </div>
+        <h1 className="h1" style={{ fontSize: 'clamp(26px, 5vw, 36px)' }}>{p.title}</h1>
+        <p className="body dim">{p.summary}</p>
+        <div className="cover">cover · 1200×600 · satori OG</div>
+
+        <div className="section-h">01 · problem <span className="grow" /></div>
+        <p className="body">{p.problem}</p>
+
+        <div className="section-h">02 · approach <span className="grow" /></div>
+        <p className="body">{p.approach}</p>
+        <pre className="codeblock"><code>{p.code}</code></pre>
+
+        <div className="section-h">03 · results <span className="grow" /></div>
+        <div className="metrics">
+          {p.metrics.map(([k,v]) => (
+            <div key={k} className="metric2"><div className="v">{v}</div><div className="k">{k}</div></div>
+          ))}
+        </div>
+
+        <hr className="hr" style={{ marginTop: 12 }} />
+        <div className="between">
+          {prev ? <a className="btn ghost" href={`#/projects/${prev.slug}`} onClick={(e)=>{e.preventDefault();nav(`/projects/${prev.slug}`);}}>← {prev.slug}</a> : <span />}
+          <a className="btn primary" href="#/contact" onClick={(e)=>{e.preventDefault();nav('/contact');}}>의뢰하기 →</a>
+          {next ? <a className="btn ghost" href={`#/projects/${next.slug}`} onClick={(e)=>{e.preventDefault();nav(`/projects/${next.slug}`);}}>{next.slug} →</a> : <span />}
+        </div>
+      </article>
+
+      <aside className="side stack" style={{ gap: 12 }}>
+        <div className="card" style={{ padding: 12 }}>
+          <div className="faint2" style={{ fontSize: 11, letterSpacing: '0.06em', textTransform: 'uppercase', marginBottom: 6 }}>meta</div>
+          <div style={{ fontFamily: 'var(--mono)', fontSize: 12, lineHeight: 1.95 }}>
+            <div><span className="dim">year</span> <span> ─ </span>{p.date.slice(0,4)}</div>
+            <div><span className="dim">role</span> <span> ─ </span>solo</div>
+            <div><span className="dim">stack</span></div>
+            <div className="cluster" style={{ marginTop: 4 }}>
+              {p.stack.map(s => <span key={s} className="pill2">{s}</span>)}
+            </div>
+          </div>
+        </div>
+        <div className="card" style={{ padding: 12 }}>
+          <div className="faint2" style={{ fontSize: 11, letterSpacing: '0.06em', textTransform: 'uppercase', marginBottom: 6 }}>on this page</div>
+          <div className="dim" style={{ fontSize: 12, lineHeight: 2 }}>
+            <div>· problem</div><div>· approach</div><div>· results</div>
+          </div>
+        </div>
+      </aside>
+    </div>
+  );
+}
+
+window.HomePage = HomePage;
+window.AboutPage = AboutPage;
+window.ProjectsPage = ProjectsPage;
+window.ProjectDetailPage = ProjectDetailPage;
+})();

--- a/docs/design-system/proto/pages-2.jsx
+++ b/docs/design-system/proto/pages-2.jsx
@@ -1,0 +1,196 @@
+/* global React, POSTS, APPS, PromptLine */
+(() => {
+const { useState, useMemo } = React;
+
+// ─────────────────────────────────────────────────────
+// BLOG list
+// ─────────────────────────────────────────────────────
+function BlogPage({ nav }) {
+  const [tag, setTag] = useState('all');
+  const tags = useMemo(() => {
+    const s = new Set();
+    POSTS.forEach(p => (p.tags||[]).forEach(t => s.add(t)));
+    return ['all', ...s];
+  }, []);
+  const list = useMemo(() => tag === 'all' ? POSTS : POSTS.filter(p => p.tags?.includes(tag)), [tag]);
+  return (
+    <>
+      <PromptLine cmd="ls posts/ --sort=date" />
+      <div className="between" style={{ alignItems: 'flex-end', flexWrap: 'wrap' }}>
+        <h1 className="h2">writing<span className="dim">.log</span></h1>
+        <span className="pill2 on">📡 /rss.xml</span>
+      </div>
+      <div className="cluster">
+        {tags.map(t => <button key={t} className={'pill2 ' + (tag===t?'on':'')} onClick={()=>setTag(t)}>#{t}</button>)}
+      </div>
+      <div className="stack" style={{ gap: 0 }}>
+        {list.map(p => (
+          <a key={p.slug} className="row-link" href={`#/blog/${p.slug}`} onClick={(e)=>{e.preventDefault();nav(`/blog/${p.slug}`);}}>
+            <span className="date">{p.date}</span>
+            <span className="title">{p.title}<span className="dim" style={{ fontWeight: 400, fontSize: 12 }}> ─ {p.lede}</span></span>
+            <span className="meta">{p.read}</span>
+          </a>
+        ))}
+      </div>
+    </>
+  );
+}
+
+// ─────────────────────────────────────────────────────
+// BLOG DETAIL
+// ─────────────────────────────────────────────────────
+function BlogDetailPage({ slug, nav }) {
+  const idx = POSTS.findIndex(p => p.slug === slug);
+  const p = POSTS[idx];
+  if (!p) {
+    return (
+      <>
+        <PromptLine cmd={`cat blog/${slug}.mdx`} />
+        <p className="body">no such file: {slug}.mdx</p>
+        <a className="btn" href="#/blog" onClick={(e)=>{e.preventDefault();nav('/blog');}}>← /blog</a>
+      </>
+    );
+  }
+  const prev = POSTS[idx - 1];
+  const next = POSTS[idx + 1];
+  return (
+    <div className="two-col">
+      <article className="stack-lg">
+        <PromptLine cmd={`cat blog/${p.slug}.mdx`} />
+        <div className="cluster">
+          <span className="pill2">{p.date}</span>
+          <span className="pill2">{p.read}</span>
+          {p.tags?.map(t => <span key={t} className="pill2">#{t}</span>)}
+        </div>
+        <h1 className="h1" style={{ fontSize: 'clamp(26px, 5vw, 36px)' }}>{p.title}</h1>
+        <p className="body dim">{p.lede}</p>
+        <div className="cover">satori og · 1200×630</div>
+
+        <div className="section-h">1. 들어가며 <span className="grow" /></div>
+        <p className="body">한 달간의 운영 기록. 단일 region에서 출발해 KV 캐싱과 RSC streaming을 단계적으로 도입.</p>
+
+        <div className="section-h">2. 코드 <span className="grow" /></div>
+        <p className="body dim">실제 운영 핸들러는 다음과 같이 단순화된다.</p>
+        <pre className="codeblock"><code>{`async function handler(req) {
+  const rsc = await render(req)
+  return new Response(rsc, { headers: { 'content-type': 'text/x-component' } })
+}`}</code></pre>
+
+        <div className="section-h">3. 결론 <span className="grow" /></div>
+        <p className="body">cold start은 신경쓸 만큼 크지 않았고, 캐싱이 90%를 해결했다.</p>
+
+        <hr className="hr" />
+        <div className="between">
+          {prev ? <a className="btn ghost" href={`#/blog/${prev.slug}`} onClick={(e)=>{e.preventDefault();nav(`/blog/${prev.slug}`);}}>← {prev.slug}</a> : <span />}
+          <a className="btn ghost" href="#/blog" onClick={(e)=>{e.preventDefault();nav('/blog');}}>모든 글</a>
+          {next ? <a className="btn ghost" href={`#/blog/${next.slug}`} onClick={(e)=>{e.preventDefault();nav(`/blog/${next.slug}`);}}>{next.slug} →</a> : <span />}
+        </div>
+      </article>
+      <aside className="side stack" style={{ gap: 12 }}>
+        <div className="card" style={{ padding: 12 }}>
+          <div className="faint2" style={{ fontSize: 11, letterSpacing: '0.06em', textTransform: 'uppercase', marginBottom: 6 }}>on this page</div>
+          <div style={{ fontSize: 12, lineHeight: 2 }}>
+            <div><a href="#1" className="dim" style={{ textDecoration: 'none' }}>· 들어가며</a></div>
+            <div><a href="#2" className="dim" style={{ textDecoration: 'none' }}>· 코드</a></div>
+            <div><a href="#3" className="dim" style={{ textDecoration: 'none' }}>· 결론</a></div>
+          </div>
+        </div>
+        <div className="card" style={{ padding: 12 }}>
+          <div className="faint2" style={{ fontSize: 11, letterSpacing: '0.06em', textTransform: 'uppercase', marginBottom: 6 }}>share</div>
+          <div className="cluster">
+            <button className="pill2" onClick={() => navigator.clipboard?.writeText(window.location.href)}>copy link</button>
+            <a className="pill2" target="_blank" rel="noreferrer" href={`https://twitter.com/intent/tweet?text=${encodeURIComponent(p.title)}`}>x</a>
+          </div>
+        </div>
+      </aside>
+    </div>
+  );
+}
+
+// ─────────────────────────────────────────────────────
+// CONTACT
+// ─────────────────────────────────────────────────────
+function ContactPage({ nav }) {
+  const [form, setForm] = useState({ name: '', email: '', kind: 'b2c', company: '', message: '' });
+  const [state, setState] = useState('idle'); // idle · sending · success · error
+  const [errors, setErrors] = useState({});
+  const onSubmit = (e) => {
+    e.preventDefault();
+    const errs = {};
+    if (!form.name.trim()) errs.name = '이름을 입력해주세요.';
+    if (!/^\S+@\S+\.\S+$/.test(form.email)) errs.email = '유효한 이메일이 아닙니다.';
+    if (form.message.trim().length < 10) errs.message = '메시지를 10자 이상 작성해주세요.';
+    setErrors(errs);
+    if (Object.keys(errs).length) return;
+    setState('sending');
+    setTimeout(() => setState('success'), 900);
+  };
+  if (state === 'success') {
+    return (
+      <>
+        <PromptLine cmd="./contact --new" />
+        <div className="card" style={{ padding: 28, textAlign: 'center', borderColor: 'var(--proto-accent)' }}>
+          <div style={{ fontSize: 40, color: 'var(--proto-accent)' }}>✓</div>
+          <h1 className="h2" style={{ marginTop: 8 }}>메시지 전송됨</h1>
+          <p className="body dim" style={{ marginTop: 6 }}>자동응답 메일이 <strong>{form.email}</strong> 으로 발송되었습니다.<br/>평균 회신 24시간.</p>
+          <div className="cluster" style={{ justifyContent: 'center', marginTop: 14 }}>
+            <button className="btn" onClick={() => { setState('idle'); setForm({ name: '', email: '', kind: 'b2c', company: '', message: '' }); }}>새 메시지</button>
+            <a className="btn ghost" href="#/" onClick={(e)=>{e.preventDefault();nav('/');}}>홈으로</a>
+          </div>
+        </div>
+      </>
+    );
+  }
+  return (
+    <>
+      <PromptLine cmd="./contact --new" />
+      <h1 className="h2">메시지를 보내주세요</h1>
+      <p className="body dim">평균 회신 24시간 이내. 또는 <a style={{color:'var(--proto-accent)'}} href="mailto:hello@tkstar.dev">hello@tkstar.dev</a></p>
+
+      <form onSubmit={onSubmit} className="stack" style={{ gap: 14 }} noValidate>
+        <div className="field">
+          <label>이름 *</label>
+          <input className="input" value={form.name} onChange={e => setForm(f => ({...f, name: e.target.value}))} placeholder="홍길동" />
+          {errors.name && <span className="err">{errors.name}</span>}
+        </div>
+        <div className="field">
+          <label>이메일 *</label>
+          <input className="input" type="email" value={form.email} onChange={e => setForm(f => ({...f, email: e.target.value}))} placeholder="you@company.com" />
+          {errors.email && <span className="err">{errors.email}</span>}
+        </div>
+        <div className="field">
+          <label>회사 (선택)</label>
+          <input className="input" value={form.company} onChange={e => setForm(f => ({...f, company: e.target.value}))} placeholder="회사명" />
+        </div>
+        <div className="field">
+          <label>의뢰 유형 *</label>
+          <div className="cluster">
+            {[['b2b','B2B 채용·제안'],['b2c','B2C 의뢰'],['etc','기타']].map(([v,l]) => (
+              <button type="button" key={v} className={'pill2 ' + (form.kind===v?'on':'')} onClick={()=>setForm(f=>({...f, kind: v}))}>{l}</button>
+            ))}
+          </div>
+        </div>
+        <div className="field">
+          <label>메시지 *</label>
+          <textarea className="input" rows={6} value={form.message} onChange={e => setForm(f => ({...f, message: e.target.value}))} placeholder="프로젝트 개요, 일정, 예산 범위 등" />
+          {errors.message && <span className="err">{errors.message}</span>}
+          <span className="help">{form.message.length}자 · 최소 10자</span>
+        </div>
+        <div className="card" style={{ padding: 12, fontSize: 11, color: 'var(--proto-faint)' }}>
+          ☐ Cloudflare Turnstile 자리 (실제 출시 시 로드)
+        </div>
+        <div className="cluster" style={{ alignItems: 'center' }}>
+          <button className="btn primary" type="submit" disabled={state==='sending'}>
+            {state==='sending' ? '전송 중...' : '↵ 메시지 보내기'}
+          </button>
+          <span className="faint2" style={{ fontSize: 11 }}>Resend → hello@tkstar.dev</span>
+        </div>
+      </form>
+    </>
+  );
+}
+
+window.BlogPage = BlogPage;
+window.BlogDetailPage = BlogDetailPage;
+window.ContactPage = ContactPage;
+})();

--- a/docs/design-system/proto/shell.jsx
+++ b/docs/design-system/proto/shell.jsx
@@ -1,0 +1,195 @@
+/* global React, PROJECTS, POSTS */
+(() => {
+const { useState, useEffect, useMemo, useRef, useCallback } = React;
+
+// ─────────────────────────────────────────────────────
+// Build searchable index
+// ─────────────────────────────────────────────────────
+function buildIndex() {
+  const items = [
+    { kind: 'route', path: '/', label: '/', desc: 'home · whoami', keywords: 'home start' },
+    { kind: 'route', path: '/about', label: '/about', desc: '이력서 · resume', keywords: 'about resume hire 채용 이력서' },
+    { kind: 'route', path: '/projects', label: '/projects', desc: '포트폴리오 · 케이스 스터디', keywords: 'projects portfolio case study work' },
+    { kind: 'route', path: '/blog', label: '/blog', desc: '월 1편 기록', keywords: 'blog writing posts' },
+    { kind: 'route', path: '/contact', label: '/contact', desc: '의뢰 · 제안', keywords: 'contact inquiry email mail 메일 문의' },
+  ];
+  PROJECTS.forEach(p => items.push({
+    kind: 'project',
+    path: `/projects/${p.slug}`,
+    label: p.title,
+    desc: p.summary,
+    keywords: [p.title, p.summary, p.slug, ...(p.stack||[]), ...(p.tags||[])].join(' '),
+    badge: 'project',
+  }));
+  POSTS.forEach(p => items.push({
+    kind: 'post',
+    path: `/blog/${p.slug}`,
+    label: p.title,
+    desc: `${p.date} · ${p.read}`,
+    keywords: [p.title, p.lede, p.slug, ...(p.tags||[])].join(' '),
+    badge: 'post',
+  }));
+  return items;
+}
+
+function filterIndex(idx, q) {
+  const tokens = q.trim().toLowerCase().split(/\s+/).filter(Boolean);
+  if (!tokens.length) return idx;
+  return idx.filter(it => {
+    const hay = (it.label + ' ' + it.desc + ' ' + it.keywords).toLowerCase();
+    return tokens.every(t => hay.includes(t));
+  });
+}
+
+// ─────────────────────────────────────────────────────
+// Command Palette
+// ─────────────────────────────────────────────────────
+function Palette({ open, onClose, onPick }) {
+  const idx = useMemo(buildIndex, []);
+  const [q, setQ] = useState('');
+  const [sel, setSel] = useState(0);
+  const inputRef = useRef(null);
+
+  const filtered = useMemo(() => filterIndex(idx, q), [idx, q]);
+
+  useEffect(() => {
+    if (open) {
+      setQ(''); setSel(0);
+      setTimeout(() => inputRef.current?.focus(), 30);
+    }
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e) => {
+      if (e.key === 'Escape') { onClose(); return; }
+      if (e.key === 'ArrowDown') { e.preventDefault(); setSel(s => Math.min(filtered.length - 1, s + 1)); }
+      else if (e.key === 'ArrowUp') { e.preventDefault(); setSel(s => Math.max(0, s - 1)); }
+      else if (e.key === 'Enter') {
+        e.preventDefault();
+        const it = filtered[sel];
+        if (it) onPick(it.path);
+      }
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [open, filtered, sel, onClose, onPick]);
+
+  // group results
+  const groups = useMemo(() => {
+    const g = { route: [], project: [], post: [] };
+    filtered.forEach((it, i) => g[it.kind].push({ ...it, _i: i }));
+    return g;
+  }, [filtered]);
+
+  if (!open) return null;
+  return (
+    <div className="palette-backdrop" onClick={onClose}>
+      <div className="palette" onClick={e => e.stopPropagation()} role="dialog" aria-label="Command palette">
+        <div className="head">
+          <span className="gt">›</span>
+          <input
+            ref={inputRef}
+            value={q}
+            onChange={(e) => { setQ(e.target.value); setSel(0); }}
+            placeholder="go to ─ /about, /projects/whiteboard, vitest..."
+            aria-label="search"
+          />
+          <span className="esc">esc</span>
+        </div>
+        <div className="results">
+          {filtered.length === 0 && (
+            <div className="item" style={{ color: 'var(--proto-faint)', cursor: 'default' }}>
+              <span className="arrow"> </span>
+              <span>일치하는 결과 없음</span>
+            </div>
+          )}
+          {['route','project','post'].map(k => groups[k].length > 0 && (
+            <div key={k}>
+              <div className="group-h">{k === 'route' ? 'pages' : k === 'project' ? 'projects' : 'posts'}</div>
+              {groups[k].map(it => (
+                <div
+                  key={it.path}
+                  className={'item' + (it._i === sel ? ' on' : '')}
+                  onMouseEnter={() => setSel(it._i)}
+                  onClick={() => onPick(it.path)}
+                >
+                  <span className="arrow">{it._i === sel ? '▸' : ' '}</span>
+                  <span className="path">{it.label}</span>
+                  <span className="desc">{it.desc}</span>
+                  {it.badge && <span className="badge">{it.badge}</span>}
+                </div>
+              ))}
+            </div>
+          ))}
+        </div>
+        <div className="foot">
+          <span><kbd>↑↓</kbd>이동</span>
+          <span><kbd>↵</kbd>진입</span>
+          <span><kbd>esc</kbd>닫기</span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ─────────────────────────────────────────────────────
+// Topbar
+// ─────────────────────────────────────────────────────
+function Topbar({ route, onNav, onOpenPalette, theme, onToggleTheme }) {
+  const isMac = typeof navigator !== 'undefined' && /Mac/i.test(navigator.platform);
+  return (
+    <header className="topbar" role="banner">
+      <a className="brand" href="#/" onClick={(e) => { e.preventDefault(); onNav('/'); }}>
+        tkstar<span className="accent">.dev</span>
+      </a>
+      <span className="path">~{route === '/' ? '' : route}</span>
+      <div className="search-wrap">
+        <button className="search-trigger" onClick={onOpenPalette} aria-label="검색 열기">
+          <span aria-hidden>›</span>
+          <span className="ph">go to ─ /about, post...</span>
+          <kbd>{isMac ? '⌘K' : 'Ctrl K'}</kbd>
+        </button>
+      </div>
+      <button className="theme-btn" onClick={onToggleTheme} aria-label="테마 토글" title="테마 토글">
+        {theme === 'dark' ? '☾' : '☀'}
+      </button>
+    </header>
+  );
+}
+
+// ─────────────────────────────────────────────────────
+// Footer
+// ─────────────────────────────────────────────────────
+function FootBar() {
+  return (
+    <footer className="foot">
+      <span>© 2026 tkstar.dev · solo</span>
+      <span style={{ display: 'flex', gap: 14 }}>
+        <a href="https://github.com" target="_blank" rel="noreferrer">github</a>
+        <a href="https://x.com" target="_blank" rel="noreferrer">x</a>
+        <a href="#/blog">/rss.xml</a>
+        <a href="#/contact">contact</a>
+      </span>
+    </footer>
+  );
+}
+
+// Prompt (small command line breadcrumb)
+function PromptLine({ cmd }) {
+  return (
+    <div className="prompt">
+      <span className="user">tkstar@dev</span>
+      <span className="sep">:</span>
+      <span className="path">~</span>
+      <span className="dollar">$</span>
+      <span className="cmd">{cmd}</span>
+    </div>
+  );
+}
+
+window.Topbar = Topbar;
+window.FootBar = FootBar;
+window.Palette = Palette;
+window.PromptLine = PromptLine;
+})();

--- a/docs/design-system/prototype.css
+++ b/docs/design-system/prototype.css
@@ -1,0 +1,631 @@
+/* tkstar.dev — interactive prototype styles
+   Mobile-first, responsive, hi-fi terminal aesthetic.
+   Loaded after styles.css to inherit color tokens. */
+
+/* ── reset prototype-specific tokens ── */
+:root {
+  --proto-bg: var(--bg);
+  --proto-fg: var(--ink);
+  --proto-dim: var(--ink-dim);
+  --proto-faint: var(--ink-faint);
+  --proto-line: var(--line);
+  --proto-line-strong: var(--line-strong);
+  --proto-accent: var(--accent);
+  --proto-accent-2: var(--accent-2);
+  --proto-elev: var(--bg-elev);
+
+  --topbar-h: 52px;
+  --measure: 720px;
+  --gutter: 18px;
+}
+
+/* ── App shell — mobile-first ── */
+html, body { height: 100%; }
+body.proto {
+  margin: 0;
+  font-family: var(--mono);
+  background: var(--proto-bg);
+  color: var(--proto-fg);
+  font-size: 14px;
+  line-height: 1.6;
+  -webkit-text-size-adjust: 100%;
+  -webkit-font-smoothing: antialiased;
+}
+
+#root { min-height: 100%; }
+
+.app {
+  min-height: 100vh;
+  min-height: 100dvh;
+  display: flex;
+  flex-direction: column;
+  background: var(--proto-bg);
+}
+
+/* ── Top bar (search-led nav) ── */
+.topbar {
+  position: sticky;
+  top: 0;
+  z-index: 30;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  height: var(--topbar-h);
+  padding: 0 var(--gutter);
+  background: color-mix(in oklab, var(--proto-bg) 92%, transparent);
+  backdrop-filter: saturate(140%) blur(8px);
+  -webkit-backdrop-filter: saturate(140%) blur(8px);
+  border-bottom: 1px solid var(--proto-line);
+  font-family: var(--mono);
+}
+.topbar .brand {
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  font-size: 14px;
+  color: var(--proto-fg);
+  text-decoration: none;
+  white-space: nowrap;
+}
+.topbar .brand .accent { color: var(--proto-accent); }
+.topbar .path {
+  display: none;
+  color: var(--proto-faint);
+  font-size: 12px;
+}
+.topbar .search-wrap {
+  flex: 1;
+  display: flex;
+  justify-content: flex-end;
+}
+.topbar .search-trigger {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 10px;
+  border: 1px solid var(--proto-line-strong);
+  border-radius: 6px;
+  background: var(--proto-elev);
+  color: var(--proto-faint);
+  font-family: var(--mono);
+  font-size: 12px;
+  cursor: pointer;
+  width: 100%;
+  max-width: 280px;
+}
+.topbar .search-trigger .ph { flex: 1; text-align: left; }
+.topbar .search-trigger kbd {
+  display: none;
+  font-family: var(--mono);
+  font-size: 10px;
+  padding: 1px 5px;
+  border: 1px solid var(--proto-line-strong);
+  border-radius: 3px;
+  color: var(--proto-faint);
+}
+.topbar .theme-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px; height: 32px;
+  border: 1px solid var(--proto-line);
+  border-radius: 6px;
+  background: transparent;
+  color: var(--proto-dim);
+  cursor: pointer;
+  flex-shrink: 0;
+}
+
+@media (min-width: 720px) {
+  .topbar { padding: 0 28px; gap: 16px; }
+  .topbar .path { display: inline; }
+  .topbar .search-trigger kbd { display: inline-block; }
+  .topbar .search-trigger { max-width: 360px; }
+}
+
+/* ── Page container ── */
+main.page-main {
+  flex: 1;
+  width: 100%;
+  max-width: var(--measure);
+  margin: 0 auto;
+  padding: 22px var(--gutter) 80px;
+  display: flex;
+  flex-direction: column;
+  gap: 22px;
+}
+@media (min-width: 720px) {
+  main.page-main { padding: 36px 28px 120px; gap: 28px; }
+}
+
+/* ── Footer ── */
+.foot {
+  border-top: 1px solid var(--proto-line);
+  padding: 22px var(--gutter);
+  font-size: 11px;
+  color: var(--proto-faint);
+  display: flex;
+  flex-wrap: wrap;
+  gap: 14px;
+  justify-content: space-between;
+}
+.foot a { color: var(--proto-dim); text-decoration: none; }
+.foot a:hover { color: var(--proto-accent); }
+
+/* ── Generic typography ── */
+.h1 {
+  font-family: var(--mono);
+  font-weight: 700;
+  font-size: clamp(28px, 6vw, 44px);
+  line-height: 1.1;
+  letter-spacing: -0.02em;
+  margin: 0;
+}
+.h2 {
+  font-family: var(--mono);
+  font-weight: 600;
+  font-size: clamp(20px, 3.4vw, 24px);
+  line-height: 1.2;
+  margin: 0;
+  letter-spacing: -0.01em;
+}
+.h3 {
+  font-family: var(--mono);
+  font-weight: 600;
+  font-size: 15px;
+  margin: 0;
+}
+.body {
+  color: var(--proto-fg);
+  font-size: 14px;
+  line-height: 1.7;
+}
+.dim { color: var(--proto-dim); }
+.faint2 { color: var(--proto-faint); }
+
+/* ── Prompt line ── */
+.prompt {
+  font-family: var(--mono);
+  font-size: 12px;
+  color: var(--proto-faint);
+  display: flex;
+  align-items: baseline;
+  gap: 0;
+}
+.prompt .user { color: var(--proto-accent); }
+.prompt .sep { color: var(--proto-faint); }
+.prompt .path { color: var(--proto-accent-2); }
+.prompt .dollar { color: var(--proto-faint); margin-right: 6px; }
+.prompt .cmd { color: var(--proto-fg); }
+.prompt .caret {
+  display: inline-block;
+  width: 0.55ch;
+  background: var(--proto-accent);
+  margin-left: 3px;
+  animation: blink 1s steps(1) infinite;
+}
+@keyframes blink { 50% { opacity: 0; } }
+
+/* ── Pill / tag ── */
+.pill2 {
+  display: inline-block;
+  padding: 2px 8px;
+  border: 1px solid var(--proto-line-strong);
+  border-radius: 999px;
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--proto-dim);
+  letter-spacing: 0.02em;
+}
+.pill2.on { color: var(--proto-accent); border-color: var(--proto-accent); }
+.pill2.amber { color: var(--proto-accent-2); border-color: var(--proto-accent-2); }
+
+/* ── Sep ── */
+.hr {
+  border: none;
+  border-top: 1px solid var(--proto-line);
+  margin: 0;
+}
+
+/* ── Buttons ── */
+.btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 16px;
+  border: 1px solid var(--proto-line-strong);
+  border-radius: 6px;
+  background: transparent;
+  color: var(--proto-fg);
+  font-family: var(--mono);
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  text-decoration: none;
+  transition: all 120ms ease;
+}
+.btn:hover { border-color: var(--proto-accent); color: var(--proto-accent); }
+.btn.primary {
+  background: var(--proto-accent);
+  border-color: var(--proto-accent);
+  color: #0d0f12;
+}
+.btn.primary:hover { filter: brightness(1.08); color: #0d0f12; }
+[data-theme='light'] .btn.primary { color: #f4f1ea; }
+.btn.ghost { color: var(--proto-dim); border-color: var(--proto-line); }
+
+/* ── Card ── */
+.card {
+  background: var(--proto-elev);
+  border: 1px solid var(--proto-line);
+  border-radius: 8px;
+  padding: 16px;
+}
+.card.hover { transition: border-color 120ms; cursor: pointer; }
+.card.hover:hover { border-color: var(--proto-accent); }
+
+/* ── Code block ── */
+.codeblock {
+  background: var(--proto-elev);
+  border: 1px solid var(--proto-line);
+  border-radius: 6px;
+  padding: 14px 16px;
+  font-family: var(--mono);
+  font-size: 12.5px;
+  line-height: 1.7;
+  color: var(--proto-fg);
+  overflow-x: auto;
+}
+.codeblock .c { color: var(--proto-faint); }
+.codeblock .k { color: oklch(72% 0.14 240); }
+.codeblock .s { color: oklch(72% 0.14 65); }
+.codeblock .f { color: oklch(72% 0.14 155); }
+[data-theme='light'] .codeblock .k { color: oklch(45% 0.18 240); }
+[data-theme='light'] .codeblock .s { color: oklch(50% 0.16 65); }
+[data-theme='light'] .codeblock .f { color: oklch(45% 0.18 155); }
+
+/* ── Image placeholder ── */
+.cover {
+  width: 100%;
+  aspect-ratio: 16/9;
+  background:
+    repeating-linear-gradient(45deg, var(--hatch) 0 8px, transparent 8px 16px),
+    var(--proto-elev);
+  border: 1px solid var(--proto-line);
+  border-radius: 6px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--proto-faint);
+  font-size: 11px;
+  letter-spacing: 0.06em;
+  font-family: var(--mono);
+}
+
+/* ── Section header ── */
+.section-h {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin: 12px 0 6px;
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--proto-faint);
+}
+.section-h::before { content: '##'; color: var(--proto-accent); }
+.section-h .grow { flex: 1; height: 1px; background: var(--proto-line); }
+
+/* ── List rows ── */
+.row-link {
+  display: grid;
+  grid-template-columns: 88px 1fr auto;
+  gap: 10px;
+  padding: 14px 0;
+  border-bottom: 1px solid var(--proto-line);
+  font-family: var(--mono);
+  font-size: 13px;
+  align-items: baseline;
+  text-decoration: none;
+  color: var(--proto-fg);
+  transition: color 120ms;
+}
+.row-link:hover { color: var(--proto-accent); }
+.row-link .date { color: var(--proto-faint); font-size: 11px; }
+.row-link .title { color: var(--proto-fg); font-weight: 500; }
+.row-link .meta { color: var(--proto-faint); font-size: 11px; }
+@media (max-width: 559px) {
+  .row-link { grid-template-columns: 1fr auto; }
+  .row-link .date { grid-column: 1 / -1; font-size: 10px; }
+}
+
+/* ── Input ── */
+.input {
+  display: block;
+  width: 100%;
+  padding: 12px 14px;
+  background: var(--proto-elev);
+  border: 1px solid var(--proto-line-strong);
+  border-radius: 6px;
+  color: var(--proto-fg);
+  font-family: var(--mono);
+  font-size: 14px;
+  outline: none;
+}
+.input::placeholder { color: var(--proto-faint); }
+.input:focus { border-color: var(--proto-accent); }
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.field label {
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--proto-faint);
+  letter-spacing: 0.05em;
+}
+.field .help { font-size: 11px; color: var(--proto-faint); }
+.field .err { font-size: 11px; color: var(--warn); }
+
+/* ── Command palette ── */
+.palette-backdrop {
+  position: fixed;
+  inset: 0;
+  background: color-mix(in oklab, var(--proto-bg) 70%, black 30%);
+  backdrop-filter: blur(4px);
+  z-index: 100;
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  padding: 12vh 16px 16px;
+  animation: fade 120ms ease-out;
+}
+@keyframes fade { from { opacity: 0; } to { opacity: 1; } }
+
+.palette {
+  width: 100%;
+  max-width: 560px;
+  background: var(--proto-bg);
+  border: 1px solid var(--proto-line-strong);
+  border-radius: 10px;
+  overflow: hidden;
+  box-shadow: 0 24px 60px rgba(0,0,0,0.45);
+  display: flex;
+  flex-direction: column;
+  max-height: 70vh;
+}
+.palette .head {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 14px 16px;
+  border-bottom: 1px solid var(--proto-line);
+}
+.palette .head .gt { color: var(--proto-accent); font-family: var(--mono); }
+.palette .head input {
+  flex: 1;
+  background: transparent;
+  border: none;
+  outline: none;
+  color: var(--proto-fg);
+  font-family: var(--mono);
+  font-size: 15px;
+}
+.palette .head .esc {
+  font-family: var(--mono);
+  font-size: 10px;
+  color: var(--proto-faint);
+  border: 1px solid var(--proto-line);
+  padding: 2px 6px;
+  border-radius: 3px;
+}
+.palette .results {
+  overflow: auto;
+  padding: 4px 0;
+}
+.palette .item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 16px;
+  font-family: var(--mono);
+  font-size: 13px;
+  color: var(--proto-dim);
+  cursor: pointer;
+  border-left: 2px solid transparent;
+}
+.palette .item.on {
+  background: var(--proto-elev);
+  color: var(--proto-fg);
+  border-left-color: var(--proto-accent);
+}
+.palette .item .arrow { color: var(--proto-accent); width: 14px; text-align: center; }
+.palette .item .path { font-weight: 600; }
+.palette .item .desc { color: var(--proto-faint); flex: 1; }
+.palette .item .badge {
+  font-size: 10px;
+  padding: 1px 6px;
+  border: 1px solid var(--proto-line);
+  border-radius: 999px;
+  color: var(--proto-faint);
+}
+.palette .group-h {
+  padding: 8px 16px 4px;
+  font-family: var(--mono);
+  font-size: 10px;
+  letter-spacing: 0.12em;
+  color: var(--proto-faint);
+  text-transform: uppercase;
+}
+.palette .foot {
+  display: flex;
+  gap: 14px;
+  padding: 8px 16px;
+  border-top: 1px solid var(--proto-line);
+  font-family: var(--mono);
+  font-size: 10px;
+  color: var(--proto-faint);
+}
+.palette .foot kbd {
+  font-family: var(--mono);
+  border: 1px solid var(--proto-line);
+  padding: 1px 5px;
+  border-radius: 3px;
+  margin-right: 4px;
+}
+
+/* ── Stack helpers ── */
+.stack { display: flex; flex-direction: column; gap: 12px; }
+.stack-lg { display: flex; flex-direction: column; gap: 22px; }
+.cluster { display: flex; flex-wrap: wrap; gap: 6px; }
+.between { display: flex; align-items: center; justify-content: space-between; gap: 12px; }
+
+/* ── 2-col on desktop ── */
+.two-col { display: grid; grid-template-columns: 1fr; gap: 22px; }
+@media (min-width: 880px) {
+  .two-col { grid-template-columns: 1fr 240px; gap: 36px; }
+  .two-col .side { position: sticky; top: calc(var(--topbar-h) + 18px); align-self: flex-start; }
+}
+
+/* ── Metrics ── */
+.metrics {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: 10px;
+}
+.metric2 {
+  border: 1px solid var(--proto-line);
+  border-radius: 6px;
+  padding: 14px;
+  background: var(--proto-elev);
+}
+.metric2 .v { font-size: 24px; font-weight: 700; color: var(--proto-accent); font-family: var(--mono); }
+.metric2 .k { font-size: 10px; color: var(--proto-faint); letter-spacing: 0.1em; margin-top: 2px; text-transform: uppercase; }
+
+/* ── Legal mode (chrome stripped, sober) ── */
+.legal {
+  --measure: 680px;
+  background: var(--proto-bg);
+  color: var(--proto-fg);
+  font-size: 14px;
+  line-height: 1.75;
+}
+.legal .legal-head {
+  padding: 22px var(--gutter) 12px;
+  border-bottom: 1px solid var(--proto-line);
+  max-width: var(--measure);
+  margin: 0 auto;
+}
+.legal .legal-head h1 {
+  font-family: var(--mono);
+  font-weight: 600;
+  font-size: 20px;
+  letter-spacing: -0.01em;
+  margin: 0;
+}
+.legal .legal-head .meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-top: 8px;
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--proto-faint);
+}
+.legal .legal-body {
+  padding: 22px var(--gutter) 80px;
+  max-width: var(--measure);
+  margin: 0 auto;
+}
+.legal .legal-body h2 {
+  font-family: var(--mono);
+  font-size: 14px;
+  font-weight: 600;
+  margin: 28px 0 8px;
+  color: var(--proto-fg);
+}
+.legal .legal-body h3 {
+  font-family: var(--mono);
+  font-size: 13px;
+  font-weight: 600;
+  margin: 18px 0 6px;
+  color: var(--proto-dim);
+}
+.legal .legal-body p {
+  margin: 0 0 12px;
+  color: var(--proto-fg);
+}
+.legal .legal-body ul, .legal .legal-body ol {
+  margin: 0 0 12px;
+  padding-left: 22px;
+}
+.legal .legal-body li { margin: 4px 0; }
+.legal .legal-body table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 13px;
+  margin: 8px 0 16px;
+}
+.legal .legal-body th, .legal .legal-body td {
+  text-align: left;
+  padding: 8px 10px;
+  border-bottom: 1px solid var(--proto-line);
+  vertical-align: top;
+}
+.legal .legal-body th {
+  font-weight: 600;
+  color: var(--proto-faint);
+  font-size: 11px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+.legal .legal-toc {
+  margin: 14px 0 8px;
+  padding: 12px 14px;
+  border: 1px solid var(--proto-line);
+  border-radius: 6px;
+  background: var(--proto-elev);
+  font-size: 12.5px;
+}
+.legal .legal-toc ol {
+  margin: 6px 0 0;
+  padding-left: 22px;
+  color: var(--proto-dim);
+  line-height: 1.85;
+}
+.legal .legal-toc a { color: var(--proto-dim); text-decoration: none; }
+.legal .legal-toc a:hover { color: var(--proto-accent); }
+
+/* ── Status indicator ── */
+.dot-status {
+  display: inline-block;
+  width: 6px; height: 6px; border-radius: 999px;
+  background: var(--proto-accent);
+  margin-right: 6px;
+  vertical-align: middle;
+}
+.dot-status.warn { background: var(--proto-accent-2); }
+.dot-status.err { background: var(--warn); }
+
+/* ── Table-like rows for terminal data ── */
+.table-rows {
+  display: flex;
+  flex-direction: column;
+  font-family: var(--mono);
+  font-size: 12.5px;
+}
+.table-rows .tr {
+  display: grid;
+  gap: 8px;
+  padding: 10px 0;
+  border-bottom: 1px solid var(--proto-line);
+  text-decoration: none;
+  color: var(--proto-fg);
+}
+.table-rows .tr:hover { color: var(--proto-accent); }
+.table-rows .tr .l1 { display: flex; gap: 8px; align-items: baseline; }
+.table-rows .tr .l1 .name { font-weight: 600; }
+.table-rows .tr .l1 .date { color: var(--proto-faint); font-size: 11px; margin-left: auto; }
+.table-rows .tr .l2 { color: var(--proto-dim); font-size: 12px; }
+.table-rows .tr .tags { display: flex; flex-wrap: wrap; gap: 4px; margin-top: 2px; }

--- a/docs/design-system/prototype.html
+++ b/docs/design-system/prototype.html
@@ -1,0 +1,132 @@
+<!doctype html>
+<html lang="ko" data-theme="dark">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover" />
+<meta name="theme-color" content="#0d0f12" />
+<title>tkstar.dev — Prototype</title>
+<link rel="stylesheet" href="styles.css" />
+<link rel="stylesheet" href="prototype.css" />
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+</head>
+<body class="proto">
+<div id="root"></div>
+
+<script type="text/babel" src="proto/data.jsx"></script>
+<script type="text/babel" src="proto/shell.jsx"></script>
+<script type="text/babel" src="proto/pages-1.jsx"></script>
+<script type="text/babel" src="proto/pages-2.jsx"></script>
+<script type="text/babel" src="proto/legal.jsx"></script>
+
+<script type="text/babel" data-presets="react">
+(() => {
+const { useState, useEffect, useCallback } = React;
+
+function App() {
+  const [route, nav] = window.useRoute();
+  const [paletteOpen, setPaletteOpen] = useState(false);
+  const [theme, setTheme] = useState(() => {
+    return localStorage.getItem('proto-theme') || 'dark';
+  });
+
+  // apply theme to root
+  useEffect(() => {
+    document.documentElement.setAttribute('data-theme', theme);
+    document.documentElement.setAttribute('data-sketch', 'neat');
+    localStorage.setItem('proto-theme', theme);
+    document.querySelector('meta[name=theme-color]')?.setAttribute('content', theme === 'dark' ? '#0d0f12' : '#f4f1ea');
+  }, [theme]);
+
+  const toggleTheme = () => setTheme(t => t === 'dark' ? 'light' : 'dark');
+
+  // global ⌘K / Ctrl+K
+  useEffect(() => {
+    const onKey = (e) => {
+      if ((e.metaKey || e.ctrlKey) && (e.key === 'k' || e.key === 'K')) {
+        e.preventDefault();
+        setPaletteOpen(o => !o);
+      } else if (e.key === '/' && !paletteOpen) {
+        const tag = (e.target?.tagName || '').toUpperCase();
+        if (tag !== 'INPUT' && tag !== 'TEXTAREA') {
+          e.preventDefault();
+          setPaletteOpen(true);
+        }
+      }
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [paletteOpen]);
+
+  const onPick = (path) => {
+    setPaletteOpen(false);
+    nav(path);
+  };
+
+  // route → page
+  const renderPage = () => {
+    // legal mobile webview routes — no chrome
+    const legalMatch = route.match(/^\/legal\/apps\/([^\/]+)\/(terms|privacy)$/);
+    if (legalMatch) {
+      return { chrome: false, node: <window.LegalDoc app={legalMatch[1]} kind={legalMatch[2]} /> };
+    }
+    const pdMatch = route.match(/^\/projects\/([^\/]+)$/);
+    if (pdMatch) return { chrome: true, node: <window.ProjectDetailPage slug={pdMatch[1]} nav={nav} /> };
+    const bdMatch = route.match(/^\/blog\/([^\/]+)$/);
+    if (bdMatch) return { chrome: true, node: <window.BlogDetailPage slug={bdMatch[1]} nav={nav} /> };
+
+    if (route === '/' || route === '') return { chrome: true, node: <window.HomePage nav={nav} onOpenPalette={() => setPaletteOpen(true)} /> };
+    if (route === '/about') return { chrome: true, node: <window.AboutPage nav={nav} /> };
+    if (route === '/projects') return { chrome: true, node: <window.ProjectsPage nav={nav} /> };
+    if (route === '/blog') return { chrome: true, node: <window.BlogPage nav={nav} /> };
+    if (route === '/contact') return { chrome: true, node: <window.ContactPage nav={nav} /> };
+    if (route === '/legal') return { chrome: true, node: <window.LegalIndexPage nav={nav} /> };
+
+    return {
+      chrome: true,
+      node: (
+        <>
+          <window.PromptLine cmd={`cd ${route}`} />
+          <p className="body">cd: no such route: <span style={{color:'var(--warn)'}}>{route}</span></p>
+          <a className="btn" href="#/" onClick={(e)=>{e.preventDefault();nav('/');}}>← /home</a>
+        </>
+      ),
+    };
+  };
+
+  const { chrome, node } = renderPage();
+
+  // legal webview-style: render with NO chrome (no topbar, no footer)
+  if (!chrome) {
+    return (
+      <div className="app">
+        {node}
+        <window.Palette open={paletteOpen} onClose={() => setPaletteOpen(false)} onPick={onPick} />
+      </div>
+    );
+  }
+
+  return (
+    <div className="app">
+      <window.Topbar
+        route={route}
+        onNav={nav}
+        onOpenPalette={() => setPaletteOpen(true)}
+        theme={theme}
+        onToggleTheme={toggleTheme}
+      />
+      <main className="page-main" id="main">
+        {node}
+      </main>
+      <window.FootBar />
+      <window.Palette open={paletteOpen} onClose={() => setPaletteOpen(false)} onPick={onPick} />
+    </div>
+  );
+}
+
+ReactDOM.createRoot(document.getElementById('root')).render(<App />);
+})();
+</script>
+</body>
+</html>

--- a/docs/design-system/styles.css
+++ b/docs/design-system/styles.css
@@ -1,0 +1,311 @@
+/* ──────────────────────────────────────────────────────────
+   tkstar.dev — wireframe styles
+   Technical/Terminal vibe + sketchy hand-drawn overlay
+   ────────────────────────────────────────────────────────── */
+
+@import url('https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&family=Caveat:wght@400;600;700&family=Gaegu:wght@400;700&display=swap');
+
+:root {
+  /* dark (default per PRD) */
+  --bg: #0d0f12;
+  --bg-elev: #15181d;
+  --bg-card: #1a1e24;
+  --ink: #e8ebef;
+  --ink-dim: #8a93a0;
+  --ink-faint: #4a525e;
+  --line: #2a3038;
+  --line-strong: #3a424d;
+  --accent: oklch(72% 0.14 155);     /* terminal green */
+  --accent-2: oklch(72% 0.14 65);    /* amber for warning/highlight */
+  --warn: oklch(72% 0.14 30);
+  --hatch: rgba(232, 235, 239, 0.04);
+
+  --mono: 'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, monospace;
+  --hand: 'Gaegu', 'Caveat', cursive;
+  --hand-tight: 'Caveat', cursive;
+
+  --r: 6px;
+}
+
+[data-theme='light'] {
+  --bg: #f4f1ea;
+  --bg-elev: #ebe7dd;
+  --bg-card: #f9f7f1;
+  --ink: #1a1c20;
+  --ink-dim: #5a6068;
+  --ink-faint: #a8aab0;
+  --line: #c8c2b3;
+  --line-strong: #8a8678;
+  --accent: oklch(48% 0.14 155);
+  --accent-2: oklch(55% 0.14 65);
+  --warn: oklch(55% 0.14 30);
+  --hatch: rgba(26, 28, 32, 0.05);
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  font-family: var(--mono);
+  background: var(--bg);
+  color: var(--ink);
+  font-size: 13px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+}
+
+/* ── sketch intensity (controlled via [data-sketch] on root) ── */
+[data-sketch='neat'] .wf,
+[data-sketch='neat'] .wf-card,
+[data-sketch='neat'] .wf-btn,
+[data-sketch='neat'] .wf-input,
+[data-sketch='neat'] .wf-box {
+  border-style: solid !important;
+}
+[data-sketch='neat'] .hand,
+[data-sketch='neat'] .scribble,
+[data-sketch='neat'] .annot {
+  font-family: var(--mono) !important;
+  transform: none !important;
+}
+
+[data-sketch='sketchy'] .wf-card,
+[data-sketch='sketchy'] .wf-btn,
+[data-sketch='sketchy'] .wf-input,
+[data-sketch='sketchy'] .wf-box {
+  border-style: dashed;
+}
+
+/* ── core wireframe primitives ── */
+.wf-frame {
+  background: var(--bg);
+  color: var(--ink);
+  border: 1.5px solid var(--line-strong);
+  border-radius: var(--r);
+  position: relative;
+  overflow: hidden;
+}
+
+.wf-card {
+  background: var(--bg-card);
+  border: 1.5px dashed var(--line-strong);
+  border-radius: var(--r);
+  padding: 14px;
+}
+
+.wf-box {
+  border: 1.5px dashed var(--line-strong);
+  border-radius: var(--r);
+  background: transparent;
+}
+
+.wf-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 14px;
+  border: 1.5px dashed var(--line-strong);
+  border-radius: var(--r);
+  background: transparent;
+  color: var(--ink);
+  font-family: var(--mono);
+  font-size: 12px;
+  cursor: pointer;
+}
+.wf-btn.solid {
+  background: var(--ink);
+  color: var(--bg);
+  border-style: solid;
+}
+.wf-btn.accent {
+  background: var(--accent);
+  color: #0d0f12;
+  border-style: solid;
+  border-color: var(--accent);
+}
+.wf-btn.ghost { color: var(--ink-dim); }
+
+.wf-input {
+  display: block;
+  width: 100%;
+  padding: 9px 12px;
+  border: 1.5px dashed var(--line-strong);
+  border-radius: var(--r);
+  background: transparent;
+  color: var(--ink-dim);
+  font-family: var(--mono);
+  font-size: 12px;
+}
+
+/* placeholder image — diagonal stripes */
+.wf-img {
+  background:
+    repeating-linear-gradient(
+      45deg,
+      var(--hatch) 0 8px,
+      transparent 8px 16px
+    ),
+    var(--bg-elev);
+  border: 1.5px dashed var(--line-strong);
+  border-radius: var(--r);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--ink-faint);
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 0.05em;
+}
+
+/* hand-written overlay text */
+.hand {
+  font-family: var(--hand);
+  font-weight: 400;
+  color: var(--accent);
+  letter-spacing: 0.01em;
+}
+.hand-tight {
+  font-family: var(--hand-tight);
+  font-weight: 600;
+  color: var(--accent);
+}
+
+.annot {
+  font-family: var(--hand);
+  color: var(--ink-dim);
+  font-size: 13px;
+  letter-spacing: 0.02em;
+}
+
+.scribble {
+  font-family: var(--hand);
+  color: var(--accent-2);
+  font-size: 14px;
+}
+
+/* arrows */
+.arrow {
+  position: absolute;
+  pointer-events: none;
+}
+
+/* tag */
+.wf-tag {
+  display: inline-block;
+  padding: 2px 7px;
+  border: 1px solid var(--line-strong);
+  border-radius: 999px;
+  font-size: 10px;
+  color: var(--ink-dim);
+  font-family: var(--mono);
+  letter-spacing: 0.04em;
+}
+
+/* terminal prompt prefix */
+.prompt::before {
+  content: '$ ';
+  color: var(--accent);
+}
+.prompt-c::before {
+  content: '> ';
+  color: var(--ink-faint);
+}
+
+/* mono label */
+.label {
+  font-family: var(--mono);
+  font-size: 10px;
+  color: var(--ink-faint);
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+/* divider line — wobbly */
+.wobble {
+  height: 2px;
+  background: var(--line-strong);
+  border-radius: 2px;
+  position: relative;
+}
+
+/* phone-style frame chrome (header bar mock) */
+.chrome {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 14px;
+  border-bottom: 1.5px dashed var(--line);
+  background: var(--bg-elev);
+}
+.chrome .dot {
+  width: 8px; height: 8px; border-radius: 999px;
+  background: var(--line-strong);
+}
+
+/* visible only at small zoom — simple text */
+.muted { color: var(--ink-dim); }
+.faint { color: var(--ink-faint); }
+.strong { color: var(--ink); }
+.green { color: var(--accent); }
+.amber { color: var(--accent-2); }
+
+/* small util */
+.row { display: flex; gap: 12px; }
+.col { display: flex; flex-direction: column; gap: 12px; }
+.center { display: flex; align-items: center; justify-content: center; }
+.between { display: flex; align-items: center; justify-content: space-between; }
+
+/* artboard inner page padding */
+.page {
+  padding: 24px;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  background: var(--bg);
+  color: var(--ink);
+}
+
+/* sidebar shell */
+.shell-sidebar {
+  display: grid;
+  grid-template-columns: 240px 1fr;
+  height: 100%;
+  background: var(--bg);
+}
+.shell-sidebar > aside {
+  border-right: 1.5px dashed var(--line);
+  padding: 24px 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+.shell-sidebar > main {
+  padding: 28px 32px;
+  overflow: hidden;
+}
+
+/* topbar shell */
+.shell-top {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  background: var(--bg);
+}
+.shell-top > header {
+  border-bottom: 1.5px dashed var(--line);
+  padding: 14px 24px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+.shell-top > main {
+  padding: 28px;
+  flex: 1;
+  overflow: hidden;
+}
+
+/* SVG strokes use var(--line-strong) */
+svg .stroke { stroke: var(--line-strong); fill: none; stroke-width: 1.5; }
+svg .stroke-accent { stroke: var(--accent); fill: none; stroke-width: 1.5; }
+svg .fill-faint { fill: var(--ink-faint); }

--- a/docs/design-system/terminal.css
+++ b/docs/design-system/terminal.css
@@ -1,0 +1,225 @@
+/* tkstar.dev — terminal chrome styles (loaded after styles.css) */
+
+/* terminal window */
+.term-win {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  background: var(--bg);
+  border: 1.5px solid var(--line-strong);
+  border-radius: 8px;
+  overflow: hidden;
+  font-family: var(--mono);
+  position: relative;
+}
+
+.term-titlebar {
+  display: flex; align-items: center; gap: 12px;
+  padding: 8px 14px;
+  background: var(--bg-elev);
+  border-bottom: 1.5px dashed var(--line);
+  font-size: 11px;
+}
+.term-dots { display: flex; gap: 6px; }
+.term-dots .d { width: 11px; height: 11px; border-radius: 999px; background: var(--line-strong); border: 1px solid var(--line-strong); }
+.term-dots .d.red { background: oklch(72% 0.14 30); border-color: oklch(72% 0.14 30); }
+.term-dots .d.yel { background: oklch(80% 0.14 80); border-color: oklch(80% 0.14 80); }
+.term-dots .d.grn { background: oklch(72% 0.14 155); border-color: oklch(72% 0.14 155); }
+.term-title { color: var(--ink-dim); flex: 1; text-align: center; letter-spacing: 0.02em; }
+.term-meta { font-size: 10px; }
+
+.term-tabs {
+  display: flex; gap: 0;
+  border-bottom: 1.5px dashed var(--line);
+  background: var(--bg);
+  padding: 0 8px;
+  font-size: 11px;
+}
+.term-tabs .tab {
+  display: inline-flex; align-items: center; gap: 6px;
+  padding: 8px 12px;
+  color: var(--ink-faint);
+  border-right: 1.5px dashed var(--line);
+  cursor: pointer;
+}
+.term-tabs .tab.on {
+  color: var(--ink);
+  background: var(--bg-elev);
+  border-bottom: 2px solid var(--accent);
+  margin-bottom: -1.5px;
+}
+.term-tabs .tab-spacer { flex: 1; border-right: none; padding: 8px 12px; }
+
+.term-body {
+  flex: 1;
+  overflow: auto;
+  padding: 18px 22px;
+  position: relative;
+  font-size: 13px;
+  line-height: 1.7;
+}
+
+.term-statusbar {
+  display: flex; gap: 14px;
+  padding: 6px 14px;
+  border-top: 1.5px dashed var(--line);
+  background: var(--bg-elev);
+  font-size: 10px;
+  letter-spacing: 0.06em;
+}
+.status-cell { color: var(--ink-faint); }
+
+/* term lines */
+.tline {
+  font-family: var(--mono);
+  font-size: 13px;
+  line-height: 1.9;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+.tline.dim { opacity: 0.55; }
+.tline.out { color: var(--ink-dim); }
+
+/* blinking caret */
+.caret {
+  display: inline-block;
+  background: var(--accent);
+  color: var(--accent);
+  width: 0.55ch;
+  margin-left: 2px;
+  animation: caret-blink 1s steps(1) infinite;
+  vertical-align: baseline;
+}
+@keyframes caret-blink { 50% { opacity: 0; } }
+
+.kbd {
+  display: inline-block;
+  padding: 1px 6px;
+  border: 1.5px dashed var(--line-strong);
+  border-radius: 3px;
+  font-family: var(--mono);
+  font-size: 10px;
+  color: var(--ink-dim);
+  margin: 0 2px;
+}
+
+/* term list (ls-style rows) */
+.termlist { display: flex; flex-direction: column; }
+.termlist-row {
+  display: flex; align-items: center; gap: 10px;
+  padding: 8px 6px;
+  border-bottom: 1.5px dashed var(--line);
+  font-size: 12px;
+  font-family: var(--mono);
+}
+.termlist-row:hover { background: var(--bg-elev); }
+
+/* split pane */
+.split {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  height: 100%;
+}
+.split > div + div {
+  border-left: 1.5px dashed var(--line-strong);
+}
+.split-pane { padding: 18px 20px; display: flex; flex-direction: column; gap: 12px; min-width: 0; }
+
+/* big H */
+.term-h1 {
+  font-family: var(--mono);
+  font-size: 30px; font-weight: 700;
+  letter-spacing: -0.02em; line-height: 1.1;
+  margin: 0;
+}
+.term-h2 {
+  font-family: var(--mono);
+  font-size: 20px; font-weight: 600;
+  margin: 0;
+}
+
+.metric {
+  display: flex; flex-direction: column; align-items: flex-start;
+  padding: 14px;
+  border: 1.5px dashed var(--line-strong);
+  border-radius: 6px;
+}
+.metric .v { font-size: 28px; font-weight: 700; color: var(--accent); font-family: var(--mono); }
+.metric .k { font-size: 10px; color: var(--ink-faint); letter-spacing: 0.1em; margin-top: 4px; text-transform: uppercase; }
+
+/* signal — input line */
+.input-line {
+  display: flex; align-items: baseline; gap: 6px;
+  border: none;
+  border-bottom: 1.5px dashed var(--line-strong);
+  padding: 6px 0;
+  font-family: var(--mono);
+  font-size: 13px;
+  color: var(--ink);
+}
+.input-line .lbl { color: var(--ink-faint); min-width: 80px; }
+.input-line .val { color: var(--ink-dim); flex: 1; }
+.input-line .val.ph { color: var(--ink-faint); }
+
+/* tag pill (small, mono) */
+.pill {
+  display: inline-block;
+  padding: 1px 6px;
+  border-radius: 3px;
+  background: var(--bg-elev);
+  border: 1px dashed var(--line-strong);
+  font-family: var(--mono);
+  font-size: 10px;
+  color: var(--ink-dim);
+  letter-spacing: 0.04em;
+}
+.pill.on { color: var(--accent); border-color: var(--accent); }
+
+/* section header in body */
+.section-bar {
+  display: flex; align-items: center; gap: 8px;
+  margin: 14px 0 8px;
+  font-size: 11px; color: var(--ink-faint);
+  letter-spacing: 0.1em;
+}
+.section-bar::before { content: '##'; color: var(--accent); }
+.section-bar .line { flex: 1; height: 1px; background: var(--line); }
+
+/* placeholder — striped */
+.ph-img {
+  border: 1.5px dashed var(--line-strong);
+  border-radius: 4px;
+  background:
+    repeating-linear-gradient(45deg, var(--hatch) 0 7px, transparent 7px 14px),
+    var(--bg-elev);
+  display: flex; align-items: center; justify-content: center;
+  color: var(--ink-faint);
+  font-family: var(--mono); font-size: 11px;
+  letter-spacing: 0.06em;
+}
+
+/* file tree */
+.tree { font-family: var(--mono); font-size: 12px; line-height: 1.85; }
+.tree .row { color: var(--ink-dim); }
+.tree .row.on { color: var(--accent); }
+.tree .row .tk { color: var(--ink-faint); margin-right: 6px; }
+
+/* code block */
+.code {
+  background: var(--bg-elev);
+  border: 1.5px dashed var(--line);
+  border-radius: 6px;
+  padding: 12px 14px;
+  font-family: var(--mono);
+  font-size: 12px;
+  line-height: 1.7;
+  color: var(--ink);
+  overflow-x: auto;
+}
+.code .c { color: var(--ink-faint); }
+.code .k { color: oklch(72% 0.14 240); }
+.code .s { color: oklch(72% 0.14 65); }
+.code .f { color: oklch(72% 0.14 155); }
+[data-theme='light'] .code .k { color: oklch(45% 0.14 240); }
+[data-theme='light'] .code .s { color: oklch(50% 0.14 65); }
+[data-theme='light'] .code .f { color: oklch(45% 0.14 155); }

--- a/docs/design-system/tweaks-panel.jsx
+++ b/docs/design-system/tweaks-panel.jsx
@@ -1,0 +1,425 @@
+
+// tweaks-panel.jsx
+// Reusable Tweaks shell + form-control helpers.
+//
+// Owns the host protocol (listens for __activate_edit_mode / __deactivate_edit_mode,
+// posts __edit_mode_available / __edit_mode_set_keys / __edit_mode_dismissed) so
+// individual prototypes don't re-roll it. Ships a consistent set of controls so you
+// don't hand-draw <input type="range">, segmented radios, steppers, etc.
+//
+// Usage (in an HTML file that loads React + Babel):
+//
+//   const TWEAK_DEFAULTS = /*EDITMODE-BEGIN*/{
+//     "primaryColor": "#D97757",
+//     "fontSize": 16,
+//     "density": "regular",
+//     "dark": false
+//   }/*EDITMODE-END*/;
+//
+//   function App() {
+//     const [t, setTweak] = useTweaks(TWEAK_DEFAULTS);
+//     return (
+//       <div style={{ fontSize: t.fontSize, color: t.primaryColor }}>
+//         Hello
+//         <TweaksPanel>
+//           <TweakSection label="Typography" />
+//           <TweakSlider label="Font size" value={t.fontSize} min={10} max={32} unit="px"
+//                        onChange={(v) => setTweak('fontSize', v)} />
+//           <TweakRadio  label="Density" value={t.density}
+//                        options={['compact', 'regular', 'comfy']}
+//                        onChange={(v) => setTweak('density', v)} />
+//           <TweakSection label="Theme" />
+//           <TweakColor  label="Primary" value={t.primaryColor}
+//                        onChange={(v) => setTweak('primaryColor', v)} />
+//           <TweakToggle label="Dark mode" value={t.dark}
+//                        onChange={(v) => setTweak('dark', v)} />
+//         </TweaksPanel>
+//       </div>
+//     );
+//   }
+//
+// ─────────────────────────────────────────────────────────────────────────────
+
+const __TWEAKS_STYLE = `
+  .twk-panel{position:fixed;right:16px;bottom:16px;z-index:2147483646;width:280px;
+    max-height:calc(100vh - 32px);display:flex;flex-direction:column;
+    background:rgba(250,249,247,.78);color:#29261b;
+    -webkit-backdrop-filter:blur(24px) saturate(160%);backdrop-filter:blur(24px) saturate(160%);
+    border:.5px solid rgba(255,255,255,.6);border-radius:14px;
+    box-shadow:0 1px 0 rgba(255,255,255,.5) inset,0 12px 40px rgba(0,0,0,.18);
+    font:11.5px/1.4 ui-sans-serif,system-ui,-apple-system,sans-serif;overflow:hidden}
+  .twk-hd{display:flex;align-items:center;justify-content:space-between;
+    padding:10px 8px 10px 14px;cursor:move;user-select:none}
+  .twk-hd b{font-size:12px;font-weight:600;letter-spacing:.01em}
+  .twk-x{appearance:none;border:0;background:transparent;color:rgba(41,38,27,.55);
+    width:22px;height:22px;border-radius:6px;cursor:default;font-size:13px;line-height:1}
+  .twk-x:hover{background:rgba(0,0,0,.06);color:#29261b}
+  .twk-body{padding:2px 14px 14px;display:flex;flex-direction:column;gap:10px;
+    overflow-y:auto;overflow-x:hidden;min-height:0;
+    scrollbar-width:thin;scrollbar-color:rgba(0,0,0,.15) transparent}
+  .twk-body::-webkit-scrollbar{width:8px}
+  .twk-body::-webkit-scrollbar-track{background:transparent;margin:2px}
+  .twk-body::-webkit-scrollbar-thumb{background:rgba(0,0,0,.15);border-radius:4px;
+    border:2px solid transparent;background-clip:content-box}
+  .twk-body::-webkit-scrollbar-thumb:hover{background:rgba(0,0,0,.25);
+    border:2px solid transparent;background-clip:content-box}
+  .twk-row{display:flex;flex-direction:column;gap:5px}
+  .twk-row-h{flex-direction:row;align-items:center;justify-content:space-between;gap:10px}
+  .twk-lbl{display:flex;justify-content:space-between;align-items:baseline;
+    color:rgba(41,38,27,.72)}
+  .twk-lbl>span:first-child{font-weight:500}
+  .twk-val{color:rgba(41,38,27,.5);font-variant-numeric:tabular-nums}
+
+  .twk-sect{font-size:10px;font-weight:600;letter-spacing:.06em;text-transform:uppercase;
+    color:rgba(41,38,27,.45);padding:10px 0 0}
+  .twk-sect:first-child{padding-top:0}
+
+  .twk-field{appearance:none;width:100%;height:26px;padding:0 8px;
+    border:.5px solid rgba(0,0,0,.1);border-radius:7px;
+    background:rgba(255,255,255,.6);color:inherit;font:inherit;outline:none}
+  .twk-field:focus{border-color:rgba(0,0,0,.25);background:rgba(255,255,255,.85)}
+  select.twk-field{padding-right:22px;
+    background-image:url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='10' height='6' viewBox='0 0 10 6'><path fill='rgba(0,0,0,.5)' d='M0 0h10L5 6z'/></svg>");
+    background-repeat:no-repeat;background-position:right 8px center}
+
+  .twk-slider{appearance:none;-webkit-appearance:none;width:100%;height:4px;margin:6px 0;
+    border-radius:999px;background:rgba(0,0,0,.12);outline:none}
+  .twk-slider::-webkit-slider-thumb{-webkit-appearance:none;appearance:none;
+    width:14px;height:14px;border-radius:50%;background:#fff;
+    border:.5px solid rgba(0,0,0,.12);box-shadow:0 1px 3px rgba(0,0,0,.2);cursor:default}
+  .twk-slider::-moz-range-thumb{width:14px;height:14px;border-radius:50%;
+    background:#fff;border:.5px solid rgba(0,0,0,.12);box-shadow:0 1px 3px rgba(0,0,0,.2);cursor:default}
+
+  .twk-seg{position:relative;display:flex;padding:2px;border-radius:8px;
+    background:rgba(0,0,0,.06);user-select:none}
+  .twk-seg-thumb{position:absolute;top:2px;bottom:2px;border-radius:6px;
+    background:rgba(255,255,255,.9);box-shadow:0 1px 2px rgba(0,0,0,.12);
+    transition:left .15s cubic-bezier(.3,.7,.4,1),width .15s}
+  .twk-seg.dragging .twk-seg-thumb{transition:none}
+  .twk-seg button{appearance:none;position:relative;z-index:1;flex:1;border:0;
+    background:transparent;color:inherit;font:inherit;font-weight:500;min-height:22px;
+    border-radius:6px;cursor:default;padding:4px 6px;line-height:1.2;
+    overflow-wrap:anywhere}
+
+  .twk-toggle{position:relative;width:32px;height:18px;border:0;border-radius:999px;
+    background:rgba(0,0,0,.15);transition:background .15s;cursor:default;padding:0}
+  .twk-toggle[data-on="1"]{background:#34c759}
+  .twk-toggle i{position:absolute;top:2px;left:2px;width:14px;height:14px;border-radius:50%;
+    background:#fff;box-shadow:0 1px 2px rgba(0,0,0,.25);transition:transform .15s}
+  .twk-toggle[data-on="1"] i{transform:translateX(14px)}
+
+  .twk-num{display:flex;align-items:center;height:26px;padding:0 0 0 8px;
+    border:.5px solid rgba(0,0,0,.1);border-radius:7px;background:rgba(255,255,255,.6)}
+  .twk-num-lbl{font-weight:500;color:rgba(41,38,27,.6);cursor:ew-resize;
+    user-select:none;padding-right:8px}
+  .twk-num input{flex:1;min-width:0;height:100%;border:0;background:transparent;
+    font:inherit;font-variant-numeric:tabular-nums;text-align:right;padding:0 8px 0 0;
+    outline:none;color:inherit;-moz-appearance:textfield}
+  .twk-num input::-webkit-inner-spin-button,.twk-num input::-webkit-outer-spin-button{
+    -webkit-appearance:none;margin:0}
+  .twk-num-unit{padding-right:8px;color:rgba(41,38,27,.45)}
+
+  .twk-btn{appearance:none;height:26px;padding:0 12px;border:0;border-radius:7px;
+    background:rgba(0,0,0,.78);color:#fff;font:inherit;font-weight:500;cursor:default}
+  .twk-btn:hover{background:rgba(0,0,0,.88)}
+  .twk-btn.secondary{background:rgba(0,0,0,.06);color:inherit}
+  .twk-btn.secondary:hover{background:rgba(0,0,0,.1)}
+
+  .twk-swatch{appearance:none;-webkit-appearance:none;width:56px;height:22px;
+    border:.5px solid rgba(0,0,0,.1);border-radius:6px;padding:0;cursor:default;
+    background:transparent;flex-shrink:0}
+  .twk-swatch::-webkit-color-swatch-wrapper{padding:0}
+  .twk-swatch::-webkit-color-swatch{border:0;border-radius:5.5px}
+  .twk-swatch::-moz-color-swatch{border:0;border-radius:5.5px}
+`;
+
+// ── useTweaks ───────────────────────────────────────────────────────────────
+// Single source of truth for tweak values. setTweak persists via the host
+// (__edit_mode_set_keys → host rewrites the EDITMODE block on disk).
+function useTweaks(defaults) {
+  const [values, setValues] = React.useState(defaults);
+  // Accepts either setTweak('key', value) or setTweak({ key: value, ... }) so a
+  // useState-style call doesn't write a "[object Object]" key into the persisted
+  // JSON block.
+  const setTweak = React.useCallback((keyOrEdits, val) => {
+    const edits = typeof keyOrEdits === 'object' && keyOrEdits !== null
+      ? keyOrEdits : { [keyOrEdits]: val };
+    setValues((prev) => ({ ...prev, ...edits }));
+    window.parent.postMessage({ type: '__edit_mode_set_keys', edits }, '*');
+  }, []);
+  return [values, setTweak];
+}
+
+// ── TweaksPanel ─────────────────────────────────────────────────────────────
+// Floating shell. Registers the protocol listener BEFORE announcing
+// availability — if the announce ran first, the host's activate could land
+// before our handler exists and the toolbar toggle would silently no-op.
+// The close button posts __edit_mode_dismissed so the host's toolbar toggle
+// flips off in lockstep; the host echoes __deactivate_edit_mode back which
+// is what actually hides the panel.
+function TweaksPanel({ title = 'Tweaks', children }) {
+  const [open, setOpen] = React.useState(false);
+  const dragRef = React.useRef(null);
+  const offsetRef = React.useRef({ x: 16, y: 16 });
+  const PAD = 16;
+
+  const clampToViewport = React.useCallback(() => {
+    const panel = dragRef.current;
+    if (!panel) return;
+    const w = panel.offsetWidth, h = panel.offsetHeight;
+    const maxRight = Math.max(PAD, window.innerWidth - w - PAD);
+    const maxBottom = Math.max(PAD, window.innerHeight - h - PAD);
+    offsetRef.current = {
+      x: Math.min(maxRight, Math.max(PAD, offsetRef.current.x)),
+      y: Math.min(maxBottom, Math.max(PAD, offsetRef.current.y)),
+    };
+    panel.style.right = offsetRef.current.x + 'px';
+    panel.style.bottom = offsetRef.current.y + 'px';
+  }, []);
+
+  React.useEffect(() => {
+    if (!open) return;
+    clampToViewport();
+    if (typeof ResizeObserver === 'undefined') {
+      window.addEventListener('resize', clampToViewport);
+      return () => window.removeEventListener('resize', clampToViewport);
+    }
+    const ro = new ResizeObserver(clampToViewport);
+    ro.observe(document.documentElement);
+    return () => ro.disconnect();
+  }, [open, clampToViewport]);
+
+  React.useEffect(() => {
+    const onMsg = (e) => {
+      const t = e?.data?.type;
+      if (t === '__activate_edit_mode') setOpen(true);
+      else if (t === '__deactivate_edit_mode') setOpen(false);
+    };
+    window.addEventListener('message', onMsg);
+    window.parent.postMessage({ type: '__edit_mode_available' }, '*');
+    return () => window.removeEventListener('message', onMsg);
+  }, []);
+
+  const dismiss = () => {
+    setOpen(false);
+    window.parent.postMessage({ type: '__edit_mode_dismissed' }, '*');
+  };
+
+  const onDragStart = (e) => {
+    const panel = dragRef.current;
+    if (!panel) return;
+    const r = panel.getBoundingClientRect();
+    const sx = e.clientX, sy = e.clientY;
+    const startRight = window.innerWidth - r.right;
+    const startBottom = window.innerHeight - r.bottom;
+    const move = (ev) => {
+      offsetRef.current = {
+        x: startRight - (ev.clientX - sx),
+        y: startBottom - (ev.clientY - sy),
+      };
+      clampToViewport();
+    };
+    const up = () => {
+      window.removeEventListener('mousemove', move);
+      window.removeEventListener('mouseup', up);
+    };
+    window.addEventListener('mousemove', move);
+    window.addEventListener('mouseup', up);
+  };
+
+  if (!open) return null;
+  return (
+    <>
+      <style>{__TWEAKS_STYLE}</style>
+      <div ref={dragRef} className="twk-panel"
+           style={{ right: offsetRef.current.x, bottom: offsetRef.current.y }}>
+        <div className="twk-hd" onMouseDown={onDragStart}>
+          <b>{title}</b>
+          <button className="twk-x" aria-label="Close tweaks"
+                  onMouseDown={(e) => e.stopPropagation()}
+                  onClick={dismiss}>✕</button>
+        </div>
+        <div className="twk-body">{children}</div>
+      </div>
+    </>
+  );
+}
+
+// ── Layout helpers ──────────────────────────────────────────────────────────
+
+function TweakSection({ label, children }) {
+  return (
+    <>
+      <div className="twk-sect">{label}</div>
+      {children}
+    </>
+  );
+}
+
+function TweakRow({ label, value, children, inline = false }) {
+  return (
+    <div className={inline ? 'twk-row twk-row-h' : 'twk-row'}>
+      <div className="twk-lbl">
+        <span>{label}</span>
+        {value != null && <span className="twk-val">{value}</span>}
+      </div>
+      {children}
+    </div>
+  );
+}
+
+// ── Controls ────────────────────────────────────────────────────────────────
+
+function TweakSlider({ label, value, min = 0, max = 100, step = 1, unit = '', onChange }) {
+  return (
+    <TweakRow label={label} value={`${value}${unit}`}>
+      <input type="range" className="twk-slider" min={min} max={max} step={step}
+             value={value} onChange={(e) => onChange(Number(e.target.value))} />
+    </TweakRow>
+  );
+}
+
+function TweakToggle({ label, value, onChange }) {
+  return (
+    <div className="twk-row twk-row-h">
+      <div className="twk-lbl"><span>{label}</span></div>
+      <button type="button" className="twk-toggle" data-on={value ? '1' : '0'}
+              role="switch" aria-checked={!!value}
+              onClick={() => onChange(!value)}><i /></button>
+    </div>
+  );
+}
+
+function TweakRadio({ label, value, options, onChange }) {
+  const trackRef = React.useRef(null);
+  const [dragging, setDragging] = React.useState(false);
+  const opts = options.map((o) => (typeof o === 'object' ? o : { value: o, label: o }));
+  const idx = Math.max(0, opts.findIndex((o) => o.value === value));
+  const n = opts.length;
+
+  // The active value is read by pointer-move handlers attached for the lifetime
+  // of a drag — ref it so a stale closure doesn't fire onChange for every move.
+  const valueRef = React.useRef(value);
+  valueRef.current = value;
+
+  const segAt = (clientX) => {
+    const r = trackRef.current.getBoundingClientRect();
+    const inner = r.width - 4;
+    const i = Math.floor(((clientX - r.left - 2) / inner) * n);
+    return opts[Math.max(0, Math.min(n - 1, i))].value;
+  };
+
+  const onPointerDown = (e) => {
+    setDragging(true);
+    const v0 = segAt(e.clientX);
+    if (v0 !== valueRef.current) onChange(v0);
+    const move = (ev) => {
+      if (!trackRef.current) return;
+      const v = segAt(ev.clientX);
+      if (v !== valueRef.current) onChange(v);
+    };
+    const up = () => {
+      setDragging(false);
+      window.removeEventListener('pointermove', move);
+      window.removeEventListener('pointerup', up);
+    };
+    window.addEventListener('pointermove', move);
+    window.addEventListener('pointerup', up);
+  };
+
+  return (
+    <TweakRow label={label}>
+      <div ref={trackRef} role="radiogroup" onPointerDown={onPointerDown}
+           className={dragging ? 'twk-seg dragging' : 'twk-seg'}>
+        <div className="twk-seg-thumb"
+             style={{ left: `calc(2px + ${idx} * (100% - 4px) / ${n})`,
+                      width: `calc((100% - 4px) / ${n})` }} />
+        {opts.map((o) => (
+          <button key={o.value} type="button" role="radio" aria-checked={o.value === value}>
+            {o.label}
+          </button>
+        ))}
+      </div>
+    </TweakRow>
+  );
+}
+
+function TweakSelect({ label, value, options, onChange }) {
+  return (
+    <TweakRow label={label}>
+      <select className="twk-field" value={value} onChange={(e) => onChange(e.target.value)}>
+        {options.map((o) => {
+          const v = typeof o === 'object' ? o.value : o;
+          const l = typeof o === 'object' ? o.label : o;
+          return <option key={v} value={v}>{l}</option>;
+        })}
+      </select>
+    </TweakRow>
+  );
+}
+
+function TweakText({ label, value, placeholder, onChange }) {
+  return (
+    <TweakRow label={label}>
+      <input className="twk-field" type="text" value={value} placeholder={placeholder}
+             onChange={(e) => onChange(e.target.value)} />
+    </TweakRow>
+  );
+}
+
+function TweakNumber({ label, value, min, max, step = 1, unit = '', onChange }) {
+  const clamp = (n) => {
+    if (min != null && n < min) return min;
+    if (max != null && n > max) return max;
+    return n;
+  };
+  const startRef = React.useRef({ x: 0, val: 0 });
+  const onScrubStart = (e) => {
+    e.preventDefault();
+    startRef.current = { x: e.clientX, val: value };
+    const decimals = (String(step).split('.')[1] || '').length;
+    const move = (ev) => {
+      const dx = ev.clientX - startRef.current.x;
+      const raw = startRef.current.val + dx * step;
+      const snapped = Math.round(raw / step) * step;
+      onChange(clamp(Number(snapped.toFixed(decimals))));
+    };
+    const up = () => {
+      window.removeEventListener('pointermove', move);
+      window.removeEventListener('pointerup', up);
+    };
+    window.addEventListener('pointermove', move);
+    window.addEventListener('pointerup', up);
+  };
+  return (
+    <div className="twk-num">
+      <span className="twk-num-lbl" onPointerDown={onScrubStart}>{label}</span>
+      <input type="number" value={value} min={min} max={max} step={step}
+             onChange={(e) => onChange(clamp(Number(e.target.value)))} />
+      {unit && <span className="twk-num-unit">{unit}</span>}
+    </div>
+  );
+}
+
+function TweakColor({ label, value, onChange }) {
+  return (
+    <div className="twk-row twk-row-h">
+      <div className="twk-lbl"><span>{label}</span></div>
+      <input type="color" className="twk-swatch" value={value}
+             onChange={(e) => onChange(e.target.value)} />
+    </div>
+  );
+}
+
+function TweakButton({ label, onClick, secondary = false }) {
+  return (
+    <button type="button" className={secondary ? 'twk-btn secondary' : 'twk-btn'}
+            onClick={onClick}>{label}</button>
+  );
+}
+
+Object.assign(window, {
+  useTweaks, TweaksPanel, TweakSection, TweakRow,
+  TweakSlider, TweakToggle, TweakRadio, TweakSelect,
+  TweakText, TweakNumber, TweakColor, TweakButton,
+});

--- a/docs/reports/prd-validation-2026-04-28.md
+++ b/docs/reports/prd-validation-2026-04-28.md
@@ -1,0 +1,316 @@
+# PRD Technical Verification Result: tkstarDev (`tkstar.dev`)
+
+> **Validation Date**: 2026-04-28
+> **Validated Document**: `docs/PRD.md` (35,721 bytes)
+> **Cross-checked Against**: `docs/PROJECT-STRUCTURE.md`, `package.json`, `CLAUDE.md`, `docs/design-system/`
+> **Platform**: Web (React Router v7 Framework mode, SSR on Cloudflare Workers)
+> **Scale**: Small (solo developer, no auth/RBAC, single locale)
+> **Validator**: prd-validator
+
+---
+
+## Chain of Thought Verification Summary
+
+### Reasoning Path
+1. **Initial Observation** — Static personal-brand site, DB-less, MDX-driven, Cloudflare Workers SSR.
+2. **Hypothesis** — Tech stack is internally consistent and the dominant risk is the gap between the design source (React 18 + babel-standalone) and the production target (React Router v7 + React 19 ESM), plus a *cross-document* mismatch between PRD/PROJECT-STRUCTURE (web) and `CLAUDE.md` (Expo/React Native).
+3. **Step-by-step Verification** — Versions resolved against `package.json`; external service claims (Resend, Turnstile, Satori, velite, Tailwind v4, RR v7) cross-checked.
+4. **Logical Connection** — Feature -> Page -> Menu cross-references in `PRD.md` reconciled with the `app/presentation/routes/` layout in `PROJECT-STRUCTURE.md`.
+5. **Comprehensive Judgment** — Conditional Pass with one Blocker (CLAUDE.md misalignment) and several High/Medium issues to harden before implementation.
+
+### Technical Confidence Distribution
+- **High Confidence** [FACT]: ~70% — versions match `package.json`; external services (Resend free tier, Turnstile siteverify, Satori standalone, velite Zod) verified against official docs.
+- **Medium Confidence** [INFERENCE]: ~25% — architecture-level claims about CA layering, on-this-page TOC, search index strategy.
+- **Low Confidence** [UNCERTAIN]: ~5% — assumptions explicitly tagged in PRD (rehype-toc choice, asset fetch path, cert-issuance channel, Bing later) — acceptable.
+
+### Key Findings
+- **Aligned with Expectations**: package.json versions match PRD's "Tech Stack (Latest Versions)" exactly (RR 7.14.0, React 19.2.4, TypeScript 5.9.3, Tailwind 4.2.2, Vite 8.0.3, Vitest 4.1.5, Biome 2.4.13, wrangler 4.85.0, @cloudflare/vite-plugin 1.33.2, isbot 5.1.36).
+- **Different from Expectations** (Blocker): `CLAUDE.md` describes an **Expo/React Native** project (Metro, `expo run:ios`, `react-test-renderer`, `jest.config.js`, `babel.config.js`, `setupFilesAfterEnv`). The actual codebase is a **web-only React Router v7 + Cloudflare Workers** project (Vite, Vitest). All native/Expo guidance in `CLAUDE.md` is dead instruction for this PRD.
+- **Different from Expectations** (High): PRD does not define a Non-Functional Requirements (NFR) section — no measurable targets for performance, accessibility, security, or content limits, despite the design referencing `backdrop-filter` blur, `oklch()`, `color-mix()`, and a print stylesheet that all carry browser-support and contrast obligations.
+- **Additional Considerations**: F003 PDF export ("Save as PDF" via `window.print()`) is brand-specific (different rendering between Chrome/Safari/Firefox print engines) and lacks an acceptance criterion for what a "valid PDF" looks like.
+
+---
+
+## Step-by-Step Verification Results
+
+### Step 0 - Platform Detection
+- Signals (page-by-page, menu, SSR, React Router v7, ⌘K palette) clearly identify **Web**.
+- Scale signals (single user, no auth, sequential `F001..F019` IDs, single brand) identify **Small**.
+- Multi-platform signals: **none** — `CLAUDE.md`'s Expo references are inconsistent with the rest of the project (see Issue #1).
+
+### Step 1 - Initial Analysis
+**Project type**: Static personal-brand site delivered via Cloudflare Workers SSR.
+**Main tech stack** (verified against `/Users/tkstart/Desktop/project/tkstar-dev/package.json`):
+- `react-router 7.14.0`, `react 19.2.4`, `react-dom 19.2.4` — [FACT] match PRD section "Tech Stack > Frontend Framework".
+- `@react-router/dev 7.14.0`, `@cloudflare/vite-plugin ^1.33.2`, `wrangler ^4.85.0` — [FACT] match.
+- `tailwindcss ^4.2.2`, `@tailwindcss/vite ^4.2.2` — [FACT] match.
+- `vite ^8.0.3`, `vitest ^4.1.5`, `@vitejs/plugin-react ^6.0.1`, `jsdom ^29.1.0`, `@testing-library/react ^16.3.2`, `@testing-library/jest-dom ^6.9.1`, `@testing-library/dom ^10.4.1` — [FACT] match.
+- `@biomejs/biome 2.4.13`, `typescript ^5.9.3`, `isbot ^5.1.36` — [FACT] match.
+
+**External-service dependencies** (not yet in package.json, marked `[ASSUMPTION: 미설치]` in PRD — acceptable):
+- velite, MDX, shiki, Satori, React Email, Resend SDK, Turnstile (client widget + server siteverify call).
+
+**Initial Hypothesis**: "Stack is internally coherent and well-versioned. The dominant risks are (1) the design-source porting gap (React 18 IIFE -> React 19 ESM), (2) the absence of measurable NFRs, and (3) cross-document drift in `CLAUDE.md`."
+
+### Step 2 - Technical Verification & Alternatives
+
+| Claim (PRD) | Verification | Tag | Evidence |
+|---|---|---|---|
+| React Router 7.14 Framework mode runs SSR on Cloudflare Workers via `@cloudflare/vite-plugin 1.33.2` | Verified — Cloudflare ships an official RR v7 template and the Vite plugin is GA. | [FACT] | [Cloudflare Workers / React Router](https://developers.cloudflare.com/workers/framework-guides/web-apps/react-router/), [Cloudflare Vite plugin announcement](https://blog.cloudflare.com/introducing-the-cloudflare-vite-plugin/) |
+| Tailwind v4 `@variant dark (&:where([data-theme='dark'], [data-theme='dark'] *))` enables data-attribute dark mode | Verified — Tailwind v4 docs explicitly support `@custom-variant` with `[data-theme=...]`. | [FACT] | [Tailwind v4 theme variables docs](https://tailwindcss.com/docs/theme), [Custom themes in Tailwind v4](https://dev.to/vrauuss_softwares/-create-custom-themes-in-tailwind-css-v4-custom-variant-12-2nf0) |
+| Tailwind 4.2.x is current; `oklch()` / `color-mix(in oklab, ...)` are usable | Verified — 4.2.0 released 2026-02-18; modern color functions are core CSS. | [FACT] | [Tailwind 4.2 release notes](https://www.infoq.com/news/2026/04/tailwind-css-4-2-webpack/) |
+| Satori standalone build with manual `yoga.wasm` load is required on Workers, served via Asset Binding | Verified — Workers cannot compile WASM from arbitrary blobs; standalone build + module import is the documented path. | [FACT] | [Satori standalone build](https://deepwiki.com/vercel/satori/2.4-text-rendering), [Workers static asset binding](https://developers.cloudflare.com/workers/static-assets/binding/), [Satori on Cloudflare Workers writeup](https://code.charliegleason.com/satori-vite-remix-cloudflare) |
+| Resend free tier = 3,000 emails/month, 100/day, 1 custom domain | Verified — current Resend free tier exactly matches. | [FACT] | [Resend new free tier](https://resend.com/blog/new-free-tier), [Cloudflare Workers + Resend tutorial](https://developers.cloudflare.com/workers/tutorials/send-emails-with-resend/) |
+| Turnstile siteverify endpoint validates the token server-side | Verified — `POST https://challenges.cloudflare.com/turnstile/v0/siteverify` with `secret`+`response`; tokens valid 5 min, single-use. | [FACT] | [Turnstile server-side validation](https://developers.cloudflare.com/turnstile/get-started/server-side-validation/) |
+| velite turns MDX + Zod into a typed JSON data layer (used as Infrastructure read-side) | Verified — velite official docs describe exactly this workflow. | [FACT] | [velite Introduction](https://velite.js.org/guide/introduction), [velite MDX support](https://velite.js.org/guide/using-mdx), [velite repo](https://github.com/zce/velite) |
+| velite + RR v7 Framework + Cloudflare Workers all play together | No first-party docs show this exact triple stack working out of the box; conceptually it is fine because velite is a *build-time* ETL that emits static JSON consumable by any Vite-based runtime. | [INFERENCE] | velite output is a normal `.velite/` JSON tree that is statically import-friendly; no runtime Workers constraint applies. |
+| `window.print()`-based PDF export reliably produces a usable resume | Browser print engines differ in handling `@page`, page-break rules, OKLCH colors, backdrop-filter, and webfont embedding. No PRD-defined acceptance criteria. | [UNCERTAIN] | See Issue #5. |
+| Cloudflare Web Analytics is cookie-less | Confirmed by product positioning — but PRD does not capture how the snippet is loaded under SSR + CSP. | [INFERENCE] | Acceptable, but tighten via NFR/security section. |
+| `[ASSUMPTION: rehype-toc 또는 velite 후처리]` for on-this-page TOC | Both options are valid; PRD correctly tags as assumption. | [FACT] tag policy correct |  |
+
+**Alternatives explored**:
+- (F011 OG generation) If Satori standalone proves too heavy, **build-time pre-rendered PNGs per slug** is a viable fallback (content is fully static).
+- (F016 search) Single in-bundle JSON works for current scale; **FlexSearch / MiniSearch** can be deferred and PRD already says so.
+- (F008 email) MailChannels is **EOL** (2024-06-30), so Resend is correctly chosen as the only practical option.
+
+### Step 3 - Logical Consistency
+
+**Cross-references (PRD self-consistency)** — checked manually:
+- Every Feature ID `F001..F019` (excluding intentionally removed F015) is mapped to at least one page in "Page-by-Page Detailed Features".
+- Every page in "Page-by-Page Detailed Features" lists its `Implemented Features`.
+- Menu Structure references match the page list (Brand/Topbar/Footer/palette/colocated content links).
+- Removed features (F001 split-CTA, F015 audience memory) are explicitly documented under "Deferred / Removed".
+- `F018` indexing policy is consistently restated on `App Terms`, `App Privacy`, and `Not Found` pages.
+
+**Cross-references (PRD <-> PROJECT-STRUCTURE)**:
+- Routes in `PROJECT-STRUCTURE.md` (`app/presentation/routes/_index.tsx`, `about.tsx`, `projects.$slug.tsx`, `blog.$slug.tsx`, `contact.tsx`, `legal._index.tsx`, `legal.$app.terms.tsx`, `legal.$app.privacy.tsx`, `rss[.xml].tsx`, `sitemap[.xml].tsx`, `robots[.txt].tsx`, `og.projects.$slug[.png].tsx`, `og.blog.$slug[.png].tsx`, `$.tsx`) — **fully consistent** with PRD pages and resource routes.
+- Cross-cutting concerns table in `PROJECT-STRUCTURE.md` covers F010, F011, F012, F013, F016, F018, F019, F008/F009 — **all PRD features have a CA layer mapping**.
+- velite collections (`Project`, `Post`, `AppLegalDoc`) and `ContactSubmission` VO + `ThemePreference` VO match PRD's Data Model section.
+
+**Inconsistency**:
+- `CLAUDE.md` Commands table lists `bun run start` (Metro), `bun run ios` / `bun run android` (`expo run:*`), and references `babel.config.js`, `metro.config.js`, `react-test-renderer`, `setupFilesAfterEnv` in `jest.config.js`. None of these exist in this project. `package.json` exposes `dev` (`react-router dev`), `build`, `deploy`, `test` (vitest), `typecheck`. This is a **document-level contradiction** that will mislead future automation, planners, and humans (Blocker #1).
+
+### Step 4 - Complexity & Risk Assessment
+
+| Area | Complexity (1-5) | Evidence |
+|---|---|---|
+| Static content pipeline (velite + MDX + Zod + shiki) | 2 | Standard Vite-era pattern; velite explicitly supports MDX. |
+| Cmd+K Command Palette (F016) with build-time index | 2 | In-memory token search over a small static index; well-trodden. |
+| Contact form (F008/F009) on Workers | 3 | Resend SDK + Turnstile siteverify both have small footprints; main risk is secret hygiene. |
+| Satori OG on Workers (F011) | 4 | Requires standalone build, manual `yoga.wasm` load via Asset Binding, font ttf delivery; non-trivial but documented. |
+| Print resume (F003) | 3 | Browser-print quirks; not technically risky but acceptance criteria are missing. |
+| SSR + dual-meta + JSON-LD per page (F018) | 2 | RR v7 `meta` export is the canonical primitive. |
+| Sitemap / robots / RSS resource routes (F018, F012) | 1 | Trivial loaders that emit XML/text. |
+| chrome-free WebView mode (App Terms/Privacy) | 1 | Layout swap. |
+
+**Time estimation (solo dev, 3-6 month corridor)**: PRD does not specify timeline — acceptable for a Small-scale PRD per the `prd` skill's NEVER-Generate rule (no milestones / no business metrics). Implementation effort distribution looks naturally bounded inside the corridor for a solo developer.
+
+**Scale suitability**: Small scope is appropriate; the codebase plan in `PROJECT-STRUCTURE.md` (CA 4-layer + DI container as plain object/Map) is right-sized for this scale.
+
+### Step 4.5 - Scope Compliance: Business Metrics Absence
+
+**Grep over PRD for prohibited tokens** (Success Metrics / KPI / DAU / MAU / WAU / 리텐션 / Retention / Churn / 이탈률 / Conversion / 전환율 / LTV / CAC / ARPU / ARR / MRR / Adoption / Stickiness / NPS / CSAT / 만족도 / 성공 지표 / 목표지수 / 핵심 성과 지표):
+
+- **Zero hits** for any of the prohibited business-outcome keywords. The PRD never frames any number as a business goal.
+- The "metrics" field in the `Project` data model (`metrics: [string, string][]`) refers to **per-case-study result metrics that the user fills in inside MDX content** (e.g., `["MAU", "12k"]`) — this is **content payload**, not a project-level success target. **[ALLOWED]**
+- The phrase "월 1편 작성 운영" in F006 is an **operating cadence note for content creation**, not a retention/adoption target. **[ALLOWED]**
+- The phrase "평균 회신 24시간 이내" in F008 is a **user-facing copy on the success screen**, not a measured SLA. **[ALLOWED]**
+
+**Result**: **0 `[SCOPE_VIOLATION]` entries**. The PRD is fully scope-compliant for this dimension.
+
+### Step 5 - Hypothesis Verification & Revision
+
+- **Initial hypothesis confirmed**: design-source -> production gap and absent NFRs are the dominant risks.
+- **Newly discovered (and elevated to Blocker)**: `CLAUDE.md` describes a different project (Expo/RN) than the rest of the repository. This is the single most consequential finding because it will pollute every future agent's context (this is the file at the root of every conversation).
+- **Final revised hypothesis**: PRD content itself is implementable as-is; the **cross-document hygiene** must be fixed (CLAUDE.md) and **NFRs must be added** before implementation begins.
+
+---
+
+## Critical Issues (Immediate Correction Required)
+
+### Issue #1 — `CLAUDE.md` describes a different project than `PRD.md` / `PROJECT-STRUCTURE.md` / `package.json`
+- **Severity**: **Blocker**
+- **Location**: `/Users/tkstart/Desktop/project/tkstar-dev/CLAUDE.md` lines 47-73 ("Commands > Test & Quality" and "Build & Native" tables, "Presentation test notes" paragraph)
+- **Reproducible evidence**:
+  - `CLAUDE.md` line 53: `bun run test:coverage` — script does not exist in `package.json` (no `test:coverage` script).
+  - `CLAUDE.md` line 53 references `coverageThreshold` in `jest.config.js` — file does not exist; the project uses `vitest.config.ts`.
+  - `CLAUDE.md` line 54 references `babel.config.js` / `metro.config.js` — neither file exists; this project uses `vite.config.ts`.
+  - `CLAUDE.md` line 58 references `@testing-library/react-native` and `react-test-renderer` — `package.json` only has `@testing-library/react`. There is no React Native at all.
+  - `CLAUDE.md` lines 62-66 list `bun run start` (Metro), `bun run ios` (`expo run:ios`), `bun run android` (`expo run:android`), and `bunx expo prebuild --clean`. None of these scripts/tools exist; `package.json` defines `dev` (`react-router dev`), `build` (`react-router build`), `deploy` (`react-router build && wrangler deploy`), `test` (`vitest run`), `typecheck`.
+  - `package.json` confirms the project type: `"react-router": "7.14.0"` and `"wrangler": "^4.85.0"` only — pure web stack.
+- **Why this is a Blocker**: `CLAUDE.md` is loaded as project instructions on **every** Claude Code session and is referenced by the harness pipeline. Stale Expo/RN guidance will (a) push agents toward non-existent commands, (b) make TDD/Red-Green cycles fail (`jest.config.js` is missing), (c) mislead future PRD/plan/code-review work into believing a mobile target exists.
+- **Resolution recommendation**:
+  1. Replace the `Test & Quality` and `Build & Native` tables with the actual web stack: `bun run dev`, `bun run build`, `bun run deploy`, `bun run typecheck`, `bun run test`, `bun run test:watch`, `bun run lint`, `bun run format`, `bun run check`.
+  2. Drop the "Presentation test notes" paragraph entirely (RN/Jest specifics do not apply).
+  3. Drop the "Recommended workflow after dependency install" block (no `expo prebuild`).
+  4. Fill in `Service Name`, `Goal`, `Target Users` placeholders in the header so future agents have correct project framing.
+- **Urgency**: **High** — fix before next harness pipeline run.
+
+---
+
+## Major Issues (Improvement Recommended Before Development)
+
+### Issue #2 — Missing Non-Functional Requirements (NFR) section
+- **Severity**: **High**
+- **Location**: `docs/PRD.md` (no NFR section exists between "Data Model" and "Tech Stack")
+- **Risk analysis**: Without measurable NFRs, the TDD-First principle in `CLAUDE.md` cannot produce verifiable tests for cross-cutting concerns. Specifically:
+  - **Performance**: Hero LCP, Time-to-Interactive, OG-image cold-start budget, search-index payload size — none specified. Satori on Workers is a known soft spot (CPU time, ~50ms budget).
+  - **Accessibility**: PRD references `oklch()` and dark/light contrast but specifies no WCAG target (e.g., AA contrast ratio for text, `prefers-reduced-motion` handling for the `@keyframes blink` cursor in F010 / Hero).
+  - **Security**: No CSP policy specified for Cloudflare Web Analytics + Turnstile + Satori inline SVG; no rate limit on `/contact` action; no maximum message length (the `contact-submission.schema.ts` mentions "10자 이상" minimum but no maximum).
+  - **Browser support**: PRD says "모던 브라우저만 타깃" but does not enumerate (e.g., Chrome >= 119 for `oklch()`, Safari >= 16.4 for `color-mix()`).
+  - **i18n**: Explicitly out of scope (Korean only) — that is fine, but the `lang="ko"` attribute requirement should be captured.
+- **Improvement**: Add an **NFR** section with explicit, testable thresholds. Suggested skeleton:
+  - Performance: LCP < 2.5s on 4G + low-end mobile; sitemap size < 10MB; search-index < 100KB gzipped; OG render < 1.5s p95.
+  - Accessibility: WCAG 2.1 AA contrast; `prefers-reduced-motion` disables blink/fade keyframes; keyboard trap-free Command Palette with focus return on close.
+  - Security: CSP allow-list for `challenges.cloudflare.com` (Turnstile), `static.cloudflareinsights.com` (Web Analytics); contact `message` field 10..5000 chars; per-IP rate limit 5/hour on `submitContactForm`.
+  - Browser support: Chrome/Edge >= 119, Safari >= 16.4, Firefox >= 113 (minimum bar for `oklch()` + `color-mix()`).
+- **Alternatives**: If a full NFR section feels heavy for a personal site, at minimum embed the contrast/CSP/rate-limit numbers next to the relevant features (F010 dark mode, F008 contact, F013 analytics).
+- **Better option**: Move all numeric *technical* constraints (contrast, payload sizes, CSP) into a single NFR section — this stays scope-compliant per the `prd` skill (numbers describe system contract, not business outcomes).
+
+### Issue #3 — `[ASSUMPTION]` items have no resolution checkpoint
+- **Severity**: **High**
+- **Location**: `docs/PRD.md` — assumption tags scattered across:
+  - About Page Key Features (자격증 데이터 카드)
+  - Project Detail Key Features (rehype-toc 또는 velite 후처리)
+  - Tech Stack > Typography (Satori asset fetch path)
+  - Tech Stack > Content Pipeline (velite, shiki, Satori, on-this-page TOC — 미설치)
+  - Tech Stack > Forms & Email (React Email, Resend, Turnstile — 미설치)
+  - Tech Stack > Hosting (도메인 등록 채널)
+  - Tech Stack > SEO (Google/Naver 토큰 발급 시점)
+  - Not Found Fallback (splat 또는 ErrorBoundary)
+- **Risk**: Tags are correctly applied (good), but PRD provides no "resolution gate" — i.e., when must each assumption be resolved? Without a gate, assumptions silently leak into implementation and then into production.
+- **Improvement**: Add a small "Assumptions Register" at the bottom of PRD (or inside `PROJECT-STRUCTURE.md` "Architectural Decisions Open" subsection — `Resolved` already exists in the latter as D1-D5). Each entry: owner / resolution-by phase / current state.
+- **Alternative**: If a register is too heavy, append `[Resolve before: <phase name from ROADMAP.md>]` to each assumption tag. This piggy-backs on the existing ROADMAP.
+
+### Issue #4 — No DoD / Acceptance Criteria per feature
+- **Severity**: **High**
+- **Location**: `docs/PRD.md` — every Feature ID and every Page-by-Page row has `Key Features` (descriptive) but no `Acceptance Criteria` (testable / Given-When-Then).
+- **Risk**: TDD-First requires verifiable success criteria. CLAUDE.md "Goal-Driven Execution" explicitly forbids weak criteria like "make it work". As-is, F003 (PDF), F008/F009 (contact pipeline), F011 (OG), F016 (palette) cannot be opened as Red-phase tests without authoring the criteria first.
+- **Improvement**: For each Core feature, add 2-4 testable bullets. Examples:
+  - F003 PDF: "When user clicks `[⎙ PDF]`, `window.print()` is invoked once and Topbar/Footer/SearchTrigger/ThemeToggle have `display: none` in `@media print`."; "Page breaks do not split a single experience block (CSS `break-inside: avoid` on `.experience` rows)."
+  - F008 Contact: "Submitting a valid form triggers exactly one `email-sender.send` call and one auto-reply call."; "On `email-sender` failure the form is preserved and a `mailto:` fallback link is rendered."
+  - F009 Turnstile: "Server-side `siteverify` is called with `secret` + `response`, and a non-`success` response rejects the submission with HTTP 400."
+  - F016 Palette: "`Cmd+K`, `Ctrl+K`, and `/` open the palette; inside an `<input>`/`<textarea>`/`[contenteditable]` the `/` shortcut is suppressed."; "`Esc` closes the palette and returns focus to the trigger."
+
+### Issue #5 — F003 PDF export is brand-/engine-dependent and lacks an acceptance criterion
+- **Severity**: **Medium**
+- **Location**: `docs/PRD.md` F003 row + About Page Key Features
+- **Risk analysis**: `window.print()` produces output that varies between Chrome (Skia print pipeline), Safari (CG print), and Firefox (Cairo). Known pitfalls for this stack:
+  - `oklch()` and `color-mix()` may be rasterized inconsistently in print preview on Safari < 17.
+  - `backdrop-filter: blur()` regions can be rendered as solid blocks in print.
+  - Self-hosted woff2 may not be embedded by default in some print pipelines (FOIT in PDF).
+  - `@media print` style is required to hide Topbar/Footer (PRD does say this) but not specified for `@page` margins, page breaks, or color profile.
+- **Improvement**: Add to F003:
+  - Target browsers: Chrome/Edge latest + Safari 17+ (drop or call out earlier Safari).
+  - Force `print-color-adjust: exact` on the resume container to preserve OKLCH colors.
+  - Define `@page { margin: 18mm 16mm; }` and `break-inside: avoid` on experience/award rows.
+  - Add a manual smoke test step in the harness: print to PDF on each target browser and visually compare.
+
+### Issue #6 — Contact pipeline lacks a server-side rate-limit and message-size cap
+- **Severity**: **Medium**
+- **Location**: `docs/PRD.md` F008 / F009 + `domain/contact/contact-submission.schema.ts` reference in `PROJECT-STRUCTURE.md`
+- **Risk**: Turnstile catches bot traffic but does not protect against authenticated abuse (a single user mashing submit) or oversized payloads (a 10MB message would be valid by current schema). Resend free tier is hard-capped at 100 emails/day - sustained abuse drains quota.
+- **Improvement**:
+  - Add NFR: per-IP rate limit, e.g., 5 submissions / hour using Workers KV or Durable Objects.
+  - Add domain rule: `message.length <= 5000` (or similar) to `contact-submission.schema.ts`.
+  - On Resend send failure, the existing `mailto:` fallback (PRD already specifies) is the right design — explicitly capture this as an acceptance criterion (Issue #4).
+
+### Issue #7 — Satori OG hot-path budget unspecified, with no fallback for cold start
+- **Severity**: **Medium**
+- **Location**: `docs/PRD.md` F011, Tech Stack > Content Pipeline, `PROJECT-STRUCTURE.md` D5
+- **Risk**: Workers paid plan caps a single request at 30s CPU; the free plan caps at 10ms in some configurations. Satori + yoga.wasm + ttf load can exceed the budget on cold start, especially when the Asset Binding ttf is fetched for each request.
+- **Improvement**:
+  - Cache the rendered PNG: set `Cache-Control: public, max-age=31536000, immutable` on the resource route response (PRD currently does not specify caching).
+  - For the static-site-with-rare-changes case, prefer **build-time** PNG generation (run Satori during `react-router build`) and store in `public/og/<slug>.png`. The `og.*[.png].tsx` resource routes can fall back to runtime only when the static file is missing.
+  - Add an NFR: OG cold-start p95 < 1500ms; warm < 200ms.
+
+---
+
+## Minor Suggestions (Optional Improvements)
+
+### Suggestion #1 — Capture `lang="ko"` and OG locale explicitly
+- **Opportunity**: PRD says i18n is out of scope but `<html lang="...">` and `<meta property="og:locale" content="ko_KR">` should still be enforced.
+- **Expected effect**: SEO clarity for Korean engines (Naver in particular) and screen-reader correctness.
+- **Priority**: Low.
+
+### Suggestion #2 — Define the design-system port checklist
+- **Opportunity**: The "design source -> production" gap is mentioned but no concrete porting checklist exists. Consider listing each `proto/*.jsx` file and its target `app/presentation/components/*.tsx` location with the "what changes" delta (React 18 -> 19, IIFE -> ESM, `window.X` -> module imports).
+- **Expected effect**: Reduces ambiguity during the implementation phase; gives a clean unit of work for each PR.
+- **Priority**: Medium.
+
+### Suggestion #3 — Tighten the Search Index DoD
+- **Opportunity**: PRD says the index is built from velite collections; PROJECT-STRUCTURE D3 confirms `public/search-index.json`. Add: "index size budget < 100KB gzipped at MVP", "index excludes MDX body", "client lazy-fetches once per session".
+- **Expected effect**: Clear Red-phase tests for `build-search-index.service.ts`.
+- **Priority**: Low.
+
+### Suggestion #4 — Capture analytics + Turnstile under CSP
+- **Opportunity**: With Cloudflare Web Analytics + Turnstile + inline JSON-LD `<script>`, a CSP needs `script-src` allow-listed. Currently neither PRD nor PROJECT-STRUCTURE captures this.
+- **Expected effect**: Production-ready security headers from day one.
+- **Priority**: Medium.
+
+---
+
+## Final Verification Verdict
+
+### Chain of Thought Summary
+1. **Because** package.json and PRD's "Tech Stack (Latest Versions)" section line up exactly, and every external service claim (RR v7 + Workers, Tailwind v4 data-attribute variant, Satori standalone, Resend free tier, Turnstile siteverify, velite + Zod) is supported by official documentation [FACT]...
+2. **And** the PRD self-consistency (Feature -> Page -> Menu) and the cross-document consistency with PROJECT-STRUCTURE.md (CA 4-layer mapping, route file conventions, DI container approach) are both intact [INFERENCE]...
+3. **But** `CLAUDE.md` describes an Expo/React Native project that does not exist (Blocker), and the PRD is missing a Non-Functional Requirements section + per-feature Acceptance Criteria, which collide directly with TDD-First and Goal-Driven Execution [FACT]...
+4. **Therefore** the PRD's *content* is implementable as designed; the *surrounding documents* and a small set of testable-criteria gaps must be tightened before kicking off the harness pipeline.
+
+### Technical Verdict
+**Selected Verdict**: **Conditional Pass**
+
+**Verdict Basis**:
+1. [FACT] Stack versions and external services are verified and aligned.
+2. [FACT] PRD-internal cross-references are complete; PROJECT-STRUCTURE provides a coherent CA mapping.
+3. [FACT] `CLAUDE.md` is internally inconsistent with the rest of the repository — a Blocker for any pipeline run.
+4. [INFERENCE] Adding NFRs and Acceptance Criteria is the cheapest way to unlock TDD-First.
+5. **Therefore**: pass conditionally, fix Issue #1 first, then Issues #2-#4, then implement.
+
+### Confidence and Risk Levels
+- **Technical Confidence**: 8/10 (versions and external services solid; OG-on-Workers and PDF print are the soft spots)
+- **Implementation Complexity**: 5/10 (small surface area, standard patterns; Satori is the only sharp edge)
+- **External Dependency Risk**: 4/10 (Resend / Turnstile / Cloudflare Workers all are stable; velite is single-maintainer but mature for the use case)
+- **Overall Risk**: 4/10
+
+### Development Progression Recommendations
+1. **Immediate Resolution (before next pipeline run)**:
+   - Issue #1 — rewrite `CLAUDE.md` Commands and Notes to reflect the actual web stack.
+2. **Pre-Development Verification**:
+   - Issue #2 — author the NFR section.
+   - Issue #4 — add Acceptance Criteria to each Core feature (F001-F009, F016).
+   - Issue #3 — add an Assumptions Register or `[Resolve before: <phase>]` annotations.
+3. **Consider During Development**:
+   - Issue #5 — F003 PDF browser-matrix smoke test in CI or harness manual step.
+   - Issue #6 — Contact rate-limit + message size cap.
+   - Issue #7 — Satori caching + build-time fallback.
+4. **Continuous Review**:
+   - Velite, Satori, and Cloudflare Vite plugin minor releases (these are the youngest dependencies in this stack).
+   - Workers CPU budgets — re-validate Satori p95 numbers once real traffic begins.
+
+---
+
+## One-line Go / No-Go Decision
+
+**Conditional Go** — the PRD is technically implementable as designed; ship Issue #1 (CLAUDE.md realignment) and Issues #2-#4 (NFR + Acceptance Criteria + Assumptions resolution gates) **before** opening the first feature PR.
+
+---
+
+## Sources
+- [Cloudflare Workers / React Router framework guide](https://developers.cloudflare.com/workers/framework-guides/web-apps/react-router/)
+- [Cloudflare Vite plugin announcement](https://blog.cloudflare.com/introducing-the-cloudflare-vite-plugin/)
+- [React Router File Route Conventions](https://reactrouter.com/how-to/file-route-conventions)
+- [React Router Type Safety](https://reactrouter.com/explanation/type-safety)
+- [Tailwind CSS v4.0 release](https://tailwindcss.com/blog/tailwindcss-v4)
+- [Tailwind v4 Theme variables](https://tailwindcss.com/docs/theme)
+- [Tailwind v4.2 release notes (InfoQ)](https://www.infoq.com/news/2026/04/tailwind-css-4-2-webpack/)
+- [Custom themes in Tailwind v4 (data-theme)](https://dev.to/vrauuss_softwares/-create-custom-themes-in-tailwind-css-v4-custom-variant-12-2nf0)
+- [Satori standalone build (DeepWiki)](https://deepwiki.com/vercel/satori/2.4-text-rendering)
+- [Satori on Cloudflare Workers walkthrough](https://code.charliegleason.com/satori-vite-remix-cloudflare)
+- [Cloudflare Workers Static Assets Binding](https://developers.cloudflare.com/workers/static-assets/binding/)
+- [Resend new free tier](https://resend.com/blog/new-free-tier)
+- [Cloudflare Workers + Resend tutorial](https://developers.cloudflare.com/workers/tutorials/send-emails-with-resend/)
+- [Cloudflare Turnstile server-side validation](https://developers.cloudflare.com/turnstile/get-started/server-side-validation/)
+- [velite Introduction](https://velite.js.org/guide/introduction)
+- [velite MDX support](https://velite.js.org/guide/using-mdx)

--- a/docs/reports/roadmap-validation-2026-04-28.md
+++ b/docs/reports/roadmap-validation-2026-04-28.md
@@ -1,0 +1,282 @@
+# ROADMAP Validation Report: tkstarDev
+
+> **Validation Date**: 2026-04-28
+> **Validated Document**: `docs/ROADMAP.md` (572 lines, Phase 0~6, Task 001~022)
+> **Cross-checked Against**: `docs/PRD.md` (F001~F019 + AC + A001~A012), `docs/PROJECT-STRUCTURE.md` (CA 4-layer), `docs/reports/prd-validation-2026-04-28.md`, `CLAUDE.md`
+> **Platform**: Web (React Router v7 Framework + Cloudflare Workers SSR)
+> **Scale**: Small (1인 정적 사이트, DB 없음, 인증 없음)
+> **Validator**: roadmap-validator
+
+---
+
+## Validation Summary
+
+### Validation Path
+
+1. **File Collection** — 4개 문서 전부 읽음 (ROADMAP / PRD / PROJECT-STRUCTURE / PRD validation report)
+2. **Structure-First Analysis** — 7개 phase 모두 Skeleton-First + Inside-Out 준수
+3. **Task Decomposition** — 22 task 모두 PR 1개 단위 적정. 6개는 다소 큼 (003/004/008/014/017/019)이나 응집도 높아 OK
+4. **Dependency Verification** — 순환 없음. Inside-Out (Domain → Application → Infrastructure → Presentation) 준수
+5. **PRD Coverage** — F001~F019(F015 제외) 18개 = 100% 매핑. 11개 페이지 단위 모두 task에 존재
+6. **AC Mapping** — 18개 AC (F003×3, F008×4, F009×3, F011×3, F016×5) 모두 task에 명시
+7. **Assumption Resolution** — A001~A012 12개 모두 phase 게이트와 일치 (A003/A004는 더 이른 해소로 정합성 강화)
+8. **PR-only Workflow** — chore/feature/docs 분류 일관, CLAUDE.md 정책과 일치
+9. **PROJECT-STRUCTURE 정합성** — 모든 산출물 경로가 layer 정의와 일치 (단, `infrastructure/ratelimit/` 신규 모듈은 PROJECT-STRUCTURE.md에 미등록)
+10. **DoD 명확성** — 7개 phase 모두 명령어/테스트/AC 기준으로 측정 가능. "잘 동작" 류 모호 표현 없음
+
+### Confidence Distribution
+
+- **High Confidence** [FACT]: ~85% (ROADMAP 본문에서 직접 확인)
+- **Medium Confidence** [INFERENCE]: ~12% (의존 그래프 + Phase 묶음 합리성 추론)
+- **Low Confidence** [UNCERTAIN]: ~0%
+- **Issues Found** [MISSING/INCONSISTENT]: ~3% (7건, Blocker 0 / High 1 / Medium 4 / Low 2)
+
+---
+
+## Detailed Findings
+
+### Step 1: Structure-First Compliance
+
+[FACT] **Phase 순서**:
+- Phase 0 (Setup) → Phase 1 (Routing Skeleton + Domain + Theme) → Phase 2 (Content Pipeline) → Phase 3 (Core Pages) → Phase 4 (Forms + Palette) → Phase 5 (SEO/OG) → Phase 6 (Deploy)
+- Task 002 (CA 4-layer skeleton) → Task 004 (라우트 13개 placeholder) → Task 006 (Domain Zod schema) 순서로 골격이 기능보다 먼저.
+
+[FACT] **Inside-Out 검증**:
+- Domain (T006) ─→ Application Ports (T008) ─→ Infrastructure Repos (T008) ─→ Presentation routes (T010~T015): 정확히 안→밖.
+
+**준수 점수: 7/7 phase 정확하게 정렬됨.**
+
+### Step 2: Task 분해 품질
+
+| 카테고리 | 갯수 | 비고 |
+|---------|------|------|
+| 적정 크기 | 16 / 22 | T001/002/005/006/007/009/010/011/012/013/015/016/018/020/021/022 |
+| 다소 큼 (PR 1개로 가능) | 6 / 22 | T003 (Vite+RR7+Workers+Tailwind), T004 (라우트 13개+layout 2개), T008 (Ports+3repos+6services), T014 (Blog+Detail+RSS), T017 (Form+Turnstile+Resend+KV), T019 (Sitemap+Robots+meta×11+JSON-LD) |
+| 너무 작음 | 0 / 22 | — |
+
+[FACT] **모든 task에 다음이 명시됨**:
+- Task ID (T001~T022) ✅
+- Layer 매핑 (Domain/Application/Infrastructure/Presentation/Platform Adapter) ✅
+- 관련 Feature ID (F00X) ✅
+- 관련 AC ID (AC-F00X-N) ✅
+- 의존성 (blockedBy / blocks) ✅
+- 검증 방법 (명령어 / 테스트 / AC) ✅
+- 산출물 (파일 경로) ✅
+- PR 브랜치 명 ✅
+
+### Step 3: Dependency Order
+
+```
+T001 ─→ T002 ─→ T006 (Domain) ─┐
+       ↘                        ↓
+T001 ─→ T003 ─→ T004 (Routes)   T007 (velite) ─→ T008 (Ports/Repos/Services) ─→ T009 (DI)
+              ↘                                                                      ↓
+              T005 (Theme) ──────────────────────────────────────────────────────┤
+                                                                                     ↓
+                                          T010 ║ T011 ║ T012 ║ T013 ║ T014 ║ T015 (병렬)
+                                                                                     ↓
+                                                T016 (Cmd+K, T010 후) + T017 (Contact, T006/008/009)
+                                                                                     ↓
+                                                    T013/T014 → T018 (OG)
+                                                                                     ↓
+                                              T010~T015,T018 → T019 (SEO) → T020 → T021 → T022
+```
+
+[FACT] **순환 없음**, 병렬 가능 task가 명시 (`||` 표기).
+
+[INCONSISTENT] **사소한 의존성 누락**: T008의 `blockedBy`에 T002 누락. transitive로 보장되나 명시성 권장. (Issue #2)
+
+### Step 4: PRD Feature Coverage
+
+| Feature | 1차 Task | 매핑 |
+|---------|---------|------|
+| F001 Hero | T010 | ✅ |
+| F002 About | T011 | ✅ |
+| F003 PDF | T011 (+ AC-F003-1/2/3) | ✅ |
+| F004 Projects 목록 | T012 | ✅ |
+| F005 Project Case Study | T013 | ✅ |
+| F006 Blog 목록 | T014 | ✅ |
+| F007 Blog 상세 | T014 | ✅ |
+| F008 Contact Form | T017 (+ AC-F008-1/2/3/4) | ✅ |
+| F009 Turnstile | T017 (+ AC-F009-1/2/3) | ✅ |
+| F010 다크모드 | T005 | ✅ |
+| F011 SSR + 동적 OG | T018 (+ AC-F011-1/2/3) | ✅ |
+| F012 RSS | T014 | ✅ |
+| F013 Web Analytics | T020 | ✅ |
+| F014 앱 약관 | T015 | ✅ |
+| F015 (Removed) | — | ✅ 미할당 명시 |
+| F016 Cmd+K | T016 (+ AC-F016-1~5) | ✅ |
+| F017 Featured/Recent | T010 | ✅ |
+| F018 SEO Meta | T019 | ✅ |
+| F019 검색엔진 등록 | T020 | ✅ |
+
+[FACT] **F001~F019(F015 제외) 18개 = 100% coverage**. 누락된 Feature **없음**. 11개 페이지 단위(Home/About/Projects/ProjectDetail/Blog/BlogDetail/Contact/LegalIndex/AppTerms/AppPrivacy/NotFound) 모두 task에 존재.
+
+### Step 5: Acceptance Criteria 매핑
+
+[FACT] **AC를 가진 5개 Feature × 18개 AC 모두 매핑됨**:
+- AC-F003-1/2/3 → T011 line 252
+- AC-F008-1/2/3/4 → T017 line 350
+- AC-F009-1/2/3 → T017 line 350
+- AC-F011-1/2/3 → T018 line 388
+- AC-F016-1/2/3/4/5 → T016 line 332
+
+또한 T021 통합 QA에서 18개 AC 전수 회귀 매트릭스로 한 번 더 점검 (line 453).
+
+### Step 6: Assumptions Register 정합성
+
+[FACT] A001~A012 12개 모두 ROADMAP의 phase 게이트와 일치. A003/A004는 PRD 게이트(F014/F018-F019 PR)보다 더 이른 단계(Phase 1)에서 해소되도록 ROADMAP이 강화. A011/A012는 명시적 Post-MVP 분리.
+
+### Step 7: PR-only Workflow
+
+[FACT] 브랜치 명명 일관성:
+- chore: T001/002/003/021/022 (toolchain/QA/deploy)
+- feature: T004~T020 (F00X 기능 구현)
+- CLAUDE.md의 chore/* docs/* Plan/TDD 면제 정책 (line 64~65)과 ROADMAP 정책 매트릭스 (line 39~44) 일치.
+
+### Step 8: TDD-First 적용 가능성
+
+[FACT] T005/006/008/009/011/013/014/016/017/018/019는 자동 테스트 명시. T010/012/015는 "UI 표시 위주"로 자동 테스트 항목 부족 → **High severity Issue #1** (PRD 검증 리포트 Issue #4 잔여 영향).
+
+### Step 9: PROJECT-STRUCTURE.md 정합성
+
+[FACT] 모든 산출물 경로가 layer 정의와 일치. 다만 T017이 도입하는 `app/infrastructure/ratelimit/kv-rate-limiter.ts`는 PROJECT-STRUCTURE.md `app/infrastructure/` 트리에 미등록 → **Medium severity Issue #3**.
+
+### Step 10: DoD 명확성
+
+[FACT] 7개 phase의 진입 조건/완료 조건이 모두 명령어/테스트/AC 기준으로 측정 가능. "잘 동작", "작동 확인" 류 모호 표현 부재.
+
+---
+
+## Risk Items
+
+### High Severity
+
+#### Issue #1 — Task 010/012/015 자동 테스트 항목 부족 (TDD-First 약점)
+
+- **Severity**: High
+- **위치**: Phase 3 / T010 (Home), T012 (Projects List), T015 (Legal)
+- **재현 가능 근거**:
+  - ROADMAP line 241 (T010): "관련 AC: 없음 (Page-by-Page Key Features로 검증)"
+  - ROADMAP line 269 (T012): "관련 AC: 없음 (UI 표시 위주)"
+  - ROADMAP line 311 (T015): "관련 AC: 없음 (Page-by-Page Key Features + F018 차등 인덱싱은 Phase 5)"
+  - CLAUDE.md Core Principles `TDD-First`: "All implementations must be preceded by writing tests first"
+  - CLAUDE.md `Goal-Driven Execution`: "Reject weak criteria like 'make it work'"
+- **위험**: "UI 표시 위주" 문구는 Red-phase 테스트로 변환하기 어려움. 테스트 누락 시 Phase 3 정상 종료 판정이 흔들림.
+- **권장 수정안**:
+  - **T010**: 검증에 추가 — `Home loader가 getFeaturedProject + getRecentPosts(3)를 호출 (vitest mock)`, `RecentPostsList component가 3개 PostRow를 렌더 (RTL)`, `Featured 미존재 시 fallback 처리 검증`
+  - **T012**: 검증에 추가 — `Projects loader가 listProjects(tag?)를 호출`, `TagFilterChips 클릭 시 URLSearchParam 변경 (RTL + memoryRouter)`, `행 클릭 시 /projects/:slug 네비게이션 검증`
+  - **T015**: 검증에 추가 — `Legal Index loader가 listApps()를 호출`, `appCount === 0이면 Footer Legal 링크 미렌더 (RTL)`, `ChromeFreeLayout이 Topbar/Footer를 미렌더 + max-width 680px 적용 검증`
+
+### Medium Severity
+
+#### Issue #2 — Task 008 의존성에 Task 002 누락 (명시성)
+
+- **Severity**: Medium
+- **위치**: Phase 2 / T008
+- **재현 가능 근거**: ROADMAP line 189 `blockedBy: Task 006, Task 007`. T008 산출물(line 195~210)은 `app/application/content/`, `app/infrastructure/content/` 디렉토리를 사용하는데 그 디렉토리는 T002(line 71~84)에서 생성됨. T006의 `blockedBy: Task 002`(line 147)로 transitive 보장은 되나 명시성 부족.
+- **권장 수정안**: T008의 `blockedBy`를 `Task 002, Task 006, Task 007`로 보강.
+
+#### Issue #3 — `app/infrastructure/ratelimit/` 모듈이 PROJECT-STRUCTURE.md 미등록
+
+- **Severity**: Medium
+- **위치**: T017 산출물 line 366 `app/infrastructure/ratelimit/kv-rate-limiter.ts`
+- **재현 가능 근거**: PROJECT-STRUCTURE.md line 213~238의 `app/infrastructure/` 트리에 `ratelimit/` 모듈 부재. PROJECT-STRUCTURE.md "Cross-cutting Concerns Mapping" (line 549~560)에도 rate-limit 항목 없음. PRD 검증 리포트 Issue #6에서 contact rate-limit 추가 요구가 ROADMAP T017에 반영되었으나 PROJECT-STRUCTURE 갱신 누락.
+- **권장 수정안**: T017 PR에 PROJECT-STRUCTURE.md 업데이트 포함하거나, 별도 `docs/update-rate-limiter-module` 브랜치로 선행 PR. 추가 위치:
+  - PROJECT-STRUCTURE.md line 213~238 트리에 `├── ratelimit/` 항목
+  - line 549~560 Cross-cutting Concerns에 rate-limit 행 추가
+
+#### Issue #4 — Task 014 묶음 크기 (F006+F007+F012)
+
+- **Severity**: Medium (선택적 개선)
+- **위치**: Phase 3 / T014 (line 291~305)
+- **재현 가능 근거**: Blog Page + Blog Detail + RSS Resource Route + ShareTools + build-rss-feed.service + 테스트 = PR 1개. Blog 관련 파일 5개 + Application service + 테스트.
+- **위험**: PR 리뷰 부담 증가, 리뷰 중 부분 회귀 발생 가능.
+- **권장 수정안 (선택)**: T014a (Blog Page + Blog Detail) ─→ T014b (RSS Feed). 다만 1인 개발 + RSS가 Blog와 의미상 묶이므로 그대로 유지도 무방. **분할 의무는 아님**.
+
+#### Issue #5 — Task 017 KV namespace 사전 생성 단계 명시 부족
+
+- **Severity**: Medium
+- **위치**: T017 산출물 line 366, 371
+- **재현 가능 근거**: T017이 KV `RATE_LIMIT_KV` namespace를 사용하지만 검증 항목 line 351~357에 `wrangler kv namespace create` 사전 단계가 빠짐. Workers KV는 dashboard/CLI로 namespace를 먼저 만들고 ID를 wrangler.toml에 주입해야 동작.
+- **권장 수정안**: T017 검증에 추가 — `bunx wrangler kv namespace create RATE_LIMIT_KV` 실행 + 반환된 namespace ID를 `wrangler.toml`의 `[[kv_namespaces]]` 블록에 기록 + staging/production 환경별 분리.
+
+### Low Severity
+
+#### Issue #6 — Phase 6 진입 조건의 coverage threshold 수치 미명시
+
+- **Severity**: Low
+- **위치**: Phase 6 line 446 + T021 line 455
+- **재현 가능 근거**: "전체 F001~F019 자동 테스트 Green" + "`bun run test:coverage` 전체 100% Green + threshold 통과"는 명확하나 threshold 수치(lines/branches/functions %) 미명시.
+- **권장 수정안**: T021 검증에 vitest.config.ts coverage threshold 권장 수치 명시 (예: `lines: 80, branches: 75, functions: 80, statements: 80` — 1인 정적 사이트 기준).
+
+#### Issue #7 — Task 016 단축키 cross-platform 검증 명시 부족
+
+- **Severity**: Low
+- **위치**: T016 (line 328~344)
+- **재현 가능 근거**: AC-F016-1은 ⌘K(macOS) / Ctrl+K(Win/Linux) / `/` 단축키를 모두 요구. T016 검증 line 334은 "⌘K/Ctrl+K/`/` 단축키 토글" 단일 줄. macOS-Windows-Linux 3OS 차이를 vitest mock으로 어떻게 분기할지 미명시.
+- **권장 수정안**: T016 검증에 `navigator.platform` 또는 `event.metaKey` vs `event.ctrlKey` mock 분기 명시 + RTL `userEvent.keyboard('{Meta>}k{/Meta}')` / `'{Control>}k{/Control}'` 두 케이스 작성.
+
+---
+
+## Critical Issues (Must Fix Before Development)
+
+**없음.** Blocker 부재.
+
+---
+
+## Final Validation Verdict
+
+### Chain of Thought Summary
+
+1. **Because** ROADMAP은 PRD F001~F019(F015 제외) 18개 Feature와 18개 AC를 100% task에 매핑하고, A001~A012 12개 가정의 해소 게이트를 phase별로 명시했고, Structure-First + Inside-Out (Domain → Application → Infrastructure → Presentation) 순서를 정확히 준수했고, 22 task 모두 Layer/Feature/AC/의존성/검증/산출물/브랜치를 빠짐없이 기재했고 [FACT]...
+2. **And** PROJECT-STRUCTURE.md의 4-layer 구조와 모든 산출물 경로가 일치하며, 7개 phase의 DoD가 명령어·테스트·AC 기준으로 측정 가능하고, PR-only workflow + chore/feature/docs 분류가 CLAUDE.md 정책과 일관되며, 의존 그래프에 순환이 없고 병렬 가능 task가 명시되어 있고 [FACT]...
+3. **But** Task 010/012/015 3개 task가 "UI 표시 위주"로 자동 테스트 항목이 부족하고 (TDD-First 원칙 약점, High), `app/infrastructure/ratelimit/` 신규 모듈이 PROJECT-STRUCTURE.md에 미등록(Medium), Task 008의 T002 의존성 명시 누락(Medium), Task 017의 KV namespace 사전 생성 단계 미명시(Medium) 같은 보강 가능 항목이 있고 [FACT/INCONSISTENT]...
+4. **Therefore** ROADMAP은 **개발 준비 완료** 상태이며 첫 PR(Task 001 `chore/scaffold-bun-rr7-biome`) 작업 시작 가능. 단, **Task 010/012/015의 자동 테스트 항목 보강(Issue #1)은 Phase 3 진입 직전까지 반영**하면 TDD-First 원칙을 완전 충족.
+
+### Validation Verdict
+
+**Selected Verdict**: **CONDITIONAL_PASS** (마이너 이슈 존재하나 첫 PR 시작 가능)
+
+**Verdict Basis**:
+1. [FACT] PRD Feature/AC/Assumption 매핑 100% 달성
+2. [FACT] Structure-First + Inside-Out + Clean Architecture 4-layer 모두 정확히 준수
+3. [FACT] PR-only workflow + chore/feature 분류 CLAUDE.md 정책 일치
+4. [FACT] DoD 측정 가능, 모호 표현 없음
+5. [INCONSISTENT] Task 010/012/015 자동 테스트 약점 (Issue #1, High)이 유일한 즉각 보강 필요 항목
+6. [INFERENCE] 나머지 4개 Medium 이슈는 해당 task 진입 시점까지 반영하면 충분
+
+### Confidence Levels
+
+- **Structure Compliance**: 10/10
+- **Task Quality**: 8/10 (다소 큰 묶음 6개, T010/012/015 테스트 약점)
+- **PRD/AC Coverage**: 10/10
+- **Assumption Resolution**: 10/10
+- **PROJECT-STRUCTURE 정합성**: 9/10 (ratelimit 모듈 미등록)
+- **Dependency Ordering**: 9/10 (T008→T002 transitive)
+- **DoD 명확성**: 10/10
+- **Overall Readiness**: **9/10**
+
+### Recommended Actions
+
+**Immediate (Task 001 PR 시작 전)**:
+- 없음. **Task 001 (`chore/scaffold-bun-rr7-biome`) 작업 시작 가능**.
+
+**Phase 3 진입 직전 (Task 010 시작 전)**:
+1. **Issue #1 해결**: T010/012/015 검증 항목에 RTL component test + route loader test를 명시 (위 "권장 수정안" 참조).
+
+**해당 task PR에 포함**:
+2. **Issue #2**: T008 PR에서 `blockedBy: Task 002, Task 006, Task 007`로 ROADMAP 갱신.
+3. **Issue #3**: T017 PR에 PROJECT-STRUCTURE.md `ratelimit/` 모듈 추가 docs 변경 동봉 또는 선행 docs PR.
+4. **Issue #5**: T017 검증에 `wrangler kv namespace create RATE_LIMIT_KV` 사전 단계 추가.
+
+**Optional**:
+5. **Issue #4**: T014 분할 검토 (분할 의무 아님).
+6. **Issue #6**: T021 coverage threshold 수치 명시.
+7. **Issue #7**: T016 cross-platform 단축키 mock 분기 명시.
+
+---
+
+## One-line Go / No-Go Decision
+
+**GO** — ROADMAP은 100% PRD coverage + Structure-First/Inside-Out/CA 4-layer 준수 + 모든 AC·Assumption 매핑이 완료되어 **첫 PR(Task 001 `chore/scaffold-bun-rr7-biome`) 작업 시작 가능**. T010/012/015의 자동 테스트 항목 보강(Issue #1)은 Phase 3 진입 직전까지 반영하면 TDD-First 원칙 완전 충족.

--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -1,0 +1,111 @@
+# tkstarDev Task Index
+
+> 본 디렉토리는 [`docs/ROADMAP.md`](../ROADMAP.md)의 각 task를 PR-ready한 단위 작업서로 풀어둔 정본이다. 모든 task는 **Clean Architecture 4-layer + TDD-First + Inside-Out**을 준수하며, PR 1개 단위로 끝나도록 분량 조정되어 있다.
+>
+> - **Status 범례**: `Not Started` (기본) / `In Progress` (PR open) / `In Review` (review-ready) / `Done` (squash merge 완료)
+> - **TDD Cycle 면제**: `chore/*` / `docs/*` 브랜치에서는 Plan/TDD phase가 생략된다 (CLAUDE.md `chore/* docs/* 분류` 정책).
+
+## Phase 별 진행 현황
+
+| Phase | 범위 | Task 수 | 상태 |
+|-------|------|---------|------|
+| Phase 0 — Setup & Toolchain | T001 ~ T003 | 3 | ⬜ Not Started |
+| Phase 1 — Foundation | T004 ~ T006 | 3 | ⬜ Not Started |
+| Phase 2 — Content Pipeline | T007 ~ T009 | 3 | ⬜ Not Started |
+| Phase 3 — Core Pages UI | T010 ~ T013, T014a, T014b, T015 | 7 | ⬜ Not Started |
+| Phase 4 — Forms / Email | T016, T017-pre, T017 | 3 | ⬜ Not Started |
+| Phase 5 — SEO / OG / Indexing | T018 ~ T020 | 3 | ⬜ Not Started |
+| Phase 6 — Polish & Deploy | T021 ~ T022 | 2 | ⬜ Not Started |
+
+**총 24개 task** (T014 분리 + T017-pre 신규)
+
+## Task ID → 파일명 → 상태
+
+### Phase 0 — Setup & Toolchain
+
+| Task ID | Title | File | Branch | Status |
+|---------|-------|------|--------|--------|
+| T001 | 프로젝트 스캐폴딩 + Bun + TypeScript + Biome 셋업 | [T001-scaffold-bun-rr7-biome.md](./T001-scaffold-bun-rr7-biome.md) | `chore/scaffold-bun-rr7-biome` | Not Started |
+| T002 | Clean Architecture 4-layer 디렉토리 골격 + path alias | [T002-ca-4layer-skeleton.md](./T002-ca-4layer-skeleton.md) | `chore/ca-4layer-skeleton` | Not Started |
+| T003 | Vite + RR7 Framework + Cloudflare Workers + Tailwind v4 빌드 파이프라인 | [T003-vite-rr7-workers-tailwind-pipeline.md](./T003-vite-rr7-workers-tailwind-pipeline.md) | `chore/vite-rr7-workers-tailwind-pipeline` | Not Started |
+
+### Phase 1 — Foundation
+
+| Task ID | Title | File | Branch | Status |
+|---------|-------|------|--------|--------|
+| T004 | 라우트 스켈레톤 13개 + chrome / chrome-free 레이아웃 | [T004-route-skeleton.md](./T004-route-skeleton.md) | `feature/issue-N-route-skeleton` | Not Started |
+| T005 | 디자인 토큰 이식 + Tailwind v4 `@theme` + `[data-theme]` + 다크모드 (F010) | [T005-theme-tokens.md](./T005-theme-tokens.md) | `feature/issue-N-theme-tokens` | Not Started |
+| T006 | Domain Schemas — Project / Post / AppLegalDoc / ContactSubmission / ThemePreference | [T006-domain-schemas.md](./T006-domain-schemas.md) | `feature/issue-N-domain-schemas` | Not Started |
+
+### Phase 2 — Content Pipeline
+
+| Task ID | Title | File | Branch | Status |
+|---------|-------|------|--------|--------|
+| T007 | velite 설치 + 컬렉션 정의 + seed 콘텐츠 + shiki 코드블록 | [T007-velite-content-pipeline.md](./T007-velite-content-pipeline.md) | `feature/issue-N-velite-content-pipeline` | Not Started |
+| T008 | Application Ports + Content Repositories | [T008-content-ports-repos.md](./T008-content-ports-repos.md) | `feature/issue-N-content-ports-repos` | Not Started |
+| T009 | DI Container (Composition Root) + workers/app.ts wiring | [T009-di-container.md](./T009-di-container.md) | `feature/issue-N-di-container` | Not Started |
+
+### Phase 3 — Core Pages UI
+
+| Task ID | Title | File | Branch | Status |
+|---------|-------|------|--------|--------|
+| T010 | Home Page (F001 Hero + F017 Featured/Recent) | [T010-home-page.md](./T010-home-page.md) | `feature/issue-N-home-page` | Not Started |
+| T011 | About Page + F003 PDF 인쇄 스타일 | [T011-about-page-print.md](./T011-about-page-print.md) | `feature/issue-N-about-page-print` | Not Started |
+| T012 | Projects Page (F004 ls-style 행 리스트 + 태그 필터) | [T012-projects-list.md](./T012-projects-list.md) | `feature/issue-N-projects-list` | Not Started |
+| T013 | Project Detail Page (F005 + sticky sidebar + on-this-page TOC) | [T013-project-detail.md](./T013-project-detail.md) | `feature/issue-N-project-detail` | Not Started |
+| T014a | Blog Page (F006) — 목록 + 태그 필터 + RSS Resource Route (F012) | [T014a-blog-list-rss.md](./T014a-blog-list-rss.md) | `feature/issue-N-blog-list-rss` | Not Started |
+| T014b | Blog Detail Page (F007) — 본문 + sticky sidebar + share | [T014b-blog-detail.md](./T014b-blog-detail.md) | `feature/issue-N-blog-detail` | Not Started |
+| T015 | Legal Index + App Terms + App Privacy (F014, chrome-free) | [T015-legal-pages.md](./T015-legal-pages.md) | `feature/issue-N-legal-pages` | Not Started |
+
+### Phase 4 — Forms / Email
+
+| Task ID | Title | File | Branch | Status |
+|---------|-------|------|--------|--------|
+| T016 | F016 Cmd+K Command Palette (글로벌 검색 네비) | [T016-command-palette.md](./T016-command-palette.md) | `feature/issue-N-command-palette` | Not Started |
+| T017-pre | PROJECT-STRUCTURE.md 갱신 — `app/infrastructure/ratelimit/` 모듈 등록 | [T017-pre-update-project-structure-ratelimit.md](./T017-pre-update-project-structure-ratelimit.md) | `docs/update-project-structure-ratelimit` | Not Started |
+| T017 | Contact Form + Turnstile + Resend + 자동응답 메일 (F008 + F009) | [T017-contact-form-email.md](./T017-contact-form-email.md) | `feature/issue-N-contact-form-email` | Not Started |
+
+### Phase 5 — SEO / OG / Indexing
+
+| Task ID | Title | File | Branch | Status |
+|---------|-------|------|--------|--------|
+| T018 | F011 Satori 동적 OG 이미지 (Project + Blog) — Workers Asset Binding | [T018-satori-og.md](./T018-satori-og.md) | `feature/issue-N-satori-og` | Not Started |
+| T019 | F018 SEO Meta + Sitemap + Robots + JSON-LD (차등 인덱싱) | [T019-seo-sitemap-jsonld.md](./T019-seo-sitemap-jsonld.md) | `feature/issue-N-seo-sitemap-jsonld` | Not Started |
+| T020 | F019 검색엔진 등록 (Google + Naver) + Cloudflare Web Analytics (F013) | [T020-search-engine-verification.md](./T020-search-engine-verification.md) | `feature/issue-N-search-engine-verification` | Not Started |
+
+### Phase 6 — Polish & Deploy
+
+| Task ID | Title | File | Branch | Status |
+|---------|-------|------|--------|--------|
+| T021 | 통합 QA + Lighthouse + Axe 접근성 점검 + 모든 PRD AC 통과 매트릭스 | [T021-qa-pass-mvp.md](./T021-qa-pass-mvp.md) | `chore/qa-pass-mvp` | Not Started |
+| T022 | Cloudflare Workers 배포 + 도메인 연결 + Email Routing + 검색엔진 인증 완료 | [T022-deploy-production.md](./T022-deploy-production.md) | `chore/deploy-production` | Not Started |
+
+---
+
+## 작성 규칙
+
+각 task 파일은 다음 11개 섹션을 모두 포함한다:
+
+1. **Header** — Task ID, Title, Phase, Layer, Branch, 의존성, PRD Feature/AC, 예상 작업 시간, Status
+2. **Goal** — 1~2줄
+3. **Context** — Why / Phase 진입·완료 조건 / PRD 섹션 / PROJECT-STRUCTURE 디렉토리
+4. **Scope** — In Scope / Out of Scope
+5. **Acceptance Criteria** — Given-When-Then (PRD AC 보유 task는 PRD AC 인용 + task 단위 추가 AC)
+6. **Implementation Plan (TDD Cycle)** — Red → Green → Refactor (chore/docs는 `N/A`)
+7. **Files to Create / Modify** — 절대경로 + 1줄 책임 (Layer 그룹핑)
+8. **Verification Steps** — 자동 / 수동 / 측정
+9. **Dependencies** — Depends on / Blocks
+10. **Risks & Mitigations** (선택)
+11. **References** — PRD / PROJECT-STRUCTURE / design-system / 외부 docs
+
+## 진행 흐름
+
+```
+T001 → T002 → T003 → T004 → T005 → T006 → T007 → T008 → T009 →
+  ┌── T010 ┐
+  ├── T011 ┤
+  ├── T012 ├── T016 → T017-pre → T017 → T018 → T019 → T020 → T021 → T022
+  ├── T013 ┤
+  ├── T014a → T014b
+  └── T015 ┘
+```

--- a/docs/tasks/T001-scaffold-bun-rr7-biome.md
+++ b/docs/tasks/T001-scaffold-bun-rr7-biome.md
@@ -1,0 +1,99 @@
+# Task 001 — 프로젝트 스캐폴딩 + Bun + TypeScript + Biome 셋업
+
+| Field | Value |
+|-------|-------|
+| **Task ID** | T001 |
+| **Phase** | Phase 0 — Setup & Toolchain |
+| **Layer** | 전 layer (인프라성) |
+| **Branch** | `chore/scaffold-bun-rr7-biome` |
+| **Depends on** | none |
+| **Blocks** | T002, T003 |
+| **PRD Features** | — (toolchain) |
+| **PRD AC** | — |
+| **예상 작업 시간** | 0.5d |
+| **Status** | Not Started |
+
+## Goal
+빈 git 저장소에 Bun + TypeScript + Biome 기반의 빈 프로젝트 셸을 깔아, 이후 모든 phase의 진입 조건인 `bun --version` / `bun run typecheck` / `bun run lint` / `bun run format`을 무오류 통과시킨다.
+
+## Context
+- **Why**: 모든 후속 task는 이 셸 위에서 동작한다. CLAUDE.md `Tech Stack`에 명시된 bun + TypeScript + Biome 조합을 가장 먼저 가동시켜 toolchain 일관성을 확보한다.
+- **Phase 진입/완료 연결**: Phase 0의 첫 task. 이 task가 Done이 되어야 T002/T003이 시작 가능.
+- **관련 PRD 섹션**: PRD `Tech Stack — Build / Dev / Quality`, `Package Management`
+- **관련 PROJECT-STRUCTURE 디렉토리**: 루트(`package.json`, `tsconfig.json`, `biome.json`, `.gitignore`)
+
+## Scope
+
+### In Scope
+- `package.json` — 핵심 의존성 + scripts (`typecheck`, `lint`, `format`, `test` placeholder) 정의
+- `tsconfig.json` / `tsconfig.app.json` — strict 모드 + path alias `~/*` → `./app/*`
+- `biome.json` — Biome 2.4.13 lint + format 룰
+- `.gitignore` 보강 — `.velite/`, `.react-router/`, `node_modules/`, `dist/`, `.wrangler/`
+- `bun.lock` 생성
+
+### Out of Scope
+- React Router / Vite / Cloudflare Workers 설정 (T003)
+- CA 4-layer 디렉토리 생성 (T002)
+- 도메인 스키마 / 라우트 / 콘텐츠 (Phase 1+ task)
+
+## Acceptance Criteria
+- [ ] `bun --version`이 1.x 출력
+- [ ] `bun install` 후 `bun.lock` 생성됨
+- [ ] `bun run typecheck` 무오류 통과 (빈 프로젝트라도 tsc가 path alias 인식)
+- [ ] `bun run lint`가 Biome 룰로 동작 (`No files to check.`도 OK)
+- [ ] `bun run format`이 Biome formatter 호출
+- [ ] `.gitignore`에 5개 항목(`.velite/`, `.react-router/`, `node_modules/`, `dist/`, `.wrangler/`) 모두 존재
+
+## Implementation Plan (TDD Cycle)
+**N/A — chore branch policy.** `chore/*` 브랜치는 CLAUDE.md 정책상 Plan/TDD phase가 면제되며, PR 리뷰가 안전망. 단, 위 AC는 모두 명령어 수준에서 검증 가능해야 한다.
+
+## Files to Create / Modify
+
+### Config
+| Path | Responsibility |
+|------|---------------|
+| `/Users/tkstart/Desktop/project/tkstar-dev/package.json` | 의존성 매니페스트 + scripts. dependencies: `react@19.2.4`, `react-dom@19.2.4`, `react-router@7.14.0`. devDependencies: `typescript@5.9.3`, `@biomejs/biome@2.4.13` |
+| `/Users/tkstart/Desktop/project/tkstar-dev/tsconfig.json` | TS 진입점 — `extends` / `references` 분리 (`tsconfig.app.json` + `tsconfig.node.json`로 분기 가능) |
+| `/Users/tkstart/Desktop/project/tkstar-dev/tsconfig.app.json` | 앱 코드용 — `strict: true`, `paths: { "~/*": ["./app/*"] }`, `moduleResolution: "bundler"` |
+| `/Users/tkstart/Desktop/project/tkstar-dev/biome.json` | Biome lint + format 설정. `formatter.indentStyle = "tab"`(또는 프로젝트 합의), `linter.rules.recommended = true` |
+| `/Users/tkstart/Desktop/project/tkstar-dev/.gitignore` | 기존 항목에 `.velite/`, `.react-router/`, `node_modules/`, `dist/`, `.wrangler/` 추가 |
+
+### Generated (도구가 생성)
+| Path | Responsibility |
+|------|---------------|
+| `/Users/tkstart/Desktop/project/tkstar-dev/bun.lock` | bun이 자동 생성 |
+
+## Verification Steps
+
+### 자동
+- `bun --version` → `1.x.x` 출력
+- `bun install` → `bun.lock` 생성, `node_modules/` 채워짐
+- `bun run typecheck` → exit code 0
+- `bun run lint` → exit code 0
+- `bun run format` → exit code 0
+
+### 수동
+- 없음 (toolchain 검증)
+
+### 측정
+- 없음
+
+## Dependencies
+- **Depends on**: none
+- **Blocks**: T002 (CA 4-layer는 path alias가 필요), T003 (Vite/RR7은 tsconfig + bun scripts 위에서 동작)
+
+## Risks & Mitigations
+- **Risk**: bun + Biome + TypeScript 5.9 조합의 path alias 인식 차이.
+  - **Mitigation**: T001 PR에서 빈 `app/index.ts`를 임시 추가하여 `import "~/index"` 가짜 경로로 path alias 동작을 1회 검증한 뒤 제거.
+
+## References
+- CLAUDE.md `Tech Stack` (bun / TypeScript / Biome)
+- CLAUDE.md `Git Integration` — `chore/*` 브랜치 정책
+- ROADMAP.md `Phase 0` Task 001
+- [Biome v2 docs](https://biomejs.dev/) — config schema
+- [TypeScript 5.9 path mapping](https://www.typescriptlang.org/docs/handbook/module-resolution.html)
+
+## Change History
+| Date | Changes | Author |
+|------|---------|--------|
+| - | - | - |

--- a/docs/tasks/T002-ca-4layer-skeleton.md
+++ b/docs/tasks/T002-ca-4layer-skeleton.md
@@ -1,0 +1,136 @@
+# Task 002 — Clean Architecture 4-layer 디렉토리 골격 + path alias
+
+| Field | Value |
+|-------|-------|
+| **Task ID** | T002 |
+| **Phase** | Phase 0 — Setup & Toolchain |
+| **Layer** | 전 layer (구조) |
+| **Branch** | `chore/ca-4layer-skeleton` |
+| **Depends on** | T001 |
+| **Blocks** | T004, T006, T007, T008, T009 |
+| **PRD Features** | — (구조) |
+| **PRD AC** | — |
+| **예상 작업 시간** | 0.5d |
+| **Status** | Not Started |
+
+## Goal
+PROJECT-STRUCTURE.md에 명시된 Clean Architecture 4-layer(`app/{domain,application,infrastructure,presentation}/`) 디렉토리 골격을 빈 placeholder와 함께 생성하고, path alias가 모든 layer에 정상 동작하도록 한다.
+
+## Context
+- **Why**: 후속 task가 새 모듈을 추가할 때마다 위치를 고민하지 않도록 구조를 미리 확정. Domain ← Application ← Infrastructure / Presentation ← Application의 의존성 방향을 README 또는 ESLint(Biome) 규칙으로 문서화.
+- **Phase 진입/완료 연결**: T001 완료 후 즉시 시작. T002 완료 시 Phase 1의 Domain 스키마(T006), Phase 2의 ports/repos(T008)가 적절한 디렉토리에 들어갈 수 있다.
+- **관련 PRD 섹션**: 없음 (구조)
+- **관련 PROJECT-STRUCTURE 디렉토리**: `app/domain/{project,post,legal,contact,theme}/`, `app/application/{content,contact,search,og,feed,seo}/{ports,services}/`, `app/infrastructure/{config,content,email,captcha,og,search,analytics}/`, `app/presentation/{components,hooks,lib,layouts,routes}/`, `test/{fixtures,utils}/`
+
+## Scope
+
+### In Scope
+- 4-layer 최상위 디렉토리 생성 + 각 도메인 sub-디렉토리 생성
+- 각 디렉토리에 `index.ts` placeholder (`export {};`) 또는 `.gitkeep` 파일 생성 (git이 빈 디렉토리를 추적하지 않으므로)
+- `tsconfig.app.json`에 4-layer path alias 보강 (`~/domain/*`, `~/application/*`, `~/infrastructure/*`, `~/presentation/*`)
+- `app/README.md`에 의존성 방향 명시 (Domain ← Application ← Infrastructure / Presentation ← Application)
+
+### Out of Scope
+- 실제 구현(`*.entity.ts`, `*.service.ts` 등) — 후속 task
+- 라우트 파일(`app/presentation/routes/*.tsx`) — T004
+- `velite.config.ts` / `vite.config.ts` — T003/T007
+
+## Acceptance Criteria
+- [ ] `app/domain/{project,post,legal,contact,theme}/` 디렉토리가 모두 존재 (각각 `.gitkeep` 또는 `index.ts`)
+- [ ] `app/application/{content,contact,search,og,feed,seo}/{ports,services}/` 디렉토리가 모두 존재
+- [ ] `app/infrastructure/{config,content,email,captcha,og,search,analytics}/` 디렉토리가 모두 존재
+- [ ] `app/presentation/{components,hooks,lib,layouts,routes}/` 디렉토리가 모두 존재
+- [ ] `test/{fixtures,utils}/` 디렉토리가 존재
+- [ ] `bun run typecheck`가 path alias `~/domain/*` 등을 모두 인식
+- [ ] `app/README.md`에 의존성 방향이 1줄 이상으로 문서화
+
+## Implementation Plan (TDD Cycle)
+**N/A — chore branch policy.** 디렉토리 구조 자체는 테스트 대상이 아님. `bun run typecheck` 통과로 path alias 정합성을 검증.
+
+## Files to Create / Modify
+
+### Domain (5 sub-domains)
+| Path | Responsibility |
+|------|---------------|
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/domain/project/.gitkeep` | placeholder |
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/domain/post/.gitkeep` | placeholder |
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/domain/legal/.gitkeep` | placeholder |
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/domain/contact/.gitkeep` | placeholder |
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/domain/theme/.gitkeep` | placeholder |
+
+### Application (6 sub-domains × 2 sub-dirs)
+| Path | Responsibility |
+|------|---------------|
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/application/content/{ports,services}/.gitkeep` | placeholder |
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/application/contact/{ports,services}/.gitkeep` | placeholder |
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/application/search/services/.gitkeep` | placeholder |
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/application/og/{ports,services}/.gitkeep` | placeholder |
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/application/feed/services/.gitkeep` | placeholder |
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/application/seo/services/.gitkeep` | placeholder |
+
+### Infrastructure (7 modules)
+| Path | Responsibility |
+|------|---------------|
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/infrastructure/config/.gitkeep` | placeholder |
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/infrastructure/content/.gitkeep` | placeholder |
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/infrastructure/email/.gitkeep` | placeholder |
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/infrastructure/captcha/.gitkeep` | placeholder |
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/infrastructure/og/.gitkeep` | placeholder |
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/infrastructure/search/.gitkeep` | placeholder |
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/infrastructure/analytics/.gitkeep` | placeholder |
+
+### Presentation
+| Path | Responsibility |
+|------|---------------|
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/presentation/components/.gitkeep` | placeholder |
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/presentation/hooks/.gitkeep` | placeholder |
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/presentation/lib/.gitkeep` | placeholder |
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/presentation/layouts/.gitkeep` | placeholder |
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/presentation/routes/.gitkeep` | placeholder (T004에서 채움) |
+
+### Test Utils
+| Path | Responsibility |
+|------|---------------|
+| `/Users/tkstart/Desktop/project/tkstar-dev/test/fixtures/.gitkeep` | placeholder |
+| `/Users/tkstart/Desktop/project/tkstar-dev/test/utils/.gitkeep` | placeholder |
+
+### Config (수정)
+| Path | Change |
+|------|--------|
+| `/Users/tkstart/Desktop/project/tkstar-dev/tsconfig.app.json` | `paths`에 `~/domain/*`, `~/application/*`, `~/infrastructure/*`, `~/presentation/*`, `#content/*` 추가 |
+
+### Docs
+| Path | Responsibility |
+|------|---------------|
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/README.md` | 의존성 방향 문서화 (`Domain ← Application ← Infrastructure / Presentation ← Application`) — 4-layer rule 한 페이지 요약 |
+
+## Verification Steps
+
+### 자동
+- `bun run typecheck` → exit code 0
+- `find app -type d`로 4-layer 구조 확인
+- 임시 테스트 파일(`/tmp/import-test.ts`)에서 `import "~/domain/project"` / `import "~/infrastructure/config"` 등 4종 path alias가 컴파일러에 의해 resolution됨
+
+### 수동
+- 없음
+
+### 측정
+- 없음
+
+## Dependencies
+- **Depends on**: T001 (path alias가 동작해야 함)
+- **Blocks**: T004 (라우트 디렉토리 사용), T006 (Domain 디렉토리 사용), T007 (Infrastructure content 디렉토리 사용), T008 (Application/Infrastructure 디렉토리 사용), T009 (Infrastructure config 사용)
+
+## Risks & Mitigations
+- **Risk**: `.gitkeep` 대신 `index.ts` 생성 시 빈 export로 인한 lint 경고 발생 가능.
+  - **Mitigation**: `.gitkeep`을 채택. Biome `linter.includes`에서 `.gitkeep` 제외.
+
+## References
+- PROJECT-STRUCTURE.md `app/ Directory (Core Application)` (line 91~)
+- PROJECT-STRUCTURE.md `Dependency Direction Rules` (line 511~)
+- ROADMAP.md `Phase 0` Task 002
+
+## Change History
+| Date | Changes | Author |
+|------|---------|--------|
+| - | - | - |

--- a/docs/tasks/T003-vite-rr7-workers-tailwind-pipeline.md
+++ b/docs/tasks/T003-vite-rr7-workers-tailwind-pipeline.md
@@ -1,0 +1,136 @@
+# Task 003 — Vite + React Router v7 Framework + Cloudflare Workers + Tailwind v4 빌드 파이프라인
+
+| Field | Value |
+|-------|-------|
+| **Task ID** | T003 |
+| **Phase** | Phase 0 — Setup & Toolchain |
+| **Layer** | Platform Adapter (`workers/`) + Presentation 진입점 (`app/root.tsx`, `app/entry.*.tsx`) |
+| **Branch** | `chore/vite-rr7-workers-tailwind-pipeline` |
+| **Depends on** | T001 |
+| **Blocks** | T004, T005, T016 |
+| **PRD Features** | — (toolchain) |
+| **PRD AC** | — |
+| **예상 작업 시간** | 1d |
+| **Status** | Not Started |
+
+## Goal
+Vite 8 + React Router v7 Framework mode + Cloudflare Workers + Tailwind v4 + Vitest를 모두 묶은 빌드/개발 파이프라인을 가동시켜, `bun run dev`/`bunx wrangler dev`로 빈 root 페이지가 SSR 응답하도록 한다. Vitest coverage threshold도 이 단계에서 확정한다.
+
+## Context
+- **Why**: 모든 후속 페이지·기능이 이 파이프라인 위에서 동작. SSR + Edge Runtime + Tailwind v4 native(`oklch`, `@theme`, `@variant dark`) + Vitest 테스트 환경을 한꺼번에 가동해야 후속 PR이 자기 콘텐츠에만 집중 가능.
+- **Phase 진입/완료 연결**: T002 directory + T003 pipeline이 모두 Done이어야 Phase 1(T004 Routes / T005 Theme / T006 Domain)이 시작 가능.
+- **관련 PRD 섹션**: PRD `Tech Stack — Frontend Framework`, `Styling & UI`, `Hosting / Edge`, `Build / Dev / Quality`
+- **관련 PROJECT-STRUCTURE 디렉토리**: 루트(`vite.config.ts`, `react-router.config.ts`, `wrangler.toml`, `vitest.config.ts`), `workers/app.ts`, `app/{root.tsx, routes.ts, entry.server.tsx, entry.client.tsx, app.css, env.d.ts}`, `app/presentation/routes/_index.tsx`(빈 placeholder)
+
+## Scope
+
+### In Scope
+- `vite.config.ts` — `@cloudflare/vite-plugin 1.33.2`, `@tailwindcss/vite 4.2.2`, `@vitejs/plugin-react 6.0.1`
+- `react-router.config.ts` — `ssr: true`
+- `wrangler.toml` — `name`, `main`, `compatibility_date = "2026-04-01"`, `[assets] binding = "ASSETS" directory = "./public"`
+- `workers/app.ts` — fetch handler 스텁 (React Router request handler 호출 + `getLoadContext` placeholder)
+- `app/root.tsx` / `app/entry.server.tsx` / `app/entry.client.tsx` — RR7 진입점 최소 동작본 (`isbot` 분기 + `renderToReadableStream`)
+- `app/routes.ts` — `flatRoutes({ rootDirectory: "presentation/routes" })`
+- `app/presentation/routes/_index.tsx` — 빈 placeholder
+- `app/app.css` — Tailwind v4 진입점 (`@import "tailwindcss"` + 빈 `@theme {}`)
+- `app/env.d.ts` — 클라이언트 환경변수 타입 + RR7 typegen reference
+- `vitest.config.ts` — jsdom env + coverage threshold (`lines: 80`, `branches: 75`, `functions: 80`, `statements: 80`) + 제외 경로
+
+### Out of Scope
+- 디자인 토큰 / 다크모드 (T005)
+- 라우트 13개 (T004)
+- Domain 스키마 (T006)
+- velite (T007)
+
+## Acceptance Criteria
+- [ ] `bun run dev` Vite dev server가 부팅되고 `/`에 접속 시 빈 placeholder가 렌더
+- [ ] `bunx wrangler dev`가 Workers dev 서버를 띄우고 `curl http://localhost:8787`이 SSR HTML 응답
+- [ ] `bun run typecheck` 통과 (RR7 typegen `.react-router/types/*` 생성)
+- [ ] `bun run lint` 통과
+- [ ] `bun run test`가 빈 테스트 셋에서도 0 exit
+- [ ] `bun run test:coverage` 실행 시 coverage threshold 설정값 (lines 80 / branches 75 / functions 80 / statements 80)이 `vitest.config.ts`에 명시되어 있고, 빈 셋에서도 리포트 생성
+
+## Implementation Plan (TDD Cycle)
+**N/A — chore branch policy.** 빌드 파이프라인 자체는 TDD 대상 아님. 단, Vitest는 이 단계에서 가동시켜 두어야 후속 task가 Red phase부터 진행 가능.
+
+다만 가동 검증을 위해 1개 sanity test를 추가:
+- `app/__tests__/sanity.test.ts` — `expect(1 + 1).toBe(2)`로 Vitest jsdom 환경 기동 자체 검증
+
+## Files to Create / Modify
+
+### Build / Bundler Config
+| Path | Responsibility |
+|------|---------------|
+| `/Users/tkstart/Desktop/project/tkstar-dev/vite.config.ts` | Vite + RR7 + Cloudflare + Tailwind v4 + React 플러그인 조합 |
+| `/Users/tkstart/Desktop/project/tkstar-dev/react-router.config.ts` | `ssr: true` (정적 콘텐츠도 SEO/OG 위해 SSR) |
+| `/Users/tkstart/Desktop/project/tkstar-dev/wrangler.toml` | `name = "tkstar-dev"`, `main = "workers/app.ts"`, `compatibility_date = "2026-04-01"`, `[assets] binding = "ASSETS" directory = "./public"` |
+| `/Users/tkstart/Desktop/project/tkstar-dev/vitest.config.ts` | jsdom env, `setupFiles`(`@testing-library/jest-dom` 자동 매처), coverage `provider = "v8"` + thresholds (`lines: 80, branches: 75, functions: 80, statements: 80`), 제외 경로 (`**/*.config.*`, `**/__tests__/**`, `**/*.d.ts`, `workers/app.ts`, `app/entry.{server,client}.tsx`) |
+
+### Workers Entry
+| Path | Responsibility |
+|------|---------------|
+| `/Users/tkstart/Desktop/project/tkstar-dev/workers/app.ts` | `export default { fetch: createRequestHandler({ build, getLoadContext: () => ({ container: null }) }) }` 스텁. T009에서 container 채움 |
+
+### App Entry
+| Path | Responsibility |
+|------|---------------|
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/root.tsx` | `<html><head><Meta /><Links /></head><body><Outlet /><Scripts /></body></html>` 최소형 |
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/entry.server.tsx` | `isbot(request.headers.get("user-agent"))` 분기 + `renderToReadableStream` (Workers 친화) |
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/entry.client.tsx` | `hydrateRoot(document, <HydratedRouter />)` |
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/routes.ts` | `flatRoutes({ rootDirectory: "presentation/routes" }) satisfies RouteConfig` |
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/app.css` | `@import "tailwindcss";` + 빈 `@theme {}` (T005에서 토큰 채움) |
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/env.d.ts` | `/// <reference types="vite/client" />` + `/// <reference types="../.react-router/types/+register" />` |
+
+### Presentation Routes (placeholder)
+| Path | Responsibility |
+|------|---------------|
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/presentation/routes/_index.tsx` | 빈 placeholder — `export default function Index() { return <h1>tkstar.dev — coming soon</h1>; }` |
+
+### Sanity Test
+| Path | Responsibility |
+|------|---------------|
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/__tests__/sanity.test.ts` | Vitest jsdom 환경 기동 검증용 1줄 테스트 |
+
+### package.json scripts (수정)
+| Path | Change |
+|------|--------|
+| `/Users/tkstart/Desktop/project/tkstar-dev/package.json` | scripts에 `dev: "react-router dev"`, `build: "react-router build"`, `start: "wrangler dev"`, `typecheck: "tsc -b"`, `lint: "biome check ."`, `format: "biome format --write ."`, `test: "vitest run"`, `test:watch: "vitest"`, `test:coverage: "vitest run --coverage"` 추가 |
+
+## Verification Steps
+
+### 자동
+- `bun install` 완료 → `node_modules/{vite, react-router, @cloudflare/vite-plugin, @tailwindcss/vite, vitest, jsdom, @testing-library/react}` 모두 존재
+- `bun run typecheck` 통과 (typegen 디렉토리 `.react-router/types/` 생성)
+- `bun run test` → sanity test 1개 pass
+- `bun run test:coverage` → 리포트 생성 + threshold 조건 충족
+
+### 수동
+- `bun run dev` → 브라우저에서 `http://localhost:5173/` 접속 시 placeholder 렌더
+- `bunx wrangler dev` → `http://localhost:8787/` 접속 시 SSR HTML 반환 (HTML 소스에 placeholder 텍스트 포함)
+
+### 측정
+- 없음 (성능 측정은 T021)
+
+## Dependencies
+- **Depends on**: T001
+- **Blocks**: T004 (라우트 13개 추가), T005 (Tailwind v4 토큰 / `@theme`), T016 (Cmd+K palette는 root.tsx 마운트)
+
+## Risks & Mitigations
+- **Risk**: `@cloudflare/vite-plugin 1.33.2`와 RR7 7.14.0 + Tailwind v4의 plugin 순서가 잘못될 경우 빌드 실패.
+  - **Mitigation**: vite.config.ts plugin 배열 순서를 `[react(), reactRouter(), cloudflare(), tailwind()]` 순으로 시작 → 실패 시 한 단계씩 swap. 공식 RR7 + Cloudflare 템플릿(`create-react-router --template remix-run/react-router-templates/cloudflare`)을 참조해 모범 순서 확정.
+- **Risk**: Workers의 `compatibility_date`가 너무 오래되면 `URL.canParse` 등 일부 API 미지원.
+  - **Mitigation**: `2026-04-01`로 충분히 최신 설정.
+
+## References
+- PRD `Tech Stack — Frontend Framework / Styling & UI / Hosting`
+- PROJECT-STRUCTURE.md `workers/ Directory (Cloudflare Workers Entry)` (line 357~)
+- PROJECT-STRUCTURE.md `D1. 라우트 디렉토리` (line 568~)
+- ROADMAP.md `Phase 0` Task 003
+- [React Router v7 Cloudflare Workers Guide](https://reactrouter.com/start/framework/deploying)
+- [Tailwind v4 `@theme` 블록](https://tailwindcss.com/docs/theme)
+- [Cloudflare Vite Plugin](https://developers.cloudflare.com/workers/vite-plugin/)
+
+## Change History
+| Date | Changes | Author |
+|------|---------|--------|
+| - | - | - |

--- a/docs/tasks/T004-route-skeleton.md
+++ b/docs/tasks/T004-route-skeleton.md
@@ -1,0 +1,140 @@
+# Task 004 — 라우트 스켈레톤 13개 + chrome / chrome-free 레이아웃
+
+| Field | Value |
+|-------|-------|
+| **Task ID** | T004 |
+| **Phase** | Phase 1 — Foundation |
+| **Layer** | Presentation (`routes/` + `layouts/`) |
+| **Branch** | `feature/issue-N-route-skeleton` |
+| **Depends on** | T002, T003 |
+| **Blocks** | T010, T011, T012, T013, T014a, T014b, T015 |
+| **PRD Features** | F014 (chrome-free), F018/F019 (root layout meta 자리), Not Found Fallback (splat) |
+| **PRD AC** | — (라우트 placeholder 단계) |
+| **예상 작업 시간** | 1d |
+| **Status** | Not Started |
+
+## Goal
+PRD의 모든 라우트 13개에 빈 placeholder 모듈을 깔고, chrome / chrome-free 두 레이아웃을 도입하여 후속 페이지 task가 콘텐츠에만 집중할 수 있게 한다. splat(`$.tsx`) 라우트로 Not Found Fallback의 위치를 확정 (가정 A004 해소).
+
+## Context
+- **Why**: 페이지 task(T010~T015)는 모두 빈 라우트 파일을 받아서 콘텐츠를 채워 넣는 형식이어야 PR 단위가 작아진다. 또한 chrome-free 레이아웃은 F014(앱 약관)와 일반 페이지의 시각적 격리를 layout 컴포넌트 수준에서 미리 분리해야 후속 PR에서 chrome on/off 토글이 깨끗.
+- **Phase 진입/완료 연결**: T003(Vite/RR7 파이프라인)이 완료되어 typegen이 동작하면 즉시 시작. T004 완료 후 T010~T015 페이지 task들이 병렬로 시작 가능.
+- **관련 PRD 섹션**: `Menu Structure`, `Page-by-Page Detailed Features` 11개 페이지, `Not Found Fallback`
+- **관련 PROJECT-STRUCTURE 디렉토리**: `app/presentation/routes/`, `app/presentation/layouts/`
+
+## Scope
+
+### In Scope
+- 13개 라우트 placeholder 파일 생성 (각 파일은 빈 컴포넌트 + `meta` placeholder export만)
+- 5개 resource route placeholder (`rss[.xml].tsx`, `sitemap[.xml].tsx`, `robots[.txt].tsx`, `og.projects.$slug[.png].tsx`, `og.blog.$slug[.png].tsx`) — loader 본체는 후속 task가 채움, 현재는 빈 200 응답
+- splat 라우트 `$.tsx` — 터미널 메타포 `cd: no such route: <path>` placeholder
+- `<ChromeLayout />` / `<ChromeFreeLayout />` 컴포넌트 골격
+- `app/root.tsx`에 layout 분기 placeholder (URL `/legal/[app]/(terms|privacy)`이면 `<ChromeFreeLayout />`, 그 외 `<ChromeLayout />`)
+
+### Out of Scope
+- Topbar/Footer/ThemeToggle 본체 (T005)
+- 페이지별 콘텐츠/loader 본체 (T010~T015)
+- 페이지별 meta export (T019)
+- Resource route 실제 응답 (RSS는 T014a, OG는 T018, Sitemap/Robots는 T019)
+
+## Acceptance Criteria
+- [ ] `wrangler dev`에서 다음 13개 URL 직접 입력 시 모두 placeholder 응답 (404 아님): `/`, `/about`, `/projects`, `/projects/foo`, `/blog`, `/blog/foo`, `/contact`, `/legal`, `/legal/moai/terms`, `/legal/moai/privacy`, `/rss.xml`, `/sitemap.xml`, `/robots.txt`
+- [ ] 2개 OG resource route URL (`/og/projects/foo.png`, `/og/blog/foo.png`)이 200 응답 (placeholder)
+- [ ] 미존재 경로(`/random-not-exist`) 접속 시 splat이 동작하여 터미널 메타포 placeholder 렌더 (404 페이지가 아님)
+- [ ] `/legal/moai/terms`, `/legal/moai/privacy`만 chrome-free 레이아웃(임시 div로 래핑된) 사용. 나머지는 chrome 레이아웃 (Topbar/Footer placeholder slot 노출)
+- [ ] `bun run typecheck` 통과 (RR7 typegen `.react-router/types/`가 모든 라우트 모듈에 대해 생성)
+- [ ] `bun run lint` 통과
+
+## Implementation Plan (TDD Cycle)
+
+### Red
+- `app/presentation/layouts/__tests__/ChromeFreeLayout.test.tsx`
+  - `expect(<ChromeFreeLayout><p>body</p></ChromeFreeLayout>` rendered DOM): `<header>`, `<footer>` 미렌더 / 자식 `<p>body</p>`만 렌더 / 컨테이너 `max-width` style 또는 className 적용
+- `app/presentation/layouts/__tests__/ChromeLayout.test.tsx`
+  - `<ChromeLayout>` 자식 콘텐츠가 Topbar slot과 Footer slot 사이에 렌더 (현재는 placeholder div)
+
+### Green
+- `app/presentation/layouts/ChromeFreeLayout.tsx` — `<div className="legal-container">{children}</div>` (max-width 680px)
+- `app/presentation/layouts/ChromeLayout.tsx` — `<><header data-testid="topbar-slot" />{children}<footer data-testid="footer-slot" /></>` (T005에서 Topbar/Footer 본체 채움)
+- 13개 라우트 placeholder + 5개 resource route placeholder + 1개 splat
+- `app/root.tsx`에서 URL 패턴 매칭으로 layout 분기 (또는 React Router pathless layout route 사용)
+
+### Refactor
+- placeholder 컴포넌트들에 동일한 명명 규칙(`Page` suffix 또는 default export) 통일
+- `app/presentation/layouts/index.ts`로 barrel export
+
+## Files to Create / Modify
+
+### Presentation — Routes (13 page routes)
+| Path | Responsibility |
+|------|---------------|
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/presentation/routes/_index.tsx` | Home placeholder (T003에서 만든 것 위에 보강) |
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/presentation/routes/about.tsx` | About placeholder |
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/presentation/routes/projects._index.tsx` | Projects 목록 placeholder |
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/presentation/routes/projects.$slug.tsx` | Project Detail placeholder |
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/presentation/routes/blog._index.tsx` | Blog 목록 placeholder |
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/presentation/routes/blog.$slug.tsx` | Blog Detail placeholder |
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/presentation/routes/contact.tsx` | Contact placeholder |
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/presentation/routes/legal._index.tsx` | Legal Index placeholder |
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/presentation/routes/legal.$app.terms.tsx` | App Terms placeholder (chrome-free) |
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/presentation/routes/legal.$app.privacy.tsx` | App Privacy placeholder (chrome-free) |
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/presentation/routes/$.tsx` | splat — Not Found Fallback (`cd: no such route: <path>`) |
+
+### Presentation — Resource Routes (5 routes)
+| Path | Responsibility |
+|------|---------------|
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/presentation/routes/rss[.xml].tsx` | placeholder loader: 빈 RSS XML stub (T014a에서 본체) |
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/presentation/routes/sitemap[.xml].tsx` | placeholder loader: 빈 sitemap stub (T019에서 본체) |
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/presentation/routes/robots[.txt].tsx` | placeholder loader: `User-agent: *\nAllow: /` 최소형 (T019에서 본체) |
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/presentation/routes/og.projects.$slug[.png].tsx` | placeholder loader: 200 빈 PNG (T018에서 본체) |
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/presentation/routes/og.blog.$slug[.png].tsx` | placeholder loader: 200 빈 PNG (T018에서 본체) |
+
+### Presentation — Layouts
+| Path | Responsibility |
+|------|---------------|
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/presentation/layouts/ChromeLayout.tsx` | Topbar slot + children + Footer slot |
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/presentation/layouts/ChromeFreeLayout.tsx` | `.legal` 컨테이너 (max-width 680px), Topbar/Footer 미렌더 |
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/presentation/layouts/__tests__/ChromeLayout.test.tsx` | RTL: Topbar/Footer slot + children 순서 검증 |
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/presentation/layouts/__tests__/ChromeFreeLayout.test.tsx` | RTL: Topbar/Footer 미렌더, max-width 680px 적용 |
+
+### Root (수정)
+| Path | Change |
+|------|--------|
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/root.tsx` | `useMatches()` 또는 `useLocation()`으로 URL이 `/legal/:app/(terms|privacy)`이면 `<ChromeFreeLayout>`, 아니면 `<ChromeLayout>`으로 `<Outlet />` 감싸기 |
+
+## Verification Steps
+
+### 자동
+- `bun run test`에서 ChromeLayout/ChromeFreeLayout 테스트 2개 통과
+- `bun run typecheck` → 13개 라우트 + 5개 resource route + 1개 splat = 19개 라우트 모듈에 대해 typegen 정상
+
+### 수동
+- `bunx wrangler dev` 후 13개 페이지 URL 접속 → placeholder 응답
+- 미존재 경로(`/foobar`) 접속 → splat 터미널 메시지 placeholder
+- `/legal/moai/terms` 접속 → Topbar/Footer 미노출 + max-width 680px 컨테이너만 (시각 확인)
+- `/about` 접속 → Topbar slot + Footer slot 노출 (T005 이후 본체 채워짐)
+
+### 측정
+- 없음
+
+## Dependencies
+- **Depends on**: T002 (디렉토리 골격), T003 (Vite/RR7 파이프라인)
+- **Blocks**: T010 (Home 콘텐츠), T011 (About 콘텐츠), T012 (Projects 목록), T013 (Project Detail), T014a (Blog List), T014b (Blog Detail), T015 (Legal 페이지들)
+
+## Risks & Mitigations
+- **Risk**: RR7 file convention의 `legal.$app.terms.tsx` 파싱이 `:app` 동적 segment를 정확히 인식하지 않을 가능성.
+  - **Mitigation**: 공식 [File Route Conventions](https://reactrouter.com/how-to/file-route-conventions)의 `$param` 규칙 검증 + dev-only smoke test로 `/legal/moai/terms` 매칭 확인.
+- **Risk**: Resource route(`rss[.xml].tsx`)에서 escape 문법이 typegen에 영향.
+  - **Mitigation**: PROJECT-STRUCTURE.md `Route file conventions` 표(line 318~334)와 동일 명명 사용.
+
+## References
+- PRD `Menu Structure`, `Page-by-Page Detailed Features` 11개 페이지, `Not Found Fallback`
+- PROJECT-STRUCTURE.md `app/presentation/routes/` (line 299~334)
+- PROJECT-STRUCTURE.md `D1. 라우트 디렉토리` 결정 (line 568~)
+- ROADMAP.md `Phase 1` Task 004, 가정 A004 해소
+- [React Router v7 File Route Conventions](https://reactrouter.com/how-to/file-route-conventions)
+
+## Change History
+| Date | Changes | Author |
+|------|---------|--------|
+| - | - | - |

--- a/docs/tasks/T005-theme-tokens.md
+++ b/docs/tasks/T005-theme-tokens.md
@@ -1,0 +1,149 @@
+# Task 005 — 디자인 토큰 이식 + Tailwind v4 `@theme` + `[data-theme]` dark variant + 다크모드 (F010)
+
+| Field | Value |
+|-------|-------|
+| **Task ID** | T005 |
+| **Phase** | Phase 1 — Foundation |
+| **Layer** | Presentation (`components/chrome`, `hooks`, `app.css`) |
+| **Branch** | `feature/issue-N-theme-tokens` |
+| **Depends on** | T003 |
+| **Blocks** | T010, T011, T012, T013, T014a, T014b, T015 |
+| **PRD Features** | **F010** (다크모드 토글) |
+| **PRD AC** | — (UI 표시 위주, Page-by-Page Key Features로 검증) |
+| **예상 작업 시간** | 1d |
+| **Status** | Not Started |
+
+## Goal
+디자인 정본의 oklch/JetBrains Mono 토큰을 Tailwind v4 `@theme` 블록으로 이식하고, `[data-theme]` HTML 속성 셀렉터 + `@variant dark` 커스텀 변형으로 다크/라이트 모드를 SSR-safe하게 구현한다. Topbar/Footer/ThemeToggle 골격까지 포함하여 후속 페이지 task가 chrome 본체를 신경쓰지 않도록 한다.
+
+## Context
+- **Why**: F010은 "전 페이지 공통" Support 기능. 토글 클릭 → `[data-theme]` 속성 변경 → CSS 변수 즉시 반영 → localStorage `proto-theme` 저장 → 새로고침 시 강제 모드 복원. SSR 환경에서 첫 렌더 깜빡임(FOIT/FOUC)을 막기 위해 root에 blocking script가 필수.
+- **Phase 진입/완료 연결**: T003(Tailwind v4 가동) 완료 후 시작. T005가 Done이면 T010~T015 페이지 task가 Topbar/Footer/Theme 컴포넌트를 즉시 import 가능.
+- **관련 PRD 섹션**: PRD `F010` Feature, `Tech Stack — Styling & UI`, `Tech Stack — Typography`
+- **관련 PROJECT-STRUCTURE 디렉토리**: `app/app.css`, `app/presentation/components/chrome/`, `app/presentation/hooks/`, `app/root.tsx`, `public/fonts/`
+
+## Scope
+
+### In Scope
+- `app/app.css`에 `@theme { --color-*, --font-* }` 토큰 이식 (`docs/design-system/styles.css`의 oklch 토큰을 Tailwind v4 native syntax로 변환)
+- `@variant dark (&:where([data-theme='dark'], [data-theme='dark'] *))` 커스텀 변형 정의
+- `useTheme` hook — system 추종 + localStorage `proto-theme` 강제 전환
+- Topbar / Footer / ThemeToggle 컴포넌트 골격 (placeholder 콘텐츠 + 토글 동작)
+- `app/root.tsx`에 SSR-safe blocking script로 첫 렌더 깜빡임 방지
+- JetBrains Mono self-host (`public/fonts/JetBrainsMono-{Regular,Medium,Bold}.woff2` + `@font-face`)
+
+### Out of Scope
+- Cloudflare Web Analytics 스니펫 (T020)
+- 검색 트리거 버튼의 실제 Command Palette 연결 (T016)
+- 페이지별 콘텐츠 (T010~T015)
+- Satori OG용 `JetBrainsMono-Regular.ttf` (T018)
+
+## Acceptance Criteria
+- [ ] 시스템 dark 설정 → 첫 진입 시 dark 테마 자동 적용 (FOIT 없음)
+- [ ] 토글 클릭 → `<html>`의 `data-theme` 속성이 `dark` ↔ `light` 토글 + 색상 즉시 전환
+- [ ] localStorage `proto-theme = "dark" | "light"` 저장됨
+- [ ] 새로고침 시 localStorage 값으로 강제 모드 복원
+- [ ] Topbar에 `tkstar.dev` 브랜드 + 현재 경로 표시 + 검색 트리거 placeholder + ThemeToggle 노출
+- [ ] Footer에 © + GitHub / X / RSS / Contact 링크 노출 (Legal 링크는 T015에서 조건부 추가)
+- [ ] JetBrains Mono가 모든 본문/UI에 적용 (network 패널에서 woff2 fetch 확인)
+
+## Implementation Plan (TDD Cycle)
+
+### Red
+- `app/presentation/hooks/__tests__/useTheme.test.ts`
+  - **Case 1 — System 추종**: `matchMedia('(prefers-color-scheme: dark)')` mock으로 `matches: true` → hook이 `"dark"` 반환
+  - **Case 2 — 강제 전환**: `setTheme("light")` 호출 시 localStorage `proto-theme = "light"` 저장 + `document.documentElement.dataset.theme === "light"`
+  - **Case 3 — Persist**: 마운트 시 localStorage `proto-theme = "dark"`이 있으면 시스템 설정 무시하고 `"dark"` 적용
+- `app/presentation/components/chrome/__tests__/ThemeToggle.test.tsx`
+  - 클릭 시 `useTheme().setTheme`이 정확한 인자로 호출 (mock)
+
+### Green
+- `app/presentation/hooks/useTheme.ts` — useState + useEffect로 system + localStorage 추종
+- `app/presentation/components/chrome/ThemeToggle.tsx` — 클릭 핸들러
+- `app/presentation/components/chrome/Topbar.tsx`, `Footer.tsx` — 시각 골격
+- `app/app.css` — `@theme { --color-bg, --color-fg, --color-accent, --font-mono, ... }`, `@variant dark`, `@font-face` for JetBrains Mono
+- `app/root.tsx`에 SSR blocking script (`<script>` 태그를 `<head>` 가장 위에 dangerouslySetInnerHTML로 inject — localStorage 읽고 `data-theme` 속성 부착)
+
+### Refactor
+- `useTheme` hook의 SSR/client 분기를 `typeof window !== "undefined"`로 깨끗하게 분리
+- Topbar/Footer의 link 데이터를 상수로 추출 (`app/presentation/lib/chrome-links.ts`)
+
+## Files to Create / Modify
+
+### Presentation — Hooks
+| Path | Responsibility |
+|------|---------------|
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/presentation/hooks/useTheme.ts` | system + localStorage `proto-theme` 추종 / `setTheme(value: "dark" | "light")` |
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/presentation/hooks/__tests__/useTheme.test.ts` | Red 3 cases |
+
+### Presentation — Chrome Components
+| Path | Responsibility |
+|------|---------------|
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/presentation/components/chrome/Topbar.tsx` | 브랜드 / 현재 경로 / 검색트리거 placeholder / ThemeToggle |
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/presentation/components/chrome/Footer.tsx` | © / GitHub / X / RSS / Contact (Legal은 T015에서) |
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/presentation/components/chrome/ThemeToggle.tsx` | 클릭 시 `useTheme.setTheme` 호출 |
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/presentation/components/chrome/__tests__/ThemeToggle.test.tsx` | RTL 클릭 핸들러 검증 |
+
+### Presentation — Lib (refactor)
+| Path | Responsibility |
+|------|---------------|
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/presentation/lib/chrome-links.ts` | `TOPBAR_LINKS`, `FOOTER_LINKS` 상수 |
+
+### CSS (수정)
+| Path | Change |
+|------|--------|
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/app.css` | `@theme { --color-bg, --color-fg, --color-muted, --color-accent, --font-mono }` + `@variant dark`(`&:where([data-theme='dark'], [data-theme='dark'] *)`) + `@font-face` for JetBrains Mono Regular/Medium/Bold |
+
+### Root (수정)
+| Path | Change |
+|------|--------|
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/root.tsx` | `<head>`에 SSR blocking script 추가 (localStorage `proto-theme` 읽고 `document.documentElement.dataset.theme` 부착). `<ChromeLayout>` slot에 `<Topbar />`, `<Footer />` 본체 채움 |
+
+### Public Assets
+| Path | Responsibility |
+|------|---------------|
+| `/Users/tkstart/Desktop/project/tkstar-dev/public/fonts/JetBrainsMono-Regular.woff2` | self-host |
+| `/Users/tkstart/Desktop/project/tkstar-dev/public/fonts/JetBrainsMono-Medium.woff2` | self-host |
+| `/Users/tkstart/Desktop/project/tkstar-dev/public/fonts/JetBrainsMono-Bold.woff2` | self-host |
+
+## Verification Steps
+
+### 자동
+- `bun run test` — `useTheme.test.ts` 3 cases pass + `ThemeToggle.test.tsx` 1 case pass
+- `bun run typecheck` 통과
+- `bun run lint` 통과
+
+### 수동
+- DevTools에서 `prefers-color-scheme` toggle (Rendering panel) → 첫 진입 시 자동 추종 (FOIT 없음 확인 — Network throttling Slow 3G로 검증)
+- 토글 클릭 → 색상 즉시 전환 + `<html data-theme="...">` 속성 변경 (DevTools Elements 탭)
+- DevTools Application → localStorage `proto-theme` 값 확인
+- 새로고침 → localStorage 값 유지 + 강제 모드 복원
+- Network 탭에서 `JetBrainsMono-Regular.woff2` fetch 확인
+
+### 측정
+- LCP에 영향 가는 FOIT 부재 확인 (Lighthouse Performance Phase 6에서 정식 측정, 여기서는 시각 확인 수준)
+
+## Dependencies
+- **Depends on**: T003 (Tailwind v4 가동)
+- **Blocks**: T010~T015 (모든 페이지가 Topbar/Footer/ThemeToggle 사용)
+
+## Risks & Mitigations
+- **Risk**: SSR blocking script가 잘못 inject되어 첫 렌더 깜빡임 발생.
+  - **Mitigation**: blocking script는 반드시 `<head>` 가장 위에 inline으로 inject. `dangerouslySetInnerHTML`을 사용하되 escape 처리 + script가 동기 실행되도록 `<script>` 태그(async/defer 금지).
+- **Risk**: Tailwind v4 `@variant`의 `:where()` selector가 일부 모던 브라우저에서 specificity 문제.
+  - **Mitigation**: `:where` specificity 0 활용 + 디자인 정본의 `[data-theme='dark'] *` 패턴을 그대로 채택 (이미 디자인 정본에서 검증).
+- **Risk**: JetBrains Mono woff2 라이선스 누락.
+  - **Mitigation**: SIL OFL 1.1 라이선스 명시 (필요 시 `public/fonts/OFL.txt` 동봉).
+
+## References
+- PRD `F010 다크모드 토글`, `Tech Stack — Styling & UI`, `Tech Stack — Typography`
+- PROJECT-STRUCTURE.md `Cross-cutting Concerns Mapping` F010 행 (line 553)
+- PROJECT-STRUCTURE.md `app/ Root Files` `app.css` (line 352)
+- ROADMAP.md `Phase 1` Task 005
+- `docs/design-system/styles.css` — oklch 토큰 정본
+- [Tailwind v4 `@theme`](https://tailwindcss.com/docs/theme), [`@variant`](https://tailwindcss.com/docs/functions-and-directives#variant-directive)
+
+## Change History
+| Date | Changes | Author |
+|------|---------|--------|
+| - | - | - |

--- a/docs/tasks/T006-domain-schemas.md
+++ b/docs/tasks/T006-domain-schemas.md
@@ -1,0 +1,161 @@
+# Task 006 — Domain Schemas (Project / Post / AppLegalDoc / ContactSubmission / ThemePreference)
+
+| Field | Value |
+|-------|-------|
+| **Task ID** | T006 |
+| **Phase** | Phase 1 — Foundation |
+| **Layer** | **Domain** (innermost) |
+| **Branch** | `feature/issue-N-domain-schemas` |
+| **Depends on** | T002 |
+| **Blocks** | T007, T008, T009, T017 |
+| **PRD Features** | F002, F004, F005, F006, F007, F008, F010, F014, F017 (read-side 데이터 모델) |
+| **PRD AC** | AC-F008-2 (RFC 5322), AC-F008-3 (메시지 10~5000자) — `ContactSubmission` schema에 정의 |
+| **예상 작업 시간** | 1d |
+| **Status** | Not Started |
+
+## Goal
+Clean Architecture의 가장 안쪽 레이어인 Domain에 5개 콘텐츠/입력 모델의 Zod 스키마를 정의한다. 이 스키마는 velite frontmatter 검증(T007)과 Application 유스케이스(T008/T017) 양쪽이 단일 정본으로 공유한다. A001(About 자격증), A003(AppLegalDoc version/effective_date) 가정도 이 단계에서 해소.
+
+## Context
+- **Why**: Domain layer는 외부 의존성이 일체 없어야 하며(zod만 허용), Project/Post/AppLegalDoc 엔티티의 형태가 이후의 모든 read-side adapter와 페이지 컴포넌트의 타입 계약이 된다. ContactSubmission schema는 AC-F008-2/3을 단위 테스트 수준에서 직접 검증할 수 있는 첫 지점.
+- **Phase 진입/완료 연결**: T002(디렉토리) 완료 후 즉시. T006 Done 후 T007(velite가 이 스키마를 import) + T017(ContactSubmission이 Form action에 사용)이 시작 가능.
+- **관련 PRD 섹션**: PRD `Data Model` 5개 모델, AC-F008-2/3
+- **관련 PROJECT-STRUCTURE 디렉토리**: `app/domain/{project,post,legal,contact,theme}/`
+
+## Scope
+
+### In Scope
+- 5개 도메인 모듈에 entity/schema/errors/value object 파일 작성 + `__tests__/`
+- Zod 스키마는 PRD `Data Model` 섹션의 필드를 정확히 반영
+- `ContactSubmission` schema는 AC-F008-2 (RFC 5322 이메일), AC-F008-3 (메시지 10~5000자) 검증 룰 포함
+- `AppLegalDoc` schema에 `version` (string) + `effective_date` (ISO date) 필드 명시 (A003 해소)
+- `Project` schema의 `featured: boolean (optional)` 필드 (A001 해소: 자격증은 frontmatter optional 필드로 자리만 확보 — Project가 아닌 경우 별도 entity 추가는 보류)
+
+### Out of Scope
+- velite 컬렉션 정의 (T007이 이 스키마를 import)
+- Repository 구현 (T008)
+- velite raw output → Domain Entity mapper (T008)
+- ContactSubmission을 사용하는 Form/Action (T017)
+
+## Acceptance Criteria
+- [ ] `app/domain/project/project.schema.ts`가 정상 frontmatter (slug/title/summary/date/tags/stack/metrics/featured?/cover?)를 통과시킨다
+- [ ] `app/domain/post/post.schema.ts`가 정상 frontmatter (slug/title/lede/date/tags/read)를 통과시킨다
+- [ ] `app/domain/legal/app-legal-doc.schema.ts`가 정상 frontmatter (app_slug/doc_type/version/effective_date)를 통과시킨다
+- [ ] `app/domain/contact/contact-submission.schema.ts`가 RFC 5322 위반 이메일을 reject (AC-F008-2)
+- [ ] `app/domain/contact/contact-submission.schema.ts`가 메시지 10자 미만 / 5000자 초과를 reject (AC-F008-3)
+- [ ] `app/domain/theme/theme-preference.vo.ts`가 `"dark" | "light"` literal type을 export
+- [ ] 모든 5개 모듈의 `__tests__/`가 정상값 통과 + 이상값 reject 케이스를 포함하여 100% Green
+- [ ] `bun run test` + `bun run typecheck` 통과
+
+## Implementation Plan (TDD Cycle)
+
+### Red
+모든 스키마 테스트는 (a) 정상 입력 통과 (b) 각 필수 필드 누락 reject (c) 타입 위반 reject 3 카테고리를 최소 포함:
+
+- `app/domain/project/__tests__/project.schema.test.ts`
+  - 정상 frontmatter (필수 필드 모두 + featured/cover optional 미포함) → `safeParse({success: true})`
+  - `slug` 누락 → reject
+  - `metrics`가 `[string, string][]`이 아닌 경우 reject
+  - `featured: true`가 통과
+- `app/domain/post/__tests__/post.schema.test.ts`
+  - 정상 frontmatter → pass
+  - `read`가 number가 아니면 reject
+- `app/domain/legal/__tests__/app-legal-doc.schema.test.ts`
+  - `doc_type: "terms"` / `"privacy"` 통과, `"foo"` reject
+  - `effective_date` ISO 8601이 아니면 reject
+- `app/domain/contact/__tests__/contact-submission.schema.test.ts`
+  - `"foo@bar.com"` 통과, `"foo@"` / `"bar.com"` reject (AC-F008-2)
+  - 메시지 길이 9자 reject, 10자 통과, 5000자 통과, 5001자 reject (AC-F008-3)
+  - `inquiry_type`은 `"B2B" | "B2C" | "etc"` 외 값 reject
+  - `company` 미입력(undefined)도 통과 (optional)
+- `app/domain/theme/__tests__/theme-preference.test.ts` (선택, type-only면 생략 가능)
+
+### Green
+- `app/domain/project/project.entity.ts` — `Project` interface (Zod `infer`로 derive)
+- `app/domain/project/project.schema.ts` — Zod schema
+- `app/domain/project/project.errors.ts` — `ProjectNotFoundError extends Error`
+- `app/domain/post/post.{entity,schema}.ts`
+- `app/domain/legal/app-legal-doc.{entity,schema}.ts`
+- `app/domain/contact/contact-submission.vo.ts`, `contact-submission.schema.ts`, `contact.errors.ts`
+- `app/domain/theme/theme-preference.vo.ts` — `export type ThemePreference = "dark" | "light"`
+
+### Refactor
+- 공통 Zod helper(`zIso8601Date`, `zNonEmptyString`)를 `app/domain/_shared/zod-helpers.ts`로 추출 (의존성 그래프 외부화 금지)
+- entity 파일이 schema 파일을 import하는 단방향 흐름 정리
+
+## Files to Create / Modify
+
+### Domain — Project
+| Path | Responsibility |
+|------|---------------|
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/domain/project/project.entity.ts` | `export type Project = z.infer<typeof projectSchema>` |
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/domain/project/project.schema.ts` | Zod frontmatter schema (slug/title/summary/date/tags/stack/metrics/featured?/cover?) |
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/domain/project/project.errors.ts` | `ProjectNotFoundError`, `InvalidProjectFrontmatterError` |
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/domain/project/__tests__/project.schema.test.ts` | Red 4 cases |
+
+### Domain — Post
+| Path | Responsibility |
+|------|---------------|
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/domain/post/post.entity.ts` | `Post` type |
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/domain/post/post.schema.ts` | slug/title/lede/date/tags/read |
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/domain/post/__tests__/post.schema.test.ts` | Red 2 cases |
+
+### Domain — Legal
+| Path | Responsibility |
+|------|---------------|
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/domain/legal/app-legal-doc.entity.ts` | `AppLegalDoc` type |
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/domain/legal/app-legal-doc.schema.ts` | app_slug/doc_type/version/effective_date |
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/domain/legal/__tests__/app-legal-doc.schema.test.ts` | Red 2 cases |
+
+### Domain — Contact
+| Path | Responsibility |
+|------|---------------|
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/domain/contact/contact-submission.vo.ts` | Value Object (immutable) |
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/domain/contact/contact-submission.schema.ts` | RFC 5322 email + 10~5000자 message (AC-F008-2/3) |
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/domain/contact/contact.errors.ts` | `InvalidContactSubmissionError` |
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/domain/contact/__tests__/contact-submission.schema.test.ts` | Red 4+ cases (AC-F008-2/3 직접 매핑) |
+
+### Domain — Theme
+| Path | Responsibility |
+|------|---------------|
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/domain/theme/theme-preference.vo.ts` | `export type ThemePreference = "dark" \| "light"` |
+
+### Shared (Refactor 단계에서)
+| Path | Responsibility |
+|------|---------------|
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/domain/_shared/zod-helpers.ts` | `zIso8601Date`, `zNonEmptyString`, `zRfc5322Email` 등 |
+
+## Verification Steps
+
+### 자동
+- `bun run test` → 5개 도메인 모듈의 모든 테스트 Green
+- `bun run typecheck` → Zod `infer`된 타입이 entity 타입과 일치
+- `bun run lint` 통과
+
+### 수동
+- 없음
+
+### 측정
+- 없음
+
+## Dependencies
+- **Depends on**: T002 (Domain 디렉토리)
+- **Blocks**: T007 (velite가 이 스키마 import), T008 (Application 유스케이스가 entity 타입 사용), T009 (DI container가 ContactSubmissionError 등 처리), T017 (Contact form action이 ContactSubmission schema 사용)
+
+## Risks & Mitigations
+- **Risk**: Zod의 RFC 5322 이메일 검증이 `.email()` 기본 룰에서 일부 valid 이메일 reject할 수 있음.
+  - **Mitigation**: AC-F008-2은 PRD에 "RFC 5322 위반 형식(`foo@`, `foo.com`)"으로 명시. Zod `.email()` 기본 룰이 이 위반을 reject하면 충분. 더 엄격한 케이스는 추후 보강.
+- **Risk**: AppLegalDoc의 `version` 형식이 자유 문자열인지 SemVer인지 모호.
+  - **Mitigation**: PRD `Data Model`에 `version: string`으로만 명시 → free string으로 채택. SemVer 강제는 운영 단계에서 결정.
+
+## References
+- PRD `Data Model` (Project / Post / AppLegalDoc / ContactSubmission / ThemePreference)
+- PRD `Acceptance Criteria — F008` AC-F008-2/3
+- PROJECT-STRUCTURE.md `app/domain/` (line 95~132)
+- ROADMAP.md `Phase 1` Task 006, 가정 A001/A003 해소
+- [Zod docs](https://zod.dev/)
+
+## Change History
+| Date | Changes | Author |
+|------|---------|--------|
+| - | - | - |

--- a/docs/tasks/T007-velite-content-pipeline.md
+++ b/docs/tasks/T007-velite-content-pipeline.md
@@ -1,0 +1,138 @@
+# Task 007 — velite 설치 + 컬렉션 정의 + seed 콘텐츠 + shiki 코드블록
+
+| Field | Value |
+|-------|-------|
+| **Task ID** | T007 |
+| **Phase** | Phase 2 — Content Pipeline |
+| **Layer** | Infrastructure (build-time ETL) + `content/` |
+| **Branch** | `feature/issue-N-velite-content-pipeline` |
+| **Depends on** | T006 |
+| **Blocks** | T008 |
+| **PRD Features** | F004, F005, F006, F007, F014 (콘텐츠 정본) |
+| **PRD AC** | — (빌드 산출물 정상 build로 검증) |
+| **예상 작업 시간** | 1d |
+| **Status** | Not Started |
+
+## Goal
+velite를 도입하여 `content/{projects,posts,legal/apps}/**/*.mdx`를 빌드 타임에 Zod 검증 → `.velite/` JSON 출력하는 ETL 파이프라인을 가동시키고, shiki + rehype-slug 플러그인으로 코드블록 highlight + 헤딩 anchor를 동시에 갖춘다. seed 콘텐츠 3종을 작성한다 (가정 A002 1단계, A006 해소).
+
+## Context
+- **Why**: Domain 스키마(T006)가 정의되었으므로 velite가 같은 스키마를 import하여 frontmatter 검증을 빌드 타임에 적용하면 "정본 1개"가 유지된다. shiki는 코드블록 디자인의 정본이고, rehype-slug는 후속 T013(Project Detail TOC)에서 헤딩 anchor 추출에 필수.
+- **Phase 진입/완료 연결**: Phase 1 종료 후 Phase 2 시작점. T007 Done이면 `.velite/projects.json` 등 정적 산출물이 존재 → T008 repository가 이를 import 가능.
+- **관련 PRD 섹션**: PRD `Tech Stack — Content Pipeline`, `Data Model`, `Page-by-Page` Project Detail / Blog Detail Key Features (shiki)
+- **관련 PROJECT-STRUCTURE 디렉토리**: `velite.config.ts` (루트), `content/{projects,posts,legal/apps/[slug]}/`, `.velite/` (gitignore), `app/presentation/components/content/`
+
+## Scope
+
+### In Scope
+- `bun add -D velite shiki rehype-slug` 설치
+- `velite.config.ts` — 3개 컬렉션 정의 + Domain `*.schema.ts` import + rehype 플러그인 (`rehype-slug`, shiki via `@shikijs/rehype` 또는 velite의 mdx options)
+- seed 콘텐츠: `content/projects/example-project.mdx`, `content/posts/2026-04-shipping-solo.mdx`, `content/legal/apps/moai/{terms,privacy}.mdx`
+- `MdxRenderer`, `CodeBlock` 컴포넌트 골격 (velite body → React 트리, shiki 출력 외곽 컨테이너)
+- `bunx velite build` 명령이 성공하고 `.velite/projects.json`, `posts.json`, `legal.json` 생성
+- `package.json`에 `prebuild: "velite build"` 또는 `dev: "velite dev"` 등 hook 추가
+
+### Out of Scope
+- Application Ports + Repository 구현 (T008)
+- velite afterBuild 훅으로 TOC 추출 / search-index 빌드 (T013 / T016)
+- Satori OG 이미지 (T018)
+
+## Acceptance Criteria
+- [ ] `bunx velite build` 성공 → `.velite/{projects,posts,legal}.json` 생성
+- [ ] `.velite/projects.json`에 seed `example-project`가 포함되고 frontmatter 필드(slug/title/summary/date/tags/stack/metrics)가 모두 매핑됨
+- [ ] frontmatter Zod 위반 콘텐츠(예: `metrics`를 string으로 작성)를 추가하면 `velite build`가 실패
+- [ ] seed MDX의 코드블록(```ts ... ```)이 shiki로 highlight되어 `<pre>` HTML 안에 토큰별 `<span style="color: ...">`가 들어감
+- [ ] seed MDX의 `## ...` 헤딩에 rehype-slug가 `id` 속성을 자동 부여
+- [ ] `MdxRenderer` 컴포넌트가 velite body(`code` HTML 또는 `MDXComponent`)를 React로 렌더 가능
+- [ ] `bun run typecheck` + `bun run lint` 통과
+
+## Implementation Plan (TDD Cycle)
+
+### Red
+- `app/presentation/components/content/__tests__/MdxRenderer.test.tsx`
+  - velite 빌드 산출물 형태(html string 또는 MDX component)를 mock하여 `<MdxRenderer body={mock} />`이 정상 마운트
+  - 코드블록 mock에 shiki style이 보존됨 (innerHTML에 `<span style="color:`)
+- `velite.config.ts` 자체는 직접 테스트보다 `velite build` 명령 실행으로 e2e 검증 (script test로 대체):
+  - `test/integration/velite-build.test.ts` (선택) — `execSync("bunx velite build")` 후 `.velite/projects.json` 존재 검증
+
+### Green
+- `velite.config.ts`:
+  ```ts
+  import { defineConfig, defineCollection } from "velite";
+  import { projectSchema } from "./app/domain/project/project.schema";
+  // ... 3 collections (projects, posts, legal)
+  // mdx: { rehypePlugins: [rehypeSlug, [rehypeShiki, { theme: "github-dark" }]] }
+  ```
+- `content/projects/example-project.mdx` — frontmatter + problem/approach/results 본문 + 코드블록 1개
+- `content/posts/2026-04-shipping-solo.mdx` — frontmatter + 본문 + 코드블록
+- `content/legal/apps/moai/terms.mdx` + `privacy.mdx` — frontmatter (version, effective_date)만, 본문은 placeholder
+- `app/presentation/components/content/MdxRenderer.tsx`, `CodeBlock.tsx`
+
+### Refactor
+- velite collection 정의를 `velite.config.ts`에서 분리해서 `velite/collections/{projects,posts,legal}.ts`로 (선택; 1파일 유지가 단순)
+- shiki theme 토큰을 디자인 토큰과 정렬 (옵션)
+
+## Files to Create / Modify
+
+### Build / Config
+| Path | Responsibility |
+|------|---------------|
+| `/Users/tkstart/Desktop/project/tkstar-dev/velite.config.ts` | 3 컬렉션 정의 (Domain schemas import) + rehype plugins |
+| `/Users/tkstart/Desktop/project/tkstar-dev/package.json` | scripts에 `prebuild: "velite build"` 또는 `dev: "velite --watch & vite dev"` 통합. `devDependencies`에 `velite`, `shiki`, `@shikijs/rehype`, `rehype-slug` 추가 |
+
+### Content (seed)
+| Path | Responsibility |
+|------|---------------|
+| `/Users/tkstart/Desktop/project/tkstar-dev/content/projects/example-project.mdx` | seed Project (slug, title, summary, date, tags, stack, metrics, featured: true) |
+| `/Users/tkstart/Desktop/project/tkstar-dev/content/posts/2026-04-shipping-solo.mdx` | seed Post (slug, title, lede, date, tags, read) |
+| `/Users/tkstart/Desktop/project/tkstar-dev/content/legal/apps/moai/terms.mdx` | seed AppLegalDoc (terms) |
+| `/Users/tkstart/Desktop/project/tkstar-dev/content/legal/apps/moai/privacy.mdx` | seed AppLegalDoc (privacy) |
+
+### Presentation — Content Components
+| Path | Responsibility |
+|------|---------------|
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/presentation/components/content/MdxRenderer.tsx` | velite body → React (html string render 또는 useMDXComponent) |
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/presentation/components/content/CodeBlock.tsx` | shiki 출력의 외곽 `<pre className="codeblock">` 컨테이너 |
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/presentation/components/content/__tests__/MdxRenderer.test.tsx` | RTL 1~2 cases |
+
+### gitignore (수정)
+| Path | Change |
+|------|--------|
+| `/Users/tkstart/Desktop/project/tkstar-dev/.gitignore` | 이미 T001에서 `.velite/` 추가됨 — no-op 확인 |
+
+## Verification Steps
+
+### 자동
+- `bunx velite build` exit code 0 + `.velite/{projects,posts,legal}.json` 존재 (CI에서 `bun run prebuild` 통해 동작)
+- `bun run test` — `MdxRenderer.test.tsx` Green
+- 의도적으로 `metrics: "broken"` 같은 위반 frontmatter를 추가한 임시 MDX → `velite build` 실패 (수동으로 1회 검증)
+
+### 수동
+- VSCode에서 `.velite/projects.json` 열어 seed 데이터가 Domain entity 타입과 호환되는지 시각 확인
+- `wrangler dev`에서 `<MdxRenderer body={veliteProjectBody} />`가 코드블록 + 헤딩 anchor 렌더하는지 sample 페이지(임시)로 확인 (필요 시)
+
+### 측정
+- `.velite/projects.json` size 확인 — 본문 포함되므로 클라이언트 번들에 직접 import하지 않도록 주의
+
+## Dependencies
+- **Depends on**: T006 (Domain 스키마)
+- **Blocks**: T008 (Repository는 `.velite/*.json`을 import하여 Entity 매핑)
+
+## Risks & Mitigations
+- **Risk**: shiki는 WASM 기반이며 Cloudflare Workers 런타임에서 동적 로드가 불가능할 수 있음.
+  - **Mitigation**: shiki는 **빌드 타임에만** 동작 (velite의 mdx 처리 단계). 런타임 Workers에는 shiki bundle이 들어가지 않고 이미 highlighted된 HTML 문자열만 `.velite/*.json`에 저장됨. 따라서 Workers 런타임 영향 없음.
+- **Risk**: rehype-slug가 한국어 헤딩(`## 결과`)에서 anchor를 영어로 변환하여 깨질 수 있음.
+  - **Mitigation**: rehype-slug 기본값은 한글을 그대로 slug에 포함 (`id="결과"`). 깨질 경우 `github-slugger` 옵션 조정.
+
+## References
+- PRD `Tech Stack — Content Pipeline`, `Data Model`
+- PROJECT-STRUCTURE.md `content/ and .velite/` (line 405~)
+- PROJECT-STRUCTURE.md `velite Content Pipeline 노트` (line 240)
+- ROADMAP.md `Phase 2` Task 007, 가정 A002(1단계)/A006 해소
+- [velite docs](https://velite.js.org/)
+- [Shiki](https://shiki.style/), [rehype-slug](https://github.com/rehypejs/rehype-slug)
+
+## Change History
+| Date | Changes | Author |
+|------|---------|--------|
+| - | - | - |

--- a/docs/tasks/T008-content-ports-repos.md
+++ b/docs/tasks/T008-content-ports-repos.md
@@ -1,0 +1,164 @@
+# Task 008 — Application Ports + Content Repositories (Infrastructure 구현)
+
+| Field | Value |
+|-------|-------|
+| **Task ID** | T008 |
+| **Phase** | Phase 2 — Content Pipeline |
+| **Layer** | Application (`ports/services/`) + Infrastructure (`content/`) |
+| **Branch** | `feature/issue-N-content-ports-repos` |
+| **Depends on** | T002, T006, T007 |
+| **Blocks** | T009, T010, T011, T012, T013, T014a, T014b, T015, T016, T017 |
+| **PRD Features** | F004, F005, F006, F007, F014, F017 |
+| **PRD AC** | — (read-side 정확성은 unit test로 충분) |
+| **예상 작업 시간** | 2d |
+| **Status** | Not Started |
+
+## Goal
+Application Layer에 3개 Repository Port + 6개 Service(유스케이스)를 정의하고, Infrastructure Layer에 velite read-side adapter 3개 + mapper를 구현한다. 이 task가 Done이면 페이지 task가 호출할 모든 read-side 유스케이스가 가동된다.
+
+## Context
+- **Why**: PRD의 페이지 task(T010~T015)는 `getFeaturedProject`, `listProjects`, `getProjectDetail(prev/next)`, `listPosts`, `getPostDetail`, `getRecentPosts(3)` 6개 유스케이스를 직접 호출한다. CA 원칙상 페이지(Presentation)는 Repository를 직접 import하지 않고 유스케이스 service를 통해서만 데이터에 접근.
+- **Phase 진입/완료 연결**: T007에서 `.velite/{projects,posts,legal}.json`이 정상 생성되면 즉시 시작. T008 Done 후 T009(DI container)가 Service 인스턴스를 등록할 수 있다.
+- **관련 PRD 섹션**: PRD `Page-by-Page` (Home Featured/Recent — F017, Projects 목록 F004, Project Detail F005 prev/next, Blog 목록 F006, Blog Detail F007, Legal Index F014)
+- **관련 PROJECT-STRUCTURE 디렉토리**: `app/application/content/{ports,services}/`, `app/infrastructure/content/`
+
+## Scope
+
+### In Scope
+- 3개 Repository Port (`project`, `post`, `legal`) — interface only
+- 6개 Service (`list-projects`, `get-project-detail`(prev/next 포함), `get-featured-project`, `list-posts`, `get-post-detail`, `get-recent-posts`)
+- 추가 service `get-related-posts` (Blog Detail에서 prev/next에 사용)
+- 3개 velite Repository 구현 (Infrastructure)
+- 3개 mapper (velite raw output → Domain Entity)
+- 모든 모듈의 `__tests__/` colocated
+
+### Out of Scope
+- DI Container wiring (T009)
+- 페이지에서 service 호출 (T010~T015)
+- Search index 빌드 service (T016이 별도 service에서 처리)
+- RSS feed service (T014a)
+- Sitemap service (T019)
+
+## Acceptance Criteria
+- [ ] `ProjectRepository.findAll()` / `findBySlug(slug)` / `findFeatured()` / `findRelated(slug) → {prev, next}` / `findByTag(tag)` 인터페이스가 정의됨
+- [ ] `PostRepository.findAll()` / `findBySlug(slug)` / `findRecent(n)` / `findByTag(tag)` / `findRelated(slug) → {prev, next}` 정의
+- [ ] `LegalRepository.findAppDoc(app_slug, doc_type)` / `listApps()` 정의
+- [ ] 6개 Service 구현이 mock Repository로 단위 테스트 통과
+- [ ] velite Repository 구현이 fixture `.velite/*.json`을 매핑하여 Domain Entity 배열 반환
+- [ ] `findRelated(slug)`는 발행일/date 기준 정렬 기준으로 인접 항목을 반환 (첫 항목의 prev = null, 마지막 항목의 next = null)
+- [ ] `bun run test` 모든 `__tests__/` Green
+
+## Implementation Plan (TDD Cycle)
+
+### Red
+모든 service는 mock Repository를 주입하여 케이스별 검증 (Inside-Out 순서로 Application service → Infrastructure repo):
+
+#### Application Services
+- `app/application/content/services/__tests__/list-projects.service.test.ts`
+  - mock repo가 3개 project 반환 → service가 그대로 반환
+  - `tag` 인자 → `findByTag(tag)` 호출 분기
+- `app/application/content/services/__tests__/get-project-detail.service.test.ts`
+  - 정상 slug → `findBySlug` + `findRelated` 모두 호출 + `{project, prev, next}` 반환
+  - 미존재 slug → `findBySlug`가 null 반환 시 `ProjectNotFoundError` throw
+- `app/application/content/services/__tests__/get-featured-project.service.test.ts`
+  - 다수 featured 중 첫 항목만 반환
+  - featured 없음 → null 반환
+- `app/application/content/services/__tests__/list-posts.service.test.ts`
+  - 발행일 역순 정렬 검증
+- `app/application/content/services/__tests__/get-post-detail.service.test.ts`
+  - prev/next 포함, 미존재 시 throw
+- `app/application/content/services/__tests__/get-recent-posts.service.test.ts`
+  - n=3 인자 → mock repo `findRecent(3)` 호출
+
+#### Infrastructure Repositories
+- `app/infrastructure/content/__tests__/velite-project.repository.test.ts`
+  - fixture `.velite/projects.json` (test/fixtures/) → `findAll()` 정상 매핑
+  - `findFeatured()` 우선순위 검증
+  - `findRelated("foo")` → 인접 항목 `{prev, next}` 반환
+- `app/infrastructure/content/__tests__/velite-post.repository.test.ts`
+  - 발행일 역순 정렬
+- `app/infrastructure/content/__tests__/velite-legal.repository.test.ts`
+  - `findAppDoc("moai", "terms")` 정상 매핑
+  - `listApps()` 중복 제거된 app slug 배열 반환
+
+### Green
+- 6개 service 구현 (각 함수형 또는 클래스, port 의존성 주입 받음)
+- 3개 Repository 구현 (`#content/*` path alias로 `.velite/*.json` import → mapper로 Domain Entity 변환)
+- 3개 mapper
+
+### Refactor
+- service 공통 패턴(`assertExists` 등) 추출
+- mapper 공통 helper(`toIsoDate`, `toMetrics`) 추출
+
+## Files to Create / Modify
+
+### Application — Ports
+| Path | Responsibility |
+|------|---------------|
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/application/content/ports/project-repository.port.ts` | `interface ProjectRepository { findAll, findBySlug, findFeatured, findRelated, findByTag }` |
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/application/content/ports/post-repository.port.ts` | `findAll, findBySlug, findRecent, findByTag, findRelated` |
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/application/content/ports/legal-repository.port.ts` | `findAppDoc, listApps` |
+
+### Application — Services
+| Path | Responsibility |
+|------|---------------|
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/application/content/services/list-projects.service.ts` | `(repo, opts?: {tag}) => Project[]` |
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/application/content/services/get-project-detail.service.ts` | `(repo, slug) => {project, prev, next}` |
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/application/content/services/get-featured-project.service.ts` | `(repo) => Project \| null` |
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/application/content/services/list-posts.service.ts` | `(repo, opts?: {tag}) => Post[]` (발행일 역순) |
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/application/content/services/get-post-detail.service.ts` | `(repo, slug) => {post, prev, next}` |
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/application/content/services/get-recent-posts.service.ts` | `(repo, n) => Post[]` |
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/application/content/services/__tests__/*.test.ts` | 6 service tests (Red 케이스 위) |
+
+### Infrastructure — Content Repositories
+| Path | Responsibility |
+|------|---------------|
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/infrastructure/content/velite-project.repository.ts` | implements `ProjectRepository` — `.velite/projects.json` import + mapper |
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/infrastructure/content/velite-post.repository.ts` | implements `PostRepository` |
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/infrastructure/content/velite-legal.repository.ts` | implements `LegalRepository` |
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/infrastructure/content/mappers/project.mapper.ts` | velite raw → `Project` |
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/infrastructure/content/mappers/post.mapper.ts` | velite raw → `Post` |
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/infrastructure/content/mappers/legal.mapper.ts` | velite raw → `AppLegalDoc` |
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/infrastructure/content/__tests__/velite-project.repository.test.ts` | fixture-based tests |
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/infrastructure/content/__tests__/velite-post.repository.test.ts` | fixture-based tests |
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/infrastructure/content/__tests__/velite-legal.repository.test.ts` | fixture-based tests |
+
+### Test Fixtures
+| Path | Responsibility |
+|------|---------------|
+| `/Users/tkstart/Desktop/project/tkstar-dev/test/fixtures/velite-projects.fixture.ts` | mock `.velite/projects.json` 형태 데이터 (3 projects, 1 featured) |
+| `/Users/tkstart/Desktop/project/tkstar-dev/test/fixtures/velite-posts.fixture.ts` | mock posts (4개, 발행일 다양) |
+| `/Users/tkstart/Desktop/project/tkstar-dev/test/fixtures/velite-legal.fixture.ts` | mock legal (moai terms + privacy) |
+
+## Verification Steps
+
+### 자동
+- `bun run test` → 모든 service + repository 테스트 Green
+- `bun run typecheck` → port와 구현체 사이 type contract 일치
+- `bun run lint` 통과
+
+### 수동
+- 없음
+
+### 측정
+- 없음
+
+## Dependencies
+- **Depends on**: T002 (디렉토리), T006 (Domain entity 타입), T007 (`.velite/*.json` 산출물)
+- **Blocks**: T009 (DI container가 service들을 register), T010~T015 (페이지 loader가 service 호출), T016 (search-index service가 ProjectRepository/PostRepository 활용 가능), T017 (DI 통로 공유)
+
+## Risks & Mitigations
+- **Risk**: `.velite/*.json` 직접 import는 dev/build 모두에서 typegen이 필요. velite는 자체 type 생성 기능 제공.
+  - **Mitigation**: velite의 `dts: true` 옵션으로 `.velite/types.d.ts` 자동 생성 + `tsconfig`에 include. mapper에서 velite type → Domain entity로 변환하여 외부 격리.
+- **Risk**: `findRelated`의 정렬 기준이 Project(date YYYY-MM)와 Post(ISO date)가 다름 → 통합 unit test가 필요.
+  - **Mitigation**: Repository 구현 단계에서 date 파싱을 일관되게 처리 (Project의 YYYY-MM은 `${date}-01` 보강).
+
+## References
+- PRD `Page-by-Page` Home/Projects/Project Detail/Blog/Blog Detail/Legal Index Key Features
+- PROJECT-STRUCTURE.md `app/application/` (line 137~) + `app/infrastructure/content/` (line 213~)
+- ROADMAP.md `Phase 2` Task 008
+
+## Change History
+| Date | Changes | Author |
+|------|---------|--------|
+| - | - | - |

--- a/docs/tasks/T009-di-container.md
+++ b/docs/tasks/T009-di-container.md
@@ -1,0 +1,134 @@
+# Task 009 — DI Container (Composition Root) + workers/app.ts wiring + getLoadContext
+
+| Field | Value |
+|-------|-------|
+| **Task ID** | T009 |
+| **Phase** | Phase 2 — Content Pipeline |
+| **Layer** | Infrastructure (`config/`) + Platform Adapter (`workers/`) |
+| **Branch** | `feature/issue-N-di-container` |
+| **Depends on** | T008 |
+| **Blocks** | T010, T011, T012, T013, T014a, T014b, T015, T016, T017 |
+| **PRD Features** | 전반 (모든 유스케이스 주입 통로) |
+| **PRD AC** | — |
+| **예상 작업 시간** | 0.5d |
+| **Status** | Not Started |
+
+## Goal
+PROJECT-STRUCTURE D2 결정에 따라 수제 Plain object DI Container를 `app/infrastructure/config/container.ts`에 구현하고, `workers/app.ts`의 `getLoadContext`로 페이지 loader/action에서 유스케이스를 꺼내 쓸 수 있게 한다.
+
+## Context
+- **Why**: Application service들이 Repository를 직접 import하지 않고 Port에 의존하므로, 어디선가 둘을 묶어주는 Composition Root가 필요. 의존성 그래프가 작아 (~10개) 라이브러리(`awilix`, `tsyringe`)는 ROI 낮음 → 수제 채택.
+- **Phase 진입/완료 연결**: T008 Done 후 즉시. T009가 Done이면 Phase 3 페이지 task에서 `context.container.getProjectDetail(slug)` 식으로 호출 가능.
+- **관련 PRD 섹션**: PRD `Tech Stack — Hosting / Edge`
+- **관련 PROJECT-STRUCTURE 디렉토리**: `app/infrastructure/config/`, `workers/app.ts`, `app/env.d.ts`
+
+## Scope
+
+### In Scope
+- `Container` type 정의 — 모든 유스케이스 service의 함수형 시그니처를 한 객체로 묶음
+- `buildContainer(env: Env): Container` — env 인자로 Repository 인스턴스 생성 + service 인스턴스 조립
+- `workers/app.ts`의 `getLoadContext: () => ({ container: buildContainer(env) })` 연결
+- `app/env.d.ts`에 `interface AppLoadContext { container: Container }` 추가 (RR7 typegen이 loader/action `context` 타입을 자동 추론)
+
+### Out of Scope
+- Resend / Turnstile / KV rate-limiter 등록 (T017에서 Container에 추가)
+- OG renderer 등록 (T018에서 Container에 추가)
+- Search index service 등록 (T016)
+- RSS / Sitemap service 등록 (T014a / T019)
+
+## Acceptance Criteria
+- [ ] `Container` type이 6개 read-side service(listProjects, getProjectDetail, getFeaturedProject, listPosts, getPostDetail, getRecentPosts)를 모두 포함
+- [ ] `buildContainer(env)` 호출 시 모든 service가 정상 인스턴스화됨 (mock env로 단위 테스트)
+- [ ] `workers/app.ts`가 RR7 request handler에 `getLoadContext: () => ({ container: buildContainer(env) })` 전달
+- [ ] `AppLoadContext` 타입이 RR7 loader/action의 `context` 인자 타입에 자동 적용
+- [ ] `wrangler dev`에서 임시 `_index` loader가 `context.container.getFeaturedProject()` 호출 시 정상 동작 (smoke test)
+- [ ] `bun run test` Container 테스트 Green
+
+## Implementation Plan (TDD Cycle)
+
+### Red
+- `app/infrastructure/config/__tests__/container.test.ts`
+  - `buildContainer({})` 호출 시 반환 객체에 6개 service property 존재 (typeof === "function")
+  - 각 service 호출 시 fixture 데이터를 반환 (Repository는 실제 velite repo 인스턴스가 아닌 fixture-backed 변형으로 테스트 — env 분기로 fixture/실제 선택)
+
+### Green
+- `app/infrastructure/config/container.ts`:
+  ```ts
+  export type Container = {
+    listProjects: (opts?: { tag?: string }) => Promise<Project[]>;
+    getProjectDetail: (slug: string) => Promise<{ project: Project; prev: Project | null; next: Project | null }>;
+    getFeaturedProject: () => Promise<Project | null>;
+    listPosts: (opts?: { tag?: string }) => Promise<Post[]>;
+    getPostDetail: (slug: string) => Promise<{ post: Post; prev: Post | null; next: Post | null }>;
+    getRecentPosts: (n: number) => Promise<Post[]>;
+    // T017에서 submitContactForm 추가, T018에서 renderProjectOg 등 추가
+  };
+
+  export function buildContainer(env: Env): Container {
+    const projectRepo = new VeliteProjectRepository();
+    const postRepo = new VelitePostRepository();
+    const legalRepo = new VeliteLegalRepository();
+    return {
+      listProjects: (opts) => listProjectsService(projectRepo, opts),
+      getProjectDetail: (slug) => getProjectDetailService(projectRepo, slug),
+      // ...
+    };
+  }
+  ```
+- `workers/app.ts` 수정 (T003에서 만든 스텁 위에)
+- `app/env.d.ts`에 `AppLoadContext` 추가
+
+### Refactor
+- service들을 화살표 함수가 아닌 명시적 binding (`(opts) => listProjectsService(projectRepo, opts)`)으로 캡처 누수 방지
+- `Container` 타입을 service shapes에서 자동 derive할지(`type Container = {...}`) 명시 list로 둘지는 명시 list 채택 (의존성 그래프 가독성 우선)
+
+## Files to Create / Modify
+
+### Infrastructure — Config
+| Path | Responsibility |
+|------|---------------|
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/infrastructure/config/container.ts` | `Container` type + `buildContainer(env)` |
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/infrastructure/config/__tests__/container.test.ts` | type-level + runtime 검증 |
+
+### Workers Entry (수정)
+| Path | Change |
+|------|--------|
+| `/Users/tkstart/Desktop/project/tkstar-dev/workers/app.ts` | `createRequestHandler({ build, getLoadContext: (c) => ({ container: buildContainer(c.cloudflare.env) }) })`로 wiring |
+
+### Env Types (수정)
+| Path | Change |
+|------|--------|
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/env.d.ts` | `declare module "react-router" { interface AppLoadContext { container: Container } }` 추가 |
+
+## Verification Steps
+
+### 자동
+- `bun run test` Container 테스트 Green
+- `bun run typecheck` 통과 — RR7 loader 시그니처에서 `context.container`가 Container 타입으로 인식
+- `bun run lint` 통과
+
+### 수동
+- `wrangler dev`에서 임시 `_index` loader에 `console.log(await context.container.getFeaturedProject())` 삽입 → seed project 출력 확인 (검증 후 삭제)
+
+### 측정
+- 없음
+
+## Dependencies
+- **Depends on**: T008 (service + Repository 구현)
+- **Blocks**: T010~T015 (페이지 loader가 `context.container` 호출), T016/T017 (각각 search/contact service를 Container에 추가)
+
+## Risks & Mitigations
+- **Risk**: RR7의 `AppLoadContext` 타입 보강 위치(`app/env.d.ts` vs `app/types/`)가 잘못되면 typegen이 인식하지 않음.
+  - **Mitigation**: PROJECT-STRUCTURE.md `app/env.d.ts`에 명시. 검증은 `bun run typecheck`로.
+- **Risk**: `buildContainer`가 매 request마다 호출되면 Repository 인스턴스 재생성으로 메모리 압박.
+  - **Mitigation**: velite Repository는 stateless이며 `.velite/*.json`을 module scope에서 1회 import만 하므로 재생성 비용 무시 가능. 추후 stateful resource(KV, Resend client) 추가 시 module-level singleton으로 캐싱 검토.
+
+## References
+- PROJECT-STRUCTURE.md `D2. DI 컨테이너` (line 573~)
+- PROJECT-STRUCTURE.md `workers/ Directory` (line 357~)
+- ROADMAP.md `Phase 2` Task 009, 가정 D2 확정
+
+## Change History
+| Date | Changes | Author |
+|------|---------|--------|
+| - | - | - |

--- a/docs/tasks/T010-home-page.md
+++ b/docs/tasks/T010-home-page.md
@@ -1,0 +1,129 @@
+# Task 010 — Home Page (F001 Hero + F017 Featured/Recent)
+
+| Field | Value |
+|-------|-------|
+| **Task ID** | T010 |
+| **Phase** | Phase 3 — Core Pages UI |
+| **Layer** | Presentation (route + components) |
+| **Branch** | `feature/issue-N-home-page` |
+| **Depends on** | T005, T008, T009 |
+| **Blocks** | T016 |
+| **PRD Features** | **F001** (Hero), **F017** (Featured + Recent Posts) |
+| **PRD AC** | — (Page-by-Page Key Features 검증) |
+| **예상 작업 시간** | 1d |
+| **Status** | Not Started |
+
+## Goal
+Home(`/`) 페이지에 PRD `F001 Hero (whoami + 검색 + 빠른 링크)` + `F017 Featured Project + Recent Posts 3개`를 렌더한다. 검색 트리거 버튼은 Task 016의 Cmd+K Command Palette를 트리거할 placeholder hook을 미리 연결한다.
+
+## Context
+- **Why**: 사이트의 첫 진입점. B2B/B2C 두 청중을 콘텐츠 라우팅(About / Projects)으로 자연 수렴시키는 패러다임의 시작점. F017 Featured/Recent는 Home의 정보 밀도와 SEO 진입점.
+- **Phase 진입/완료 연결**: T005(Theme/Chrome) + T008(read-side service) + T009(DI) 모두 Done이어야 시작 가능. T010 Done이면 T016이 Home의 검색 트리거를 Cmd+K palette로 본격 연결.
+- **관련 PRD 섹션**: PRD `Page-by-Page — Home Page`, `F001`, `F017`
+- **관련 PROJECT-STRUCTURE 디렉토리**: `app/presentation/routes/_index.tsx`, `app/presentation/components/home/`
+
+## Scope
+
+### In Scope
+- `_index.tsx` loader가 `context.container.getFeaturedProject()` + `context.container.getRecentPosts(3)` 호출
+- Hero(`<HeroWhoami />`) — `whoami` 프롬프트 + "ship solo. ship fast." 카피 + 3-버튼 클러스터 ([검색해서 이동], [/about], [/projects])
+- `<FeaturedProjectCard />` — featured project 카드 (없으면 미렌더)
+- `<RecentPostsList />` — 정확히 3개 PostRow + "모두 보기 →" 링크
+- 검색 트리거 버튼은 `useCommandPalette` hook의 `open()`을 호출 (T016에서 본체 채워짐, T010에서는 hook signature placeholder)
+
+### Out of Scope
+- Cmd+K palette UI 본체 (T016)
+- About 페이지 콘텐츠 (T011)
+- Project Detail / Blog Detail (T013, T014b)
+- 페이지별 meta export(F018) — T019
+
+## Acceptance Criteria
+- [ ] `/` 진입 시 Hero / Featured / Recent 3 섹션이 순서대로 렌더
+- [ ] Hero의 [/about] 클릭 시 `/about`으로 네비게이션
+- [ ] Hero의 [/projects] 클릭 시 `/projects`로 네비게이션
+- [ ] [검색해서 이동] 클릭 시 `useCommandPalette().open()` 호출 (T016 마운트 후 palette 오픈)
+- [ ] Featured Project가 존재할 때 `<FeaturedProjectCard />` 렌더, 없을 때 미렌더 (전체 섹션 conditional)
+- [ ] `<RecentPostsList />`가 정확히 3개 `<PostRow>`를 렌더 + "모두 보기 →" 링크
+- [ ] DOM 구조 snapshot/selector assertion으로 위 3 섹션 순서 보장
+
+## Implementation Plan (TDD Cycle)
+
+### Red
+- `app/presentation/routes/__tests__/_index.test.tsx`
+  - mock container: `getFeaturedProject` resolves project / `getRecentPosts(3)` resolves 3 posts
+  - loader 호출 시 두 service 모두 호출됨 (`expect(mock).toHaveBeenCalledWith(...)`)
+  - RTL 렌더 후 `getByRole('heading', { name: /whoami/i })` / `getByText(/ship solo/i)` / 3-버튼 클러스터 ARIA role / Featured 카드 1개 + PostRow 3개 검증
+  - **Featured 미존재 케이스**: `getFeaturedProject` resolves null → Featured 섹션 미렌더 (`queryByTestId("featured-section")` null)
+- `app/presentation/components/home/__tests__/HeroWhoami.test.tsx`
+  - 3-버튼 클러스터 렌더 + ARIA role
+- `app/presentation/components/home/__tests__/RecentPostsList.test.tsx`
+  - props로 3 posts 전달 → `getAllByRole('article').toHaveLength(3)` + "모두 보기 →" link
+
+### Green
+- `app/presentation/routes/_index.tsx` — loader + 컴포넌트 조합
+- `app/presentation/components/home/HeroWhoami.tsx`
+- `app/presentation/components/home/FeaturedProjectCard.tsx`
+- `app/presentation/components/home/RecentPostsList.tsx`
+- `app/presentation/hooks/useCommandPalette.ts` placeholder (T016에서 본체)
+
+### Refactor
+- HeroWhoami의 카피를 상수로 추출
+- 검색 트리거 버튼을 chrome Topbar의 트리거와 일관된 컴포넌트로 묶을 수 있는지 검토 (T005에서 placeholder 둠)
+
+## Files to Create / Modify
+
+### Presentation — Route (수정)
+| Path | Change |
+|------|--------|
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/presentation/routes/_index.tsx` | placeholder 위에 loader + 컴포넌트 채움 |
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/presentation/routes/__tests__/_index.test.tsx` | RTL + mock container |
+
+### Presentation — Components
+| Path | Responsibility |
+|------|---------------|
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/presentation/components/home/HeroWhoami.tsx` | whoami + 카피 + 3-버튼 |
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/presentation/components/home/FeaturedProjectCard.tsx` | Project 큰 카드 |
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/presentation/components/home/RecentPostsList.tsx` | 3개 PostRow + "모두 보기 →" |
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/presentation/components/home/__tests__/HeroWhoami.test.tsx` | RTL |
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/presentation/components/home/__tests__/RecentPostsList.test.tsx` | RTL |
+
+### Presentation — Hook (placeholder)
+| Path | Responsibility |
+|------|---------------|
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/presentation/hooks/useCommandPalette.ts` | placeholder — `{ open: () => void }` 시그니처만 (T016에서 본체) |
+
+## Verification Steps
+
+### 자동
+- `bun run test` — `_index.test.tsx`, `HeroWhoami.test.tsx`, `RecentPostsList.test.tsx` 모두 Green (Issue #1 보강)
+- loader가 `getFeaturedProject` + `getRecentPosts(3)` 모두 호출 (mock container assertion)
+- DOM 구조 snapshot 또는 명시적 selector assertion으로 Hero / Featured / Recent 3 섹션 순서 보장
+- `bun run typecheck` 통과
+
+### 수동
+- `wrangler dev`에서 `/` 접속 → 3 섹션 렌더 시각 확인
+- [/about] / [/projects] 클릭 → 네비게이션
+- 다크/라이트 모드 시각 회귀
+
+### 측정
+- 없음 (Phase 6 Lighthouse)
+
+## Dependencies
+- **Depends on**: T005 (Theme/Chrome), T008 (`getFeaturedProject`/`getRecentPosts`), T009 (DI)
+- **Blocks**: T016 (Cmd+K가 Home의 트리거에 연결)
+
+## Risks & Mitigations
+- **Risk**: Featured project가 0개일 때 빈 섹션이 어색하게 남음.
+  - **Mitigation**: Featured 미존재 시 전체 `<section>` 자체를 conditional render로 제거. AC에 명시.
+- **Risk**: T016이 아직 없으므로 [검색해서 이동] 버튼이 동작 검증 어려움.
+  - **Mitigation**: `useCommandPalette` hook signature만 T010에서 placeholder로 만들고, T016에서 본체 채우면 자동 통합.
+
+## References
+- PRD `Page-by-Page — Home Page`, `F001`, `F017`
+- PROJECT-STRUCTURE.md `Cross-cutting Concerns Mapping`
+- ROADMAP.md `Phase 3` Task 010 (Issue #1 검증 보강 반영)
+
+## Change History
+| Date | Changes | Author |
+|------|---------|--------|
+| - | - | - |

--- a/docs/tasks/T011-about-page-print.md
+++ b/docs/tasks/T011-about-page-print.md
@@ -1,0 +1,144 @@
+# Task 011 — About Page + F003 PDF 인쇄 스타일
+
+| Field | Value |
+|-------|-------|
+| **Task ID** | T011 |
+| **Phase** | Phase 3 — Core Pages UI |
+| **Layer** | Presentation |
+| **Branch** | `feature/issue-N-about-page-print` |
+| **Depends on** | T005, T008, T009 |
+| **Blocks** | — |
+| **PRD Features** | **F002** (About), **F003** (PDF 저장) |
+| **PRD AC** | **AC-F003-1**, **AC-F003-2**, **AC-F003-3** |
+| **예상 작업 시간** | 1.5d |
+| **Status** | Not Started |
+
+## Goal
+About 페이지를 사이트 자체 이력서 역할로 완성하고, `[⎙ PDF]` 버튼 클릭 시 `window.print()`을 호출하여 `@media print` 전용 스타일로 깨끗한 PDF가 저장되게 한다 (AC-F003-1/2/3 모두 통과).
+
+## Context
+- **Why**: B2B 청중의 1차 검토 자료. PDF 트리를 별도로 두지 않고 CSS print로 완전히 대체. A001 가정 해소 시점.
+- **Phase 진입/완료 연결**: T005(Chrome) + T008(read-side) + T009(DI) Done 후. 다른 task를 막지 않음.
+- **관련 PRD 섹션**: PRD `Page-by-Page — About Page`, `F002`, `F003`, AC-F003-1/2/3
+- **관련 PROJECT-STRUCTURE 디렉토리**: `app/presentation/routes/about.tsx`, `app/presentation/components/about/`, `app/presentation/lib/print.ts`, `app/app.css` (`@media print` 블록)
+
+## Scope
+
+### In Scope
+- About 페이지 콘텐츠 — 헤더(이름 + 포지셔닝 + 이메일 + `[⎙ PDF]` 버튼) / 기술스택 카드 3개(frontend / edge·backend / quality) / 경력(역순) / 학력 / 수상 카드 2개
+- `[⎙ PDF]` 버튼 → `triggerPrint()` 래퍼 호출 (테스트 가능한 분리)
+- `@media print` 블록 — Topbar/Footer/검색트리거/토글 `display: none`, `@page { size: A4; margin: 0 }`, `print-color-adjust: exact`, h2 `break-after: avoid`
+- Snapshot 또는 DOM 구조 assertion으로 print-only 스타일 적용 검증
+- A001 해소 — 자격증은 frontmatter optional 필드 자리만 (현재는 데이터 0개)
+
+### Out of Scope
+- 자격증 데이터 추가 (운영 task)
+- 페이지별 meta export — T019
+- About에서 직접 Project Detail 링크 — T013에서 prev/next 패턴 확정 후 검토
+
+## Acceptance Criteria (PRD AC 인용)
+- [ ] **AC-F003-1**: About 페이지에서 사용자가 `[⎙ PDF]` 버튼을 클릭한다 → `window.print()` 다이얼로그가 열린다 → `@page { size: A4; margin: 0 }` 적용 + Topbar/Footer/검색트리거/토글이 `display: none`으로 시각적으로 숨겨짐
+- [ ] **AC-F003-2**: 본문에 OKLCH 색상이 포함된 섹션이 존재 → 인쇄 미리보기를 본다 → `print-color-adjust: exact`가 적용되어 화면과 동일한 색이 유지됨 (또는 sRGB로 자동 변환되어도 가독성 손상 없음)
+- [ ] **AC-F003-3**: 인쇄 미리보기가 열린 상태 → 페이지 경계에 도달 → 섹션 헤딩(`h2`)이 페이지 하단에 고립되지 않음 (`break-after: avoid` 또는 `page-break-inside: avoid`)
+
+### Task 추가 AC
+- [ ] About 페이지에 헤더 / 기술스택 3 카드 / 경력 / 학력 / 수상 5 영역이 모두 렌더
+- [ ] `triggerPrint()`가 unit test에서 `window.print` mock을 1회 호출
+
+## Implementation Plan (TDD Cycle)
+
+### Red
+- `app/presentation/lib/__tests__/print.test.ts`
+  - `triggerPrint()` 호출 시 `window.print` mock이 1회 호출됨 (jsdom)
+- `app/presentation/components/about/__tests__/AboutHeader.test.tsx`
+  - `[⎙ PDF]` 버튼 클릭 시 `triggerPrint`가 호출됨 (mock injection)
+- `app/presentation/routes/__tests__/about.test.tsx`
+  - 5 영역(헤더/스택/경력/학력/수상) 모두 렌더
+  - DOM에 `@media print` 적용 시 hide 대상이 되는 elements들이 정확한 `data-print-hidden` 또는 className 보유 (snapshot 검증)
+- `app/presentation/components/about/__tests__/print-styles.test.ts` (선택)
+  - `@media print` 적용된 computed style이 jsdom에서 시뮬레이션 가능한 부분만 검증 (jsdom은 print media 일부만 지원하므로 className/data attr 기반 검증으로 대체)
+
+### Green
+- `app/presentation/routes/about.tsx` — 5 영역 컴포넌트 조립
+- `app/presentation/components/about/AboutHeader.tsx` — 이름 + 포지셔닝 + 이메일 + `[⎙ PDF]` 버튼
+- `app/presentation/components/about/StackCards.tsx` — 3 카드 (frontend / edge·backend / quality)
+- `app/presentation/components/about/CareerTimeline.tsx`
+- `app/presentation/components/about/EducationCard.tsx`
+- `app/presentation/components/about/AwardsCard.tsx`
+- `app/presentation/lib/print.ts` — `export function triggerPrint() { window.print(); }`
+- `app/app.css`에 `@media print` 블록:
+  ```css
+  @media print {
+    @page { size: A4; margin: 0; }
+    [data-chrome="topbar"], [data-chrome="footer"], [data-chrome="search-trigger"], [data-chrome="theme-toggle"] { display: none !important; }
+    body { print-color-adjust: exact; -webkit-print-color-adjust: exact; }
+    h2 { break-after: avoid; page-break-after: avoid; }
+  }
+  ```
+
+### Refactor
+- 5 영역 데이터를 `app/presentation/lib/about-data.ts`로 추출 (자격증 추가 시 단일 진입점)
+
+## Files to Create / Modify
+
+### Presentation — Route
+| Path | Responsibility |
+|------|---------------|
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/presentation/routes/about.tsx` | 5 영역 컴포넌트 조립 |
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/presentation/routes/__tests__/about.test.tsx` | RTL + AC-F003 매핑 |
+
+### Presentation — Components
+| Path | Responsibility |
+|------|---------------|
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/presentation/components/about/AboutHeader.tsx` | 헤더 + PDF 버튼 |
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/presentation/components/about/StackCards.tsx` | 3 카드 |
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/presentation/components/about/CareerTimeline.tsx` | 역순 경력 |
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/presentation/components/about/EducationCard.tsx` | 학력 |
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/presentation/components/about/AwardsCard.tsx` | 수상 (자격증은 future optional) |
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/presentation/components/about/__tests__/AboutHeader.test.tsx` | RTL |
+
+### Presentation — Lib
+| Path | Responsibility |
+|------|---------------|
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/presentation/lib/print.ts` | `triggerPrint()` |
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/presentation/lib/__tests__/print.test.ts` | window.print mock |
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/presentation/lib/about-data.ts` | 정적 about 데이터 (Refactor 단계) |
+
+### CSS (수정)
+| Path | Change |
+|------|--------|
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/app.css` | `@media print` 블록 추가. T005에서 `[data-chrome]` data attribute를 chrome 컴포넌트들에 미리 부착했어야 print에서 hide 대상이 됨 — T011 PR에서 chrome 컴포넌트도 `data-chrome` 추가 |
+
+## Verification Steps
+
+### 자동
+- `bun run test` — print/AboutHeader/about route 테스트 모두 Green
+- AC-F003-1/2/3 매핑 테스트가 명시적으로 통과 (each test 이름에 AC ID 포함)
+
+### 수동
+- Chrome 인쇄 미리보기 → Topbar/Footer/검색트리거/토글 미노출, A4 size, 색상 유지, h2 페이지 하단 고립 부재
+- Safari 인쇄 미리보기 추가 검증 (선택)
+- 다크모드에서 인쇄 → 색상 적절하게 변환 (light scheme 자동 fallback이 디자인 의도와 맞는지 확인; PRD는 `print-color-adjust: exact`로 화면과 동일 색을 유도)
+
+### 측정
+- 없음
+
+## Dependencies
+- **Depends on**: T005 (chrome data attribute), T008 (Page-by-Page 데이터 — 정적이지만 Phase 2 후 시작), T009 (DI)
+- **Blocks**: 없음
+
+## Risks & Mitigations
+- **Risk**: jsdom에서 `@media print` 적용 시 computed style이 정확히 시뮬레이션되지 않음.
+  - **Mitigation**: print 스타일 적용을 `data-print-hidden` className 기반으로 검증 + 실제 화면 검증은 수동(Chrome 인쇄 미리보기). AC-F003-1/2/3은 자동 + 수동 조합으로 매핑.
+- **Risk**: `print-color-adjust: exact`가 일부 브라우저에서 무시됨.
+  - **Mitigation**: `-webkit-print-color-adjust` prefixed 함께 작성. AC-F003-2는 "또는 sRGB로 자동 변환되어도 가독성 손상이 없다"로 fallback 허용.
+
+## References
+- PRD `Page-by-Page — About Page`, `F002`, `F003`, AC-F003-1/2/3
+- ROADMAP.md `Phase 3` Task 011, 가정 A001 해소
+- [print-color-adjust MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/print-color-adjust)
+
+## Change History
+| Date | Changes | Author |
+|------|---------|--------|
+| - | - | - |

--- a/docs/tasks/T012-projects-list.md
+++ b/docs/tasks/T012-projects-list.md
@@ -1,0 +1,121 @@
+# Task 012 — Projects Page (F004 ls-style 행 리스트 + 태그 필터)
+
+| Field | Value |
+|-------|-------|
+| **Task ID** | T012 |
+| **Phase** | Phase 3 — Core Pages UI |
+| **Layer** | Presentation |
+| **Branch** | `feature/issue-N-projects-list` |
+| **Depends on** | T005, T008, T009 |
+| **Blocks** | — |
+| **PRD Features** | **F004** (Projects 목록) |
+| **PRD AC** | — (UI 표시 위주, Issue #1 보강으로 자동 테스트 추가) |
+| **예상 작업 시간** | 1d |
+| **Status** | Not Started |
+
+## Goal
+`/projects` 목록 페이지를 ls-style 행 리스트(카드 그리드 X)로 구현하고, 태그 칩 필터를 URLSearchParam(`?tag=xxx`)에 동기화한다. 행 클릭 시 `/projects/:slug`로 네비게이션.
+
+## Context
+- **Why**: B2C 청중에게 "이 사람이 내 문제를 해결할 수 있는가"의 1차 답변. 디자인 정본의 ls-style 행 리스트는 카드 그리드보다 정보 밀도가 높고 터미널 메타포와 일관됨.
+- **Phase 진입/완료 연결**: T005/T008/T009 Done 후. 다른 task와 병렬 가능.
+- **관련 PRD 섹션**: PRD `Page-by-Page — Projects Page`, `F004`
+- **관련 PROJECT-STRUCTURE 디렉토리**: `app/presentation/routes/projects._index.tsx`, `app/presentation/components/project/`, `app/presentation/lib/format.ts`
+
+## Scope
+
+### In Scope
+- `projects._index.tsx` loader: URL `?tag` 파싱 → `context.container.listProjects({ tag })`
+- `<ProjectRow />` — ls-style 행 (`slug/ + title + date(YYYY-MM)` / `summary` / `stack pills`)
+- `<TagFilterChips />` — 모든 unique 태그 추출 + 클릭 시 URL 갱신 (`useSearchParams`)
+- `formatYearMonth(date)` 유틸
+- 행 클릭 시 `<Link to={"/projects/" + slug}>`로 네비게이션
+
+### Out of Scope
+- Project Detail (T013)
+- 페이지별 meta export (T019)
+
+## Acceptance Criteria
+- [ ] `/projects` 진입 시 모든 project가 행 리스트로 렌더 (카드 그리드 아님)
+- [ ] 각 행에 `slug/`, `title`, `date(YYYY-MM)`, `summary`, `stack pills`가 모두 표시
+- [ ] 태그 칩 클릭 시 URL이 `?tag=<tag>`로 변경 + loader가 해당 태그로 필터링된 결과 반환
+- [ ] 행 클릭 시 `/projects/:slug`로 네비게이션
+- [ ] DOM 구조 snapshot 또는 명시적 selector assertion으로 ls-style 행 레이아웃이 grid가 아닌 flat row 구조임을 보장 (Issue #1 보강)
+
+## Implementation Plan (TDD Cycle)
+
+### Red
+- `app/presentation/routes/__tests__/projects._index.test.tsx` (Issue #1 보강)
+  - mock container `listProjects({ tag })`로 호출되는지 (URL `?tag=foo` 인 경우 tag="foo" 전달)
+  - 결과 리스트가 `<ProjectRow>` 갯수와 일치
+- `app/presentation/components/project/__tests__/ProjectRow.test.tsx`
+  - `slug/`, `title`, `date(YYYY-MM)`, `summary`, `stack pills` 모두 RTL `getByText`로 검색 가능
+  - 행 컨테이너에 `<Link to="/projects/${slug}">`가 존재
+- `app/presentation/components/project/__tests__/TagFilterChips.test.tsx`
+  - props로 4 태그 → 4 칩 렌더
+  - 칩 클릭 시 `useSearchParams` setter가 `{ tag: clickedTag }`로 호출됨 (memoryRouter + RTL `userEvent.click`)
+- `app/presentation/lib/__tests__/format.test.ts`
+  - `formatYearMonth("2026-04")` → `"2026-04"` 또는 `"2026.04"` 등 디자인 정본 포맷
+  - ISO date → YYYY-MM 변환 검증
+
+### Green
+- `app/presentation/routes/projects._index.tsx` — loader + 컴포넌트 조합
+- `app/presentation/components/project/ProjectRow.tsx`
+- `app/presentation/components/project/TagFilterChips.tsx`
+- `app/presentation/lib/format.ts` — `formatYearMonth`
+
+### Refactor
+- ls-style 행 레이아웃을 Tailwind utility로 명시적 className (`flex items-baseline gap-`)으로 정리
+
+## Files to Create / Modify
+
+### Presentation — Route
+| Path | Responsibility |
+|------|---------------|
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/presentation/routes/projects._index.tsx` | loader + UI |
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/presentation/routes/__tests__/projects._index.test.tsx` | RTL + URLSearchParam |
+
+### Presentation — Components
+| Path | Responsibility |
+|------|---------------|
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/presentation/components/project/ProjectRow.tsx` | ls-style 행 |
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/presentation/components/project/TagFilterChips.tsx` | 태그 칩 + URLSearchParam |
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/presentation/components/project/__tests__/ProjectRow.test.tsx` | RTL |
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/presentation/components/project/__tests__/TagFilterChips.test.tsx` | RTL + memoryRouter |
+
+### Presentation — Lib
+| Path | Responsibility |
+|------|---------------|
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/presentation/lib/format.ts` | `formatYearMonth(date)` |
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/presentation/lib/__tests__/format.test.ts` | unit |
+
+## Verification Steps
+
+### 자동
+- `bun run test` — projects._index / ProjectRow / TagFilterChips / format 테스트 모두 Green (Issue #1 보강)
+- DOM 구조 snapshot 또는 selector assertion으로 행 레이아웃 보장
+
+### 수동
+- `wrangler dev`에서 `/projects` 접속 → 행 리스트 시각 확인
+- 태그 칩 클릭 → URL 변경 + 결과 필터링
+- 행 클릭 → Project Detail로 네비게이션
+
+### 측정
+- 없음
+
+## Dependencies
+- **Depends on**: T005 (Theme/Chrome), T008 (`listProjects`), T009 (DI)
+- **Blocks**: 없음
+
+## Risks & Mitigations
+- **Risk**: 태그 필터 후 결과 0개일 때 빈 화면.
+  - **Mitigation**: empty state placeholder ("해당 태그의 프로젝트가 없어요") 추가.
+
+## References
+- PRD `Page-by-Page — Projects Page`, `F004`
+- ROADMAP.md `Phase 3` Task 012 (Issue #1 검증 보강 반영)
+
+## Change History
+| Date | Changes | Author |
+|------|---------|--------|
+| - | - | - |

--- a/docs/tasks/T013-project-detail.md
+++ b/docs/tasks/T013-project-detail.md
@@ -1,0 +1,142 @@
+# Task 013 — Project Detail Page (F005 + sticky sidebar + on-this-page TOC)
+
+| Field | Value |
+|-------|-------|
+| **Task ID** | T013 |
+| **Phase** | Phase 3 — Core Pages UI |
+| **Layer** | Presentation + Application(`getProjectDetail`) |
+| **Branch** | `feature/issue-N-project-detail` |
+| **Depends on** | T005, T007, T008, T009 |
+| **Blocks** | T018 (OG) |
+| **PRD Features** | **F005** (Project Case Study) |
+| **PRD AC** | — (UI 표시 위주, OG는 Phase 5 F011) |
+| **예상 작업 시간** | 1.5d |
+| **Status** | Not Started |
+
+## Goal
+Project Detail 페이지를 Case Study 구조(문제 → 접근 → 결과)로 완성하고, 데스크탑 880px+에서 sticky sidebar(meta + on-this-page TOC)를 가동시킨다. `← prev` / `의뢰하기 →` (primary) / `next →` 3분할 푸터 포함. velite 후처리로 TOC를 frontmatter에 자동 주입하여 가정 A002 완료.
+
+## Context
+- **Why**: B2C 청중의 신뢰성 검증 핵심 페이지. sticky sidebar TOC는 긴 본문에서 섹션 점프를 가능하게 하고, "의뢰하기 →" CTA는 모든 콘텐츠 페이지의 최종 수렴점.
+- **Phase 진입/완료 연결**: T007에 rehype-slug 적용 완료 후 시작. T013 Done이면 T018(OG)이 Project Detail의 frontmatter를 사용 가능.
+- **관련 PRD 섹션**: PRD `Page-by-Page — Project Detail Page`, `F005`
+- **관련 PROJECT-STRUCTURE 디렉토리**: `app/presentation/routes/projects.$slug.tsx`, `app/presentation/components/project/`
+
+## Scope
+
+### In Scope
+- `projects.$slug.tsx` loader: `getProjectDetail(slug)` 호출 → `{project, prev, next}` 반환, 미존재 slug throw → splat fallback
+- 본문 problem / approach / results 섹션 렌더 (MDX body)
+- `<ProjectMetaSidebar />` — year / role / stack pills (sticky 880px+)
+- `<OnThisPageToc />` — h2 헤딩 자동 추출 anchor
+- velite 후처리 — `velite.config.ts`의 `transform` hook에서 본문 h2 헤딩을 `toc` frontmatter 필드로 주입 (가정 A002 2단계 완료)
+- `<ProjectFooterNav />` — 3분할 (`← prev` / `의뢰하기 →` primary / `next →`)
+- 모바일 < 880px에서는 sidebar inline
+
+### Out of Scope
+- Satori OG (T018)
+- 페이지별 meta export (T019)
+
+## Acceptance Criteria
+- [ ] `/projects/:slug` 진입 시 본문 problem/approach/results 섹션 렌더
+- [ ] 데스크탑 880px+에서 sticky sidebar(`.two-col`)에 meta(year/role/stack pills) + TOC가 노출
+- [ ] 모바일 < 880px에서는 sidebar inline (sticky 미적용)
+- [ ] TOC 클릭 시 해당 h2로 스크롤 (`#${slug}` anchor)
+- [ ] 하단 3분할 푸터 — prev/next는 collection의 인접 항목, 가운데 [의뢰하기 →]는 `/contact`로 primary CTA
+- [ ] 미존재 slug 접속 시 splat 라우트로 fallback (404 응답)
+- [ ] 가정 A002 완료 — `toc` 필드가 frontmatter에 자동 주입됨
+
+## Implementation Plan (TDD Cycle)
+
+### Red
+- `app/presentation/routes/__tests__/projects.$slug.test.tsx`
+  - mock container `getProjectDetail("foo")` → `{project, prev, next}` 반환
+  - 본문 + meta sidebar + TOC + footer nav 렌더
+  - `getProjectDetail("missing")` throw → ErrorBoundary 또는 splat 처리
+- `app/presentation/components/project/__tests__/OnThisPageToc.test.tsx`
+  - props `toc: [{slug, text}]` → `<a href="#${slug}">{text}</a>` 리스트 렌더
+- `app/presentation/components/project/__tests__/ProjectFooterNav.test.tsx`
+  - prev null → `<span>` (link 없음), next null → 동일
+  - "의뢰하기 →" 항상 노출, `/contact` 링크
+- velite 후처리 검증:
+  - `test/integration/velite-toc-extraction.test.ts` (선택) — `bunx velite build` 후 `.velite/projects.json`의 첫 항목에 `toc: [{slug, text}]` 배열 존재
+
+### Green
+- `velite.config.ts`의 project 컬렉션에 `transform` 추가:
+  ```ts
+  transform: async (data) => {
+    const tocItems = extractH2(data.body); // markdown ast 파싱 또는 rendered html parse
+    return { ...data, toc: tocItems };
+  }
+  ```
+  - `extractH2`는 mdast 또는 hast 통해 h2 노드 추출 → `{slug, text}` 배열 (rehype-slug가 이미 id를 부착했으므로 동일 slug 사용)
+- `projects.$slug.tsx` — loader + 컴포넌트
+- `ProjectMetaSidebar`, `OnThisPageToc`, `ProjectFooterNav`
+
+### Refactor
+- TOC 추출 로직을 `velite/transforms/extract-toc.ts`로 분리하여 Post에서도 재사용 가능 (T014b 활용)
+
+## Files to Create / Modify
+
+### Velite (수정)
+| Path | Change |
+|------|--------|
+| `/Users/tkstart/Desktop/project/tkstar-dev/velite.config.ts` | project 컬렉션에 `transform` 추가하여 `toc` 필드 주입. post 컬렉션도 동일 transform 재사용 (T014b) |
+| `/Users/tkstart/Desktop/project/tkstar-dev/velite/transforms/extract-toc.ts` | h2 추출 helper |
+
+### Domain (수정)
+| Path | Change |
+|------|--------|
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/domain/project/project.schema.ts` | `toc: z.array(z.object({slug, text})).optional()` 필드 추가 |
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/domain/post/post.schema.ts` | 동일 (T014b 사용) |
+
+### Presentation — Route
+| Path | Responsibility |
+|------|---------------|
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/presentation/routes/projects.$slug.tsx` | loader + UI |
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/presentation/routes/__tests__/projects.$slug.test.tsx` | RTL |
+
+### Presentation — Components
+| Path | Responsibility |
+|------|---------------|
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/presentation/components/project/ProjectMetaSidebar.tsx` | sticky meta box |
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/presentation/components/project/OnThisPageToc.tsx` | TOC anchor list |
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/presentation/components/project/ProjectFooterNav.tsx` | prev/next/의뢰하기 |
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/presentation/components/project/__tests__/OnThisPageToc.test.tsx` | RTL |
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/presentation/components/project/__tests__/ProjectFooterNav.test.tsx` | RTL |
+
+## Verification Steps
+
+### 자동
+- `bun run test` — projects.$slug / OnThisPageToc / ProjectFooterNav 모두 Green
+- velite build 후 `.velite/projects.json`에 `toc` 필드 존재 확인 (선택 integration test)
+- `bun run typecheck` 통과
+
+### 수동
+- `wrangler dev` `/projects/example-project` → 본문 + sticky sidebar 시각 확인
+- 데스크탑 ≥880px에서 스크롤 시 sidebar fixed
+- 모바일 viewport에서 sidebar inline
+- TOC 항목 클릭 → 해당 h2로 스크롤
+- prev/next 링크 검증
+
+### 측정
+- 없음
+
+## Dependencies
+- **Depends on**: T005 (Theme), T007 (rehype-slug for h2 anchors), T008 (`getProjectDetail`), T009 (DI)
+- **Blocks**: T018 (OG가 Project Detail frontmatter 사용)
+
+## Risks & Mitigations
+- **Risk**: velite transform에서 mdast 파싱 비용이 큼.
+  - **Mitigation**: 빌드 타임 1회만 수행되므로 런타임 영향 없음. 콘텐츠 100+ 시 캐싱 검토.
+- **Risk**: sticky sidebar가 짧은 본문에서 의도와 다르게 노출.
+  - **Mitigation**: `top: 88px` + `overflow-y: auto` + `max-height: calc(100vh - 100px)` 적용.
+
+## References
+- PRD `Page-by-Page — Project Detail Page`, `F005`
+- ROADMAP.md `Phase 3` Task 013, 가정 A002 완료
+
+## Change History
+| Date | Changes | Author |
+|------|---------|--------|
+| - | - | - |

--- a/docs/tasks/T014a-blog-list-rss.md
+++ b/docs/tasks/T014a-blog-list-rss.md
@@ -1,0 +1,130 @@
+# Task 014a — Blog Page (F006) — 목록 + 태그 필터 + RSS Resource Route (F012)
+
+| Field | Value |
+|-------|-------|
+| **Task ID** | T014a |
+| **Phase** | Phase 3 — Core Pages UI |
+| **Layer** | Presentation + Application(`build-rss-feed.service`) + Resource Route |
+| **Branch** | `feature/issue-N-blog-list-rss` |
+| **Depends on** | T005, T007, T008, T009 |
+| **Blocks** | T014b, T018 |
+| **PRD Features** | **F006** (Blog 목록), **F012** (RSS) |
+| **PRD AC** | — (UI 표시 + RSS XML well-formed) |
+| **예상 작업 시간** | 1d |
+| **Status** | Not Started |
+
+## Goal
+`/blog` 목록 페이지를 발행일 역순 + 태그 필터 + 행 형태로 구현하고, `/rss.xml` 리소스 라우트가 RSS 2.0 well-formed XML을 반환하게 한다. T014b(Blog Detail)의 사전 단계.
+
+## Context
+- **Why**: Blog는 월 1편 작성으로 전문성 노출 + SEO 자산 누적. RSS는 구독자 채널 확보. T014가 Blog+Detail+RSS 묶음으로 너무 컸으므로 검증 리포트 Issue #4에 따라 T014a/T014b로 분할.
+- **Phase 진입/완료 연결**: T007 + T008 + T009 Done 후. T014a Done이면 T014b Blog Detail이 시작 가능.
+- **관련 PRD 섹션**: PRD `Page-by-Page — Blog Page`, `F006`, `F012`
+- **관련 PROJECT-STRUCTURE 디렉토리**: `app/presentation/routes/{blog._index.tsx, rss[.xml].tsx}`, `app/presentation/components/post/PostRow.tsx`, `app/application/feed/services/build-rss-feed.service.ts`
+
+## Scope
+
+### In Scope
+- `blog._index.tsx` loader: `?tag` 파싱 → `listPosts({ tag })`, 발행일 역순
+- `<PostRow />` — 제목/date/lede/tags/read 표시
+- `<TagFilterChips />` — Project와 동일 패턴 (T012 컴포넌트 재사용 또는 generic 도입)
+- `build-rss-feed.service.ts` — 모든 post를 RSS 2.0 XML 문자열로 변환
+- `rss[.xml].tsx` resource route — `Content-Type: application/xml` 응답
+
+### Out of Scope
+- Blog Detail (T014b)
+- 페이지별 meta export (T019)
+
+## Acceptance Criteria
+- [ ] `/blog` 진입 시 모든 post가 발행일 역순으로 행 형태로 렌더
+- [ ] 각 행에 제목, date, lede, tags, read 표시
+- [ ] 태그 칩 클릭 시 URL `?tag=<tag>` 변경 + 필터링 결과
+- [ ] `/rss.xml` 응답이 RSS 2.0 well-formed XML, `<rss version="2.0">`, `<channel>`, `<title>`, `<link>`, `<description>`, `<item>{title,link,description,pubDate,guid}` 포함
+- [ ] item 수 = 모든 post 수
+- [ ] `Content-Type: application/xml` 헤더
+
+## Implementation Plan (TDD Cycle)
+
+### Red
+- `app/presentation/routes/__tests__/blog._index.test.tsx` (Issue #1 보강)
+  - mock container `listPosts({ tag })` 호출 + 발행일 역순 정렬 검증 (`getAllByRole('article')` 순서 = mock 결과 순서)
+  - 태그 칩 클릭 → `?tag=` URLSearchParam
+- `app/presentation/components/post/__tests__/PostRow.test.tsx`
+  - 제목/date/lede/tags/read 5 필드 모두 RTL `getByText`
+- `app/application/feed/services/__tests__/build-rss-feed.service.test.ts`
+  - mock posts 3개 → RSS 2.0 well-formed XML 반환
+  - `<title>`, `<link>`, `<description>`, `<item>` 갯수 = 3
+  - `pubDate`가 RFC 822 형식 ISO date 변환
+- `app/presentation/routes/__tests__/rss.test.ts`
+  - loader 호출 → `Response`의 `Content-Type === "application/xml"`, body가 `<?xml version="1.0"`로 시작
+
+### Green
+- `blog._index.tsx` + `<PostRow />`
+- `build-rss-feed.service.ts` — 순수 함수, posts 배열 → XML 문자열 (template literal 또는 `xml-js`)
+- `rss[.xml].tsx` loader — `context.container.buildRssFeed()` 호출 → `Response(xml, { headers })`
+- DI Container에 `buildRssFeed` service 등록 (T009 container 확장)
+
+### Refactor
+- `<TagFilterChips />`를 T012의 컴포넌트 재사용 (이미 generic이라면 import만)
+- RSS XML escape를 utility 함수로 분리 (`escapeXml(text)`)
+
+## Files to Create / Modify
+
+### Application — Service
+| Path | Responsibility |
+|------|---------------|
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/application/feed/services/build-rss-feed.service.ts` | posts → RSS 2.0 XML |
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/application/feed/services/__tests__/build-rss-feed.service.test.ts` | unit |
+
+### Presentation — Routes
+| Path | Responsibility |
+|------|---------------|
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/presentation/routes/blog._index.tsx` | loader + UI |
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/presentation/routes/rss[.xml].tsx` | resource route — XML response |
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/presentation/routes/__tests__/blog._index.test.tsx` | RTL (Issue #1) |
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/presentation/routes/__tests__/rss.test.ts` | response unit |
+
+### Presentation — Components
+| Path | Responsibility |
+|------|---------------|
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/presentation/components/post/PostRow.tsx` | 행 (제목/date/lede/tags/read) |
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/presentation/components/post/__tests__/PostRow.test.tsx` | RTL |
+
+### Infrastructure — Config (수정)
+| Path | Change |
+|------|--------|
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/infrastructure/config/container.ts` | `buildRssFeed: () => Promise<string>` 추가 |
+
+## Verification Steps
+
+### 자동
+- `bun run test` — 4 테스트 셋 (`blog._index`, `PostRow`, `build-rss-feed.service`, `rss`) 모두 Green
+- RSS XML이 well-formed임을 정규식 또는 `fast-xml-parser`로 파싱 검증
+
+### 수동
+- `wrangler dev` `/blog` → 행 리스트 시각 확인
+- `/rss.xml`을 RSS 리더(예: NetNewsWire)에 등록 → 정상 구독 확인 (선택)
+- 브라우저에서 `/rss.xml` 직접 열기 → XML 트리 표시
+
+### 측정
+- 없음
+
+## Dependencies
+- **Depends on**: T005, T007 (`.velite/posts.json`), T008 (`listPosts`), T009 (DI)
+- **Blocks**: T014b (Blog Detail), T018 (OG가 Blog frontmatter 사용)
+
+## Risks & Mitigations
+- **Risk**: RSS XML 안의 본문 또는 lede에 `<`, `&` 등 escape 누락.
+  - **Mitigation**: `escapeXml(text)` 유틸로 모든 사용자 입력 escape.
+- **Risk**: `pubDate`의 timezone 처리.
+  - **Mitigation**: ISO date → RFC 822 변환 시 UTC로 통일.
+
+## References
+- PRD `Page-by-Page — Blog Page`, `F006`, `F012`
+- ROADMAP.md `Phase 3` Task 014a (검증 리포트 Issue #4 분할)
+- [RSS 2.0 spec](https://www.rssboard.org/rss-specification)
+
+## Change History
+| Date | Changes | Author |
+|------|---------|--------|
+| - | - | - |

--- a/docs/tasks/T014b-blog-detail.md
+++ b/docs/tasks/T014b-blog-detail.md
@@ -1,0 +1,115 @@
+# Task 014b — Blog Detail Page (F007) — 본문 + sticky sidebar + share
+
+| Field | Value |
+|-------|-------|
+| **Task ID** | T014b |
+| **Phase** | Phase 3 — Core Pages UI |
+| **Layer** | Presentation |
+| **Branch** | `feature/issue-N-blog-detail` |
+| **Depends on** | T014a |
+| **Blocks** | T018 |
+| **PRD Features** | **F007** (Blog 상세) |
+| **PRD AC** | — (UI 표시 위주) |
+| **예상 작업 시간** | 1d |
+| **Status** | Not Started |
+
+## Goal
+`/blog/:slug` 상세 페이지를 MDX 본문 + shiki 코드블록 + 데스크탑 880px+ sticky sidebar(TOC + share)로 구현하고, 하단 3분할 네비(`← prev` / `[모든 글]` / `next →`)을 가동시킨다.
+
+## Context
+- **Why**: 글 단위 SEO 진입점. 외부 검색에서 직접 도달하는 첫 페이지로 자주 동작. share 도구는 X 공유 + copy link로 셀프 promotion 가능.
+- **Phase 진입/완료 연결**: T014a Done 후. T014b Done이면 T018 OG가 Blog frontmatter 사용 가능.
+- **관련 PRD 섹션**: PRD `Page-by-Page — Blog Detail Page`, `F007`
+- **관련 PROJECT-STRUCTURE 디렉토리**: `app/presentation/routes/blog.$slug.tsx`, `app/presentation/components/post/ShareTools.tsx`
+
+## Scope
+
+### In Scope
+- `blog.$slug.tsx` loader: `getPostDetail(slug)` 호출 → `{post, prev, next}`, 미존재 throw → splat fallback
+- MDX 본문 + shiki 코드블록 (T007에서 가동)
+- T013의 `<OnThisPageToc />` 재사용 (post에도 `toc` 필드 transform — T013에서 추가됨)
+- `<ShareTools />` — copy link 버튼 (`navigator.clipboard.writeText`) + X 공유 링크 (`https://x.com/intent/post?text=...&url=...`)
+- 하단 3분할 (`← prev` / `[모든 글] → /blog` / `next →`)
+- 데스크탑 880px+에서 sticky sidebar(TOC + share)
+
+### Out of Scope
+- Satori OG (T018)
+- 페이지별 meta export (T019)
+
+## Acceptance Criteria
+- [ ] `/blog/:slug` 진입 시 본문 + shiki 코드블록 렌더
+- [ ] 데스크탑 880px+에서 sticky sidebar(TOC + share) 노출
+- [ ] copy link 버튼 클릭 시 `navigator.clipboard.writeText` 호출 + 시각 피드백 ("복사됨" toast 또는 inline)
+- [ ] X 공유 링크가 `https://x.com/intent/post?text=<title>&url=<canonical>` 형식
+- [ ] 하단 3분할 (`← prev` / `[모든 글]` / `next →`) — prev/next는 collection 인접 항목, 미존재 시 `<span>`
+- [ ] 미존재 slug 접속 시 splat fallback
+
+## Implementation Plan (TDD Cycle)
+
+### Red
+- `app/presentation/routes/__tests__/blog.$slug.test.tsx`
+  - mock container `getPostDetail("foo")` → `{post, prev, next}` 정상 케이스
+  - 미존재 slug → throw → ErrorBoundary
+  - 본문 + sidebar + footer 3 섹션 모두 렌더
+- `app/presentation/components/post/__tests__/ShareTools.test.tsx`
+  - copy link 클릭 → `navigator.clipboard.writeText` mock이 정확한 URL로 호출
+  - X 공유 링크의 `href` 값 검증 (`startsWith("https://x.com/intent/post?")` + `text` + `url` 쿼리 포함)
+
+### Green
+- `blog.$slug.tsx` — loader + 컴포넌트
+- `<ShareTools />` — copy link + X 공유
+- `<OnThisPageToc />` 재사용 (post용)
+- `<PostFooterNav />` (또는 generic `<DetailFooterNav />`로 ProjectFooterNav와 통합)
+
+### Refactor
+- `<DetailFooterNav />` 통합 컴포넌트 (project/post 공통) — props로 prev/next/center variant
+- `<OnThisPageToc />`를 component-level로 추출
+
+## Files to Create / Modify
+
+### Presentation — Route
+| Path | Responsibility |
+|------|---------------|
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/presentation/routes/blog.$slug.tsx` | loader + UI |
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/presentation/routes/__tests__/blog.$slug.test.tsx` | RTL |
+
+### Presentation — Components
+| Path | Responsibility |
+|------|---------------|
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/presentation/components/post/ShareTools.tsx` | copy link + X 공유 |
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/presentation/components/post/__tests__/ShareTools.test.tsx` | RTL + clipboard mock |
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/presentation/components/post/PostFooterNav.tsx` (or shared `<DetailFooterNav />`) | 3분할 footer |
+
+## Verification Steps
+
+### 자동
+- `bun run test` — `blog.$slug` + `ShareTools` 모두 Green
+- `bun run typecheck` 통과
+
+### 수동
+- `wrangler dev` `/blog/2026-04-shipping-solo` → 본문 + 코드블록 + sticky sidebar 시각 확인
+- copy link 클릭 → 클립보드에 URL 복사
+- X 공유 링크 클릭 → X 새 창 + prefill text/url
+- 모바일에서 sidebar inline
+
+### 측정
+- 없음
+
+## Dependencies
+- **Depends on**: T014a (PostRow / RSS / blog list)
+- **Blocks**: T018 (OG)
+
+## Risks & Mitigations
+- **Risk**: `navigator.clipboard.writeText`가 Safari에서 user gesture 외 호출 시 reject.
+  - **Mitigation**: 반드시 click handler 안에서 호출.
+- **Risk**: shiki 출력이 Cloudflare Workers SSR에서 dehydrate-rehydrate 사이클에 mismatch 위험.
+  - **Mitigation**: shiki는 빌드 타임 산출물이므로 SSR에서도 동일 HTML 문자열 → mismatch 없음.
+
+## References
+- PRD `Page-by-Page — Blog Detail Page`, `F007`
+- ROADMAP.md `Phase 3` Task 014b (검증 리포트 Issue #4 분할)
+
+## Change History
+| Date | Changes | Author |
+|------|---------|--------|
+| - | - | - |

--- a/docs/tasks/T015-legal-pages.md
+++ b/docs/tasks/T015-legal-pages.md
@@ -1,0 +1,121 @@
+# Task 015 — Legal Index + App Terms + App Privacy (F014, chrome-free)
+
+| Field | Value |
+|-------|-------|
+| **Task ID** | T015 |
+| **Phase** | Phase 3 — Core Pages UI |
+| **Layer** | Presentation |
+| **Branch** | `feature/issue-N-legal-pages` |
+| **Depends on** | T005, T007, T008, T009 |
+| **Blocks** | — |
+| **PRD Features** | **F014** (앱 약관 라우팅) |
+| **PRD AC** | — (Page-by-Page Key Features 검증, F018 차등 인덱싱은 Phase 5) |
+| **예상 작업 시간** | 1d |
+| **Status** | Not Started |
+
+## Goal
+Legal Index(`/legal`)에 등록된 앱 카드를 표시하고, `/legal/:app/terms` / `/legal/:app/privacy`를 chrome-free 레이아웃(Topbar/Footer 미노출, max-width 680px)으로 렌더한다. Footer Legal 링크는 앱 1개 이상일 때만 노출.
+
+## Context
+- **Why**: 앱 출시 시 약관 URL이 필요. 앱 내부 WebView에서 호출되므로 chrome-free sober 모드 필수. MVP에서는 1개 seed(`moai`)만 가동, 앱 출시 시 점진적 추가.
+- **Phase 진입/완료 연결**: T005/T007/T008/T009 Done 후. 다른 Phase 3 task와 병렬 가능.
+- **관련 PRD 섹션**: PRD `Page-by-Page — Legal Index / App Terms / App Privacy`, `F014`
+- **관련 PROJECT-STRUCTURE 디렉토리**: `app/presentation/routes/{legal._index, legal.$app.terms, legal.$app.privacy}.tsx`, `app/presentation/components/legal/`, `app/presentation/components/chrome/Footer.tsx`(수정)
+
+## Scope
+
+### In Scope
+- `legal._index.tsx` loader: `listApps()` → 앱 카드 목록
+- `legal.$app.terms.tsx` / `legal.$app.privacy.tsx` loader: `findAppDoc(app, "terms"|"privacy")` → MDX 본문 (chrome-free)
+- `<AppCard />` — 앱명 / slug / [terms.mdx] / [privacy.mdx] 링크
+- `<LegalDocLayout />` — chrome-free 컨테이너 wrapper (T004의 `<ChromeFreeLayout />` 위에 sober 토큰 적용)
+- `<Footer />` 수정 — `appCount > 0`이면 Legal 링크 노출, 0이면 미노출
+
+### Out of Scope
+- F018 차등 인덱싱 meta `noindex, follow` (T019)
+- 페이지별 meta export (T019)
+- chrome-free 레이아웃 자체 (T004에서 만든 `<ChromeFreeLayout />` 재사용)
+
+## Acceptance Criteria
+- [ ] `/legal` 인덱스에 등록된 앱 카드(`<AppCard />`) 갯수 = `listApps()` 결과 길이 (seed: 1개 `moai`)
+- [ ] `/legal/moai/terms`와 `/legal/moai/privacy`가 chrome-free 레이아웃으로 렌더 (Topbar/Footer 미노출, max-width 680px)
+- [ ] Footer가 일반 페이지에서 — `appCount === 0`이면 Legal 링크 미렌더, `appCount > 0`이면 노출
+- [ ] DOM 구조 snapshot/className assertion으로 chrome-free 본문 영역 보장 (Issue #1 보강)
+
+## Implementation Plan (TDD Cycle)
+
+### Red
+- `app/presentation/routes/__tests__/legal._index.test.tsx` (Issue #1 보강)
+  - mock container `listApps()` → `["moai"]` 반환
+  - `<AppCard />` 1개 렌더 + `[terms.mdx]` `[privacy.mdx]` 링크
+- `app/presentation/routes/__tests__/legal.$app.terms.test.tsx`
+  - mock container `findAppDoc("moai", "terms")` 호출
+  - chrome-free 본문 렌더 (Topbar/Footer 미렌더)
+- `app/presentation/components/chrome/__tests__/Footer.test.tsx`
+  - `appCount: 0` props → Legal 링크 미렌더 (`queryByRole('link', { name: /legal/i })` null)
+  - `appCount: 1` → Legal 링크 노출
+- `app/presentation/layouts/__tests__/ChromeFreeLayout.test.tsx` (T004 보강)
+  - `max-width: 680px` className 적용 검증
+
+### Green
+- 3개 라우트 본체
+- `<AppCard />`, `<LegalDocLayout />`
+- `<Footer />` 수정 — `appCount` props 또는 loader data로부터 분기
+
+### Refactor
+- Footer의 `appCount`를 root loader에서 한 번 계산하여 `useRouteLoaderData`로 전파 (per-page loader 호출 비용 절감)
+
+## Files to Create / Modify
+
+### Presentation — Routes
+| Path | Responsibility |
+|------|---------------|
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/presentation/routes/legal._index.tsx` | 앱 목록 |
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/presentation/routes/legal.$app.terms.tsx` | chrome-free terms |
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/presentation/routes/legal.$app.privacy.tsx` | chrome-free privacy |
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/presentation/routes/__tests__/legal._index.test.tsx` | RTL |
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/presentation/routes/__tests__/legal.$app.terms.test.tsx` | RTL |
+
+### Presentation — Components
+| Path | Responsibility |
+|------|---------------|
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/presentation/components/legal/AppCard.tsx` | 앱 카드 |
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/presentation/components/legal/LegalDocLayout.tsx` | sober mode wrapper |
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/presentation/components/chrome/Footer.tsx` (수정) | `appCount > 0`일 때 Legal 링크 |
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/presentation/components/chrome/__tests__/Footer.test.tsx` | Legal 링크 조건부 |
+
+### Root (수정)
+| Path | Change |
+|------|--------|
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/root.tsx` | root loader에 `listApps().length` 호출 추가 → `useRouteLoaderData("root")`에서 `appCount` 사용 |
+
+## Verification Steps
+
+### 자동
+- `bun run test` — 4 테스트 셋 모두 Green (Issue #1 보강)
+- `bun run typecheck` 통과
+
+### 수동
+- `wrangler dev`에서 `/legal/moai/terms` / `/legal/moai/privacy` 직접 접속 → chrome-free 시각 확인 (Topbar/Footer 미노출)
+- 일반 페이지에서 Footer Legal 링크 노출 확인
+- seed 콘텐츠를 0개로 만들어 `appCount === 0` 케이스 시각 확인 (선택)
+
+### 측정
+- 없음
+
+## Dependencies
+- **Depends on**: T005 (Theme/Chrome), T007 (legal seed MDX), T008 (`listApps`/`findAppDoc`), T009 (DI)
+- **Blocks**: 없음
+
+## Risks & Mitigations
+- **Risk**: chrome-free 레이아웃의 max-width가 모바일에서 의도와 어긋남.
+  - **Mitigation**: `max-width: 680px` + `padding: 1rem`로 viewport < 680px도 자연스럽게 fit.
+
+## References
+- PRD `Page-by-Page — Legal Index / App Terms / App Privacy`, `F014`
+- ROADMAP.md `Phase 3` Task 015 (Issue #1 검증 보강 반영)
+
+## Change History
+| Date | Changes | Author |
+|------|---------|--------|
+| - | - | - |

--- a/docs/tasks/T016-command-palette.md
+++ b/docs/tasks/T016-command-palette.md
@@ -1,0 +1,151 @@
+# Task 016 — F016 Cmd+K Command Palette (글로벌 검색 네비)
+
+| Field | Value |
+|-------|-------|
+| **Task ID** | T016 |
+| **Phase** | Phase 4 — Forms / Email |
+| **Layer** | Application(`build-search-index.service`) + Presentation(palette UI/hook) |
+| **Branch** | `feature/issue-N-command-palette` |
+| **Depends on** | T003, T008, T009, T010 |
+| **Blocks** | — |
+| **PRD Features** | **F016** (Cmd+K Command Palette) |
+| **PRD AC** | **AC-F016-1**, **AC-F016-2**, **AC-F016-3**, **AC-F016-4**, **AC-F016-5** |
+| **예상 작업 시간** | 1.5d |
+| **Status** | Not Started |
+
+## Goal
+사이트의 주 네비게이션 패러다임인 Cmd+K Command Palette를 가동시킨다. ⌘K(macOS) / Ctrl+K(Windows·Linux) / `/` 단축키로 오픈, 토큰 기반 다중 키워드 필터, 키보드/마우스 네비, 빌드 타임 검색 인덱스 lazy fetch까지 모두 AC 통과.
+
+## Context
+- **Why**: 검색이 주 네비게이션이라는 사이트 패러다임의 핵심. 기존 메뉴 버튼 대신 palette 1개로 모든 라우트 + project/post slug에 도달.
+- **Phase 진입/완료 연결**: T010 Done 이후 (Home의 검색 트리거가 palette를 oepn). T016 Done이면 모든 페이지에서 단축키로 palette 사용 가능.
+- **관련 PRD 섹션**: PRD `F016`, AC-F016-1~5
+- **관련 PROJECT-STRUCTURE 디렉토리**: `app/application/search/services/build-search-index.service.ts`, `app/presentation/hooks/useCommandPalette.ts`, `app/presentation/components/palette/CommandPalette.tsx`, `public/search-index.json`(빌드 산출물)
+
+## Scope
+
+### In Scope
+- `build-search-index.service.ts` — `.velite/{projects,posts}.json`에서 `{slug, title, summary, tags}`만 추출 + 정적 라우트(`/about`, `/projects`, `/blog`, `/contact`, `/legal`) 머지 → `public/search-index.json` 출력 (velite afterBuild 훅 또는 별도 build 스크립트)
+- `useCommandPalette` hook — 단축키(⌘K/Ctrl+K/`/`) 토글 + input/textarea 포커스 시 무시 + 토큰 기반 필터 + 키보드 네비
+- `<CommandPalette />` UI — 모달 + 그룹 헤더(pages/projects/posts) + lazy fetch 1회 + ↑↓/↵/Esc + 마우스 호버 인덱스 동기화
+- `app/root.tsx`에 `<CommandPalette />` 마운트
+- 가정 A007 해소 — 단순 includes/score 토큰 검색 채택
+
+### Out of Scope
+- FlexSearch/Fuse 도입 (콘텐츠 100+ 시 재검토)
+
+## Acceptance Criteria (PRD AC 인용)
+- [ ] **AC-F016-1**: 페이지에 입력 포커스가 없다 → ⌘K(macOS) 또는 Ctrl+K(Win/Linux) 또는 `/` 입력 → palette가 열리고 검색 input에 자동 포커스
+- [ ] **AC-F016-2**: input/textarea/contenteditable에 포커스가 있다 → 위 단축키 입력 → palette가 열리지 않고 기본 입력 동작 유지
+- [ ] **AC-F016-3**: palette 열림 + 검색어 "rou nav" → 토큰 기반 필터 → "rou"와 "nav"를 모두 포함하는 항목만 그룹 헤더(pages/projects/posts) 별로 표시
+- [ ] **AC-F016-4**: 결과 리스트 → ↓ ↑로 네비 + ↵로 진입 + Esc로 닫기 → 키보드만으로 모든 동작 + 마우스 호버 시 선택 인덱스 동기화
+- [ ] **AC-F016-5**: 사이트가 처음 로드 → 검색 인덱스 fetch → JSON gzip 100KB 이하 + 본문(body) 미포함 + 세션당 1회만 fetch
+
+### Task 추가 AC (Issue #7 보강)
+- [ ] cross-platform 단축키 분기 명시: macOS는 `event.metaKey === true`, Windows·Linux는 `event.ctrlKey === true`, `/`는 공통 — RTL `userEvent.keyboard('{Meta>}k{/Meta}')` / `'{Control>}k{/Control}'` / `'/'` 3 케이스 모두 통과
+
+## Implementation Plan (TDD Cycle)
+
+### Red
+- `app/presentation/hooks/__tests__/useCommandPalette.test.ts`
+  - **AC-F016-1 macOS**: `userEvent.keyboard('{Meta>}k{/Meta}')` → `isOpen === true`
+  - **AC-F016-1 Win/Linux**: `userEvent.keyboard('{Control>}k{/Control}')` → open
+  - **AC-F016-1 `/`**: 공통 → open
+  - **AC-F016-2**: `<input>` focus 상태에서 위 3 단축키 모두 → palette 미오픈
+  - **AC-F016-3**: query="rou nav" → mock index에서 "router navigation" 항목만 포함, "router" 단독 항목은 제외
+  - **AC-F016-4**: open 상태에서 ArrowDown → activeIndex 증가, ArrowUp → 감소, Enter → 결과 항목 onClick, Escape → close
+- `app/presentation/components/palette/__tests__/CommandPalette.test.tsx`
+  - lazy fetch가 첫 open 시 1회만 호출 (AC-F016-5)
+  - 그룹 헤더 (pages/projects/posts) 노출
+  - 마우스 hover → activeIndex 동기화
+- `app/application/search/services/__tests__/build-search-index.service.test.ts`
+  - mock projects + posts → 정적 라우트와 머지된 인덱스 객체 반환
+  - body 필드 미포함
+  - 인덱스 size 측정 (gzip 모방을 위해 raw size로 검증, 100KB 이하)
+
+### Green
+- `build-search-index.service.ts` — 순수 함수, 부수효과로 `public/search-index.json` 쓰기
+- `velite.config.ts`에 afterBuild 훅 또는 별도 npm script `build:search-index` 추가 → `package.json` `prebuild`에 chain
+- `useCommandPalette` hook — `useEffect`로 keydown listener + cross-platform 분기
+- `<CommandPalette />` UI — 모달 + lazy fetch (`useEffect` first open) + group header
+- `app/root.tsx`에 마운트
+
+### Refactor
+- 토큰 검색 함수(`tokenSearch(items, query)`)를 `app/application/search/lib/token-search.ts`로 추출 + unit test 별도
+
+## Files to Create / Modify
+
+### Application — Service
+| Path | Responsibility |
+|------|---------------|
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/application/search/services/build-search-index.service.ts` | velite output → search-index.json |
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/application/search/services/__tests__/build-search-index.service.test.ts` | unit |
+
+### Presentation — Hook
+| Path | Responsibility |
+|------|---------------|
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/presentation/hooks/useCommandPalette.ts` | T010에서 만든 placeholder를 본체로 채움 |
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/presentation/hooks/__tests__/useCommandPalette.test.ts` | RTL + 3 OS 분기 |
+
+### Presentation — Component
+| Path | Responsibility |
+|------|---------------|
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/presentation/components/palette/CommandPalette.tsx` | 모달 UI |
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/presentation/components/palette/__tests__/CommandPalette.test.tsx` | RTL + lazy fetch mock |
+
+### Root (수정)
+| Path | Change |
+|------|--------|
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/root.tsx` | `<CommandPalette />` 마운트 |
+
+### Build Hook
+| Path | Change |
+|------|--------|
+| `/Users/tkstart/Desktop/project/tkstar-dev/velite.config.ts` | afterBuild 훅에서 `build-search-index.service` 호출 (또는 별도 script) |
+| `/Users/tkstart/Desktop/project/tkstar-dev/package.json` | scripts에 `build:search-index: "node scripts/build-search-index.mjs"` (또는 velite afterBuild로 통합) |
+
+### Public Asset (생성)
+| Path | Responsibility |
+|------|---------------|
+| `/Users/tkstart/Desktop/project/tkstar-dev/public/search-index.json` | 빌드 산출물 (gitignore 검토 — 빌드 시 항상 재생성되므로 commit 금지) |
+
+## Verification Steps
+
+### 자동
+- `bun run test` — `useCommandPalette` (3 OS), `CommandPalette` (lazy fetch + 그룹 헤더), `build-search-index` 모두 Green
+- AC-F016-1~5 매핑 테스트가 명시적으로 통과 (test 이름에 AC ID 포함)
+- `bun run build`(또는 velite build) 후 `public/search-index.json` 생성 + size 검증
+
+### 수동
+- macOS Chrome에서 ⌘K → palette open
+- Windows/Linux 가상 머신 또는 키보드 layout 변경으로 Ctrl+K 검증
+- input focus 시 단축키 무시 확인
+- "rou nav" 같은 토큰 검색 결과 시각 확인
+- 키보드만으로 ↑↓ + Enter + Esc 모두 동작
+- 마우스 hover 시 선택 인덱스 동기화
+
+### 측정
+- `public/search-index.json` size — gzip(`gzip -c public/search-index.json | wc -c`) ≤ 100KB
+
+## Dependencies
+- **Depends on**: T003 (root.tsx 마운트), T008 (`.velite/*.json`), T009 (DI), T010 (Home에서 검색 트리거 placeholder)
+- **Blocks**: 없음
+
+## Risks & Mitigations
+- **Risk**: 콘텐츠 100+ 도달 시 토큰 검색 성능 저하.
+  - **Mitigation**: 가정 A007 — 100+ 도달 시 FlexSearch/Fuse 도입 검토. MVP에서는 단순 검색으로 충분.
+- **Risk**: gzip 100KB threshold가 빌드 시점에 깨질 수 있음.
+  - **Mitigation**: `build:search-index` script에 size assertion 추가 → CI에서 깨지면 빌드 fail.
+- **Risk**: macOS의 Cmd+K가 일부 브라우저(Chrome)에서 검색 바 단축키와 충돌.
+  - **Mitigation**: `event.preventDefault()` + Cmd 단축키 가로채기. 충돌 발생 시 사용자 노출은 미미.
+
+## References
+- PRD `F016`, AC-F016-1~5
+- PROJECT-STRUCTURE.md `D3. F016 검색 인덱스: 빌드 타임 정적 산출물` (line 578~)
+- ROADMAP.md `Phase 4` Task 016 (Issue #7 cross-platform 보강 반영), 가정 A007 해소
+- [React Router v7 useEffect + keyboard event](https://react.dev/reference/react/useEffect)
+
+## Change History
+| Date | Changes | Author |
+|------|---------|--------|
+| - | - | - |

--- a/docs/tasks/T017-contact-form-email.md
+++ b/docs/tasks/T017-contact-form-email.md
@@ -1,0 +1,187 @@
+# Task 017 — Contact Form + Turnstile + Resend + 자동응답 메일 (F008 + F009)
+
+| Field | Value |
+|-------|-------|
+| **Task ID** | T017 |
+| **Phase** | Phase 4 — Forms / Email |
+| **Layer** | Application(`submit-contact-form.service`) + Infrastructure(Resend, Turnstile, React Email, Workers KV rate-limit) + Presentation(Form, Turnstile widget) |
+| **Branch** | `feature/issue-N-contact-form-email` |
+| **Depends on** | T002, T006, T008, T009, T017-pre |
+| **Blocks** | — |
+| **PRD Features** | **F008** (Contact Form), **F009** (Turnstile) |
+| **PRD AC** | **AC-F008-1**, **AC-F008-2**, **AC-F008-3**, **AC-F008-4**, **AC-F009-1**, **AC-F009-2**, **AC-F009-3** |
+| **예상 작업 시간** | 2.5d |
+| **Status** | Not Started |
+
+## Goal
+Contact 페이지의 폼 검증 + Cloudflare Turnstile 클라이언트 위젯 + 서버 검증 + Resend 발신 + React Email 자동응답을 모두 가동시킨다. F008/F009의 7개 AC를 모두 자동 테스트로 통과 (rate-limit 포함). 가정 A009 해소.
+
+## Context
+- **Why**: B2B 채용 / B2C 의뢰 모든 분기의 수렴점. 메일 only 채널이라 스팸 방지 + rate-limit이 필수. Resend 무료 티어 + Turnstile + Workers KV 조합으로 운영 비용 0원 유지.
+- **Phase 진입/완료 연결**: T006 (ContactSubmission schema) + T008/T009 (DI) + T017-pre (PROJECT-STRUCTURE 등록) Done 후. T017 Done 후 Phase 5(SEO/OG) 진입.
+- **관련 PRD 섹션**: PRD `Page-by-Page — Contact Page`, `F008`, `F009`, AC-F008-1~4, AC-F009-1~3, `Tech Stack — Forms & Email`
+- **관련 PROJECT-STRUCTURE 디렉토리**: `app/application/contact/{ports,services}/`, `app/infrastructure/{email,captcha,ratelimit}/`, `app/presentation/{routes/contact.tsx, components/contact/, hooks/useTurnstile.ts}`
+
+## Scope
+
+### In Scope
+- **사전 단계 (PR 본 작업 전 1회)**:
+  - `bunx wrangler kv namespace create RATE_LIMIT_KV` (production용) → 반환 `id` 기록
+  - `bunx wrangler kv namespace create RATE_LIMIT_KV --preview` (preview/dev용) → 반환 `preview_id` 기록
+  - `wrangler.toml`에 `[[kv_namespaces]] binding = "RATE_LIMIT_KV"`, `id`, `preview_id` 등록
+  - `app/env.d.ts`의 `Env`(또는 `AppLoadContext`)에 `RATE_LIMIT_KV: KVNamespace` 추가
+- **Application**: 3개 port + 1개 service
+- **Infrastructure**: Resend 어댑터 + React Email 템플릿 + Turnstile 어댑터 + KV rate-limiter
+- **Presentation**: Contact route(loader + action) + 4개 컴포넌트 + 1개 hook
+- 환경변수 시크릿 등록: `RESEND_API_KEY`, `TURNSTILE_SECRET`, `CONTACT_TO_EMAIL`(var)
+- `Container`에 `submitContactForm` service 등록 (T009 container 확장)
+
+### Out of Scope
+- Resend domain verification(DNS) — T022
+- Cloudflare Email Routing 설정 — T022
+- Turnstile site key 발급 — 배포 단계 (T022) (dev에는 test key 사용)
+
+## Acceptance Criteria (PRD AC 인용 — 7개)
+- [ ] **AC-F008-1**: 사용자가 `/contact`에서 이름·이메일·메시지(10자 이상)·의뢰 유형을 채우고 Turnstile 통과 → `submit` 클릭 → Resend API가 1회 호출되어 hello@tkstar.dev → 본인 메일 발신 + 제출자 자동응답 메일 + 성공 화면
+- [ ] **AC-F008-2**: 이메일 RFC 5322 위반 (`foo@`, `foo.com`) → `submit` 클릭 → 클라이언트에서 차단 + 인라인 에러 + 네트워크 요청 미발생
+- [ ] **AC-F008-3**: 메시지 길이 10자 미만 또는 5000자 초과 → `submit` → 인라인 에러 + 폼 상태 유지
+- [ ] **AC-F008-4**: Resend API가 5xx 또는 네트워크 오류 → 응답 수신 → 에러 토스트 + `mailto:hello@tkstar.dev?subject=...&body=...` 폴백 (폼 입력값 prefill)
+- [ ] **AC-F009-1**: Contact 폼 마운트 → Turnstile 위젯 렌더 → `cf-turnstile-response` 토큰이 폼 상태에 바인딩 + 토큰 비어있으면 submit 버튼 비활성화
+- [ ] **AC-F009-2**: 클라이언트가 위조 토큰 함께 submit → 서버가 `https://challenges.cloudflare.com/turnstile/v0/siteverify` 검증 → `success: false` → 400 응답 + Resend 호출 일어나지 않음
+- [ ] **AC-F009-3**: 동일 IP가 1시간 내 5회 이상 submit → 6번째 submit → 서버 429 응답 + "잠시 후 다시 시도해주세요"
+
+### Task 추가 AC (Issue #5 보강)
+- [ ] `wrangler.toml`에 `[[kv_namespaces]]` 블록이 `binding = "RATE_LIMIT_KV"`, `id`, `preview_id` 모두 포함
+- [ ] `Env` 타입에 `RATE_LIMIT_KV: KVNamespace` 등록
+
+## Implementation Plan (TDD Cycle)
+
+### Red — Inside-Out 순서 (Domain → Application → Infrastructure → Presentation)
+
+#### Domain (T006에서 이미 작성)
+- `contact-submission.schema.test.ts` — AC-F008-2/3 검증 (T006에서 Green)
+
+#### Application
+- `app/application/contact/services/__tests__/submit-contact-form.service.test.ts`
+  - mock `emailSender`, `captchaVerifier`, `rateLimiter` 주입
+  - **AC-F008-1 happy path**: 모든 mock OK → emailSender.send 1회 호출 + autoReply 1회 호출 + 성공 반환
+  - **AC-F009-2**: captchaVerifier.verify → false → throw `InvalidCaptchaError` → emailSender 미호출
+  - **AC-F009-3**: rateLimiter.check → false → throw `RateLimitExceededError` → captchaVerifier 미호출
+  - **AC-F008-4**: emailSender.send → 5xx throw → service가 그대로 throw → action에서 fallback
+
+#### Infrastructure
+- `app/infrastructure/email/__tests__/resend-email-sender.test.ts`
+  - `fetch` mock — Resend API 200 → success
+  - 5xx → throw
+- `app/infrastructure/captcha/__tests__/turnstile-verifier.test.ts`
+  - `fetch` mock — `siteverify` 200 + `success: true` → return true
+  - 200 + `success: false` → return false
+- `app/infrastructure/ratelimit/__tests__/kv-rate-limiter.test.ts` (Issue #5)
+  - KV mock(`miniflare` 또는 in-memory map) — 5회 OK + 6번째 false
+  - TTL 1시간 (`expirationTtl: 3600`) 검증
+
+#### Presentation
+- `app/presentation/routes/__tests__/contact.test.tsx`
+  - **AC-F008-2 client**: 잘못된 이메일 입력 → submit 클릭 → action 호출되지 않음 (network mock count = 0)
+  - **AC-F008-3 client**: 메시지 9자 또는 5001자 → submit → action 미호출 + 인라인 에러
+  - **AC-F009-1**: Turnstile mock 토큰 비어있음 → submit 버튼 disabled
+  - **AC-F008-4 fallback**: action mock이 5xx 응답 → mailto 링크 노출 + prefill body 검증
+  - 통합: 전체 flow happy path
+
+### Green
+- 3 ports + 1 service (Application)
+- 4 어댑터 (email, captcha, ratelimit, react-email template)
+- contact route + 4 컴포넌트 + useTurnstile hook
+- DI Container에 `submitContactForm` 추가
+
+### Refactor
+- error 변환 로직(`InvalidCaptchaError → 400`, `RateLimitExceededError → 429`)을 `app/application/contact/error-mapper.ts`로 추출
+- React Email 템플릿의 본문 텍스트를 상수 module로 분리
+
+## Files to Create / Modify
+
+### Pre-step (사전 작업)
+| Path | Change |
+|------|--------|
+| `/Users/tkstart/Desktop/project/tkstar-dev/wrangler.toml` | `[[kv_namespaces]] binding = "RATE_LIMIT_KV", id, preview_id` 등록 / `[vars] CONTACT_TO_EMAIL = "..."` |
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/env.d.ts` | `Env`에 `RATE_LIMIT_KV: KVNamespace` + `RESEND_API_KEY: string` + `TURNSTILE_SECRET: string` + `CONTACT_TO_EMAIL: string` |
+
+### Application — Ports
+| Path | Responsibility |
+|------|---------------|
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/application/contact/ports/email-sender.port.ts` | `interface EmailSender { send(to, subject, html, text?): Promise<void> }` |
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/application/contact/ports/captcha-verifier.port.ts` | `verify(token, ip): Promise<boolean>` |
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/application/contact/ports/rate-limiter.port.ts` | `check(key, max, windowSec): Promise<boolean>` |
+
+### Application — Service
+| Path | Responsibility |
+|------|---------------|
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/application/contact/services/submit-contact-form.service.ts` | rate-limit → captcha → email → autoReply 순차 |
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/application/contact/services/__tests__/submit-contact-form.service.test.ts` | 4 분기 |
+
+### Infrastructure
+| Path | Responsibility |
+|------|---------------|
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/infrastructure/email/resend-email-sender.ts` | implements EmailSender, Resend HTTP API |
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/infrastructure/email/templates/AutoReplyEmail.tsx` | React Email 템플릿 |
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/infrastructure/email/__tests__/resend-email-sender.test.ts` | fetch mock |
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/infrastructure/captcha/turnstile-verifier.ts` | implements CaptchaVerifier, siteverify HTTP API |
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/infrastructure/captcha/__tests__/turnstile-verifier.test.ts` | fetch mock |
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/infrastructure/ratelimit/kv-rate-limiter.ts` | implements RateLimiter, Workers KV `RATE_LIMIT_KV` |
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/infrastructure/ratelimit/__tests__/kv-rate-limiter.test.ts` | KV mock |
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/infrastructure/config/container.ts` (수정) | `submitContactForm` 추가 |
+
+### Presentation
+| Path | Responsibility |
+|------|---------------|
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/presentation/routes/contact.tsx` | loader (Turnstile site key) + action (submit) |
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/presentation/routes/__tests__/contact.test.tsx` | 통합 |
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/presentation/components/contact/ContactForm.tsx` | 폼 UI + 클라이언트 검증 |
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/presentation/components/contact/TurnstileWidget.tsx` | Turnstile 위젯 마운트 + 토큰 콜백 |
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/presentation/components/contact/SuccessScreen.tsx` | 성공 화면 |
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/presentation/components/contact/MailtoFallback.tsx` | AC-F008-4 폴백 링크 |
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/presentation/hooks/useTurnstile.ts` | 위젯 라이프사이클 |
+
+## Verification Steps
+
+### 자동
+- `bun run test` — 모든 layer의 테스트가 7개 AC를 매핑하여 Green
+- AC ID가 test 이름에 명시 (e.g. `it("AC-F008-1 — happy path", ...)`)
+- `bun run test:coverage` threshold 통과
+
+### 수동
+- `wrangler dev --local` (Turnstile test key + KV local)에서 폼 제출 happy path 시각 확인
+- 의도적으로 Turnstile token 비활성 → submit 버튼 disabled 확인
+- 잘못된 이메일 → 인라인 에러
+- Resend가 dev key로 정상 발신되는지 (또는 mock으로 대체)
+- KV mock으로 rate-limit 5회 + 6번째 429 시각 확인
+
+### 측정
+- 없음
+
+## Dependencies
+- **Depends on**: T002 (디렉토리), T006 (ContactSubmission schema), T008 (DI 컨벤션), T009 (DI Container), T017-pre (PROJECT-STRUCTURE 등록)
+- **Blocks**: 없음
+
+## Risks & Mitigations
+- **Risk**: Workers KV의 `eventually consistent` 특성으로 rate-limit이 잠시 빠질 수 있음.
+  - **Mitigation**: KV가 한 region 안에서는 strongly consistent. AC-F009-3은 동일 IP 기준이므로 1 region 안에서 검증 → 충분.
+- **Risk**: Turnstile site key가 wrangler.toml에 노출되면 안됨 (secret).
+  - **Mitigation**: `TURNSTILE_SECRET`은 `wrangler secret put`으로 등록. site key는 vars 가능 (공개 가능).
+- **Risk**: Resend가 React Email 템플릿을 HTML+plain text 둘 다 지원해야 함.
+  - **Mitigation**: React Email의 `render()` 출력 + `convertHtmlToText` 옵션 사용.
+
+## References
+- PRD `Page-by-Page — Contact Page`, `F008`, `F009`, AC-F008-1~4, AC-F009-1~3
+- PROJECT-STRUCTURE.md `Cross-cutting Concerns Mapping` (Contact 관련 행)
+- ROADMAP.md `Phase 4` Task 017 (Issue #3/#5 보강 반영)
+- T017-pre task file (PROJECT-STRUCTURE 등록 사전 작업)
+- [Resend HTTP API](https://resend.com/docs/api-reference/emails/send-email)
+- [Cloudflare Turnstile siteverify](https://developers.cloudflare.com/turnstile/get-started/server-side-validation/)
+- [Workers KV namespace](https://developers.cloudflare.com/kv/api/)
+- [React Email](https://react.email/)
+
+## Change History
+| Date | Changes | Author |
+|------|---------|--------|
+| - | - | - |

--- a/docs/tasks/T017-pre-update-project-structure-ratelimit.md
+++ b/docs/tasks/T017-pre-update-project-structure-ratelimit.md
@@ -1,0 +1,82 @@
+# Task 017-pre — PROJECT-STRUCTURE.md 갱신: `app/infrastructure/ratelimit/` 모듈 등록 (docs)
+
+| Field | Value |
+|-------|-------|
+| **Task ID** | T017-pre |
+| **Phase** | Phase 4 — Forms / Email |
+| **Layer** | docs (구조 정합성) |
+| **Branch** | `docs/update-project-structure-ratelimit` |
+| **Depends on** | none (T017보다 선행) |
+| **Blocks** | T017 |
+| **PRD Features** | F009 (rate-limit 보강) |
+| **PRD AC** | — |
+| **예상 작업 시간** | 0.25d |
+| **Status** | Not Started |
+
+## Goal
+T017이 신규 도입할 `app/infrastructure/ratelimit/kv-rate-limiter.ts` 모듈을 PROJECT-STRUCTURE.md에 사전 등록하여 (a) 구조 정합성을 유지하고 (b) T017 PR이 코드 변경에만 집중할 수 있도록 한다 (검증 리포트 Issue #3 해소).
+
+## Context
+- **Why**: 검증 리포트 Issue #3 — PRD 검증 리포트에서 contact rate-limit 추가 요구가 ROADMAP T017에 반영되었으나 PROJECT-STRUCTURE.md 갱신이 누락. 이를 docs 전용 PR로 분리하면 T017 PR이 깨끗하고, 구조 정본 1개를 유지.
+- **Phase 진입/완료 연결**: Phase 4 진입 직후, T017 시작 전. 다른 task와 의존성 무관.
+- **관련 PRD 섹션**: PRD `F009 Contact 스팸 방지` + AC-F009-3 (rate-limit)
+- **관련 PROJECT-STRUCTURE 디렉토리**: `app/infrastructure/` 트리 + Cross-cutting Concerns Mapping
+
+## Scope
+
+### In Scope
+- `docs/PROJECT-STRUCTURE.md`의 `app/infrastructure/` 트리(현재 line 213~238)에 `ratelimit/` 항목 추가
+- Cross-cutting Concerns Mapping(현재 line 549~560)에 `Contact rate-limit (F009 보강)` 행 추가
+- (선택) `Architectural Decisions (Resolved)` 절에 `D6. Workers KV 기반 rate-limit` 추가 — 결정 근거 명시 (KV가 Workers 친화 + free tier 충분)
+
+### Out of Scope
+- 실제 `kv-rate-limiter.ts` 코드 — T017
+- `wrangler.toml` KV namespace 등록 — T017 (사전 단계)
+- Application port 정의 — T017
+
+## Acceptance Criteria
+- [ ] `docs/PROJECT-STRUCTURE.md`의 `app/infrastructure/` 트리에 `├── ratelimit/` + `│   ├── kv-rate-limiter.ts` + `│   └── __tests__/` 항목이 추가됨
+- [ ] Cross-cutting Concerns Mapping 표에 `Contact rate-limit (F009 보강) | Application Port + Infrastructure 구현 | application/contact/ports/rate-limiter.port.ts + infrastructure/ratelimit/kv-rate-limiter.ts` 행이 추가됨
+- [ ] `docs/` 외 파일은 변경되지 않음 (surgical change)
+- [ ] PR 생성 시 squash merge 후 `development` 브랜치에 정합성 반영
+
+## Implementation Plan (TDD Cycle)
+**N/A — docs branch policy.** docs 변경은 PR 리뷰가 안전망이며 Plan/TDD phase 면제.
+
+## Files to Create / Modify
+
+### Docs
+| Path | Change |
+|------|--------|
+| `/Users/tkstart/Desktop/project/tkstar-dev/docs/PROJECT-STRUCTURE.md` | (a) `app/infrastructure/` 트리에 `ratelimit/` 항목 추가, (b) Cross-cutting Concerns Mapping 표에 rate-limit 행 추가, (c) `Architectural Decisions (Resolved)` 절에 D6 추가 (선택) |
+
+## Verification Steps
+
+### 자동
+- 없음
+
+### 수동
+- 변경된 PROJECT-STRUCTURE.md 마크다운 정상 렌더 확인
+- 후속 T017 작업자가 ratelimit/ 위치를 의심없이 파악할 수 있는지 검토
+
+### 측정
+- 없음
+
+## Dependencies
+- **Depends on**: none
+- **Blocks**: T017 (T017은 사전 등록된 ratelimit/ 모듈에 코드를 채움)
+
+## Risks & Mitigations
+- **Risk**: docs 변경이 후속 T017 PR과 충돌.
+  - **Mitigation**: T017-pre를 먼저 squash merge한 뒤 T017이 development를 rebase. 1~2일 내 처리하면 충돌 거의 없음.
+
+## References
+- 검증 리포트 `docs/reports/roadmap-validation-2026-04-28.md` Issue #3
+- PRD `F009 Contact 스팸 방지`, AC-F009-3
+- PROJECT-STRUCTURE.md 현재 `app/infrastructure/` 트리 (line 213~) + Cross-cutting Concerns Mapping (line 549~)
+- ROADMAP.md `Phase 4` Task 017-pre (신규)
+
+## Change History
+| Date | Changes | Author |
+|------|---------|--------|
+| - | - | - |

--- a/docs/tasks/T018-satori-og.md
+++ b/docs/tasks/T018-satori-og.md
@@ -1,0 +1,161 @@
+# Task 018 — F011 Satori 동적 OG 이미지 (Project + Blog) — Workers Asset Binding
+
+| Field | Value |
+|-------|-------|
+| **Task ID** | T018 |
+| **Phase** | Phase 5 — SEO / OG / Indexing |
+| **Layer** | Application(`render-*-og.service`, port) + Infrastructure(Satori standalone + Asset Binding) + Resource Route |
+| **Branch** | `feature/issue-N-satori-og` |
+| **Depends on** | T013, T014a, T014b |
+| **Blocks** | T019 |
+| **PRD Features** | **F011** (SSR + 동적 OG 이미지) |
+| **PRD AC** | **AC-F011-1**, **AC-F011-2**, **AC-F011-3** |
+| **예상 작업 시간** | 1.5d |
+| **Status** | Not Started |
+
+## Goal
+Satori standalone + Workers Asset Binding으로 `/og/projects/:slug.png` / `/og/blog/:slug.png` 리소스 라우트를 가동하여 슬러그별 1200×630 PNG OG 이미지를 SSR 시점 또는 첫 요청 시 생성한다. 미존재 slug는 fallback PNG, 폰트/yoga.wasm 누락 시 graceful degradation. 가정 A005 해소.
+
+## Context
+- **Why**: SNS 공유 / 검색엔진 미리보기에서 OG 이미지는 클릭률에 큰 영향. Project/Blog 슬러그별 동적 생성으로 운영 부담 0 + 자동 일관성.
+- **Phase 진입/완료 연결**: T013 Project Detail + T014a/T014b Blog Detail이 Done이어야 frontmatter 사용 가능. T018 Done 후 T019 SEO meta가 `og:image` URL을 등록.
+- **관련 PRD 섹션**: PRD `F011`, AC-F011-1~3, `Tech Stack — Content Pipeline / Typography`
+- **관련 PROJECT-STRUCTURE 디렉토리**: `app/application/og/{ports,services}/`, `app/infrastructure/og/`, `app/presentation/routes/og.*[.png].tsx`, `public/{fonts,wasm}/`
+
+## Scope
+
+### In Scope
+- `og-image-renderer.port.ts` — `render(template, data): Promise<Uint8Array>` 인터페이스
+- `render-project-og.service.ts` / `render-post-og.service.ts` — frontmatter → Satori 호출
+- `satori-og-renderer.ts` — Satori standalone 어댑터, `env.ASSETS.fetch(...)` 로 ttf + yoga.wasm 로드
+- 2개 resource route (`og.projects.$slug[.png].tsx`, `og.blog.$slug[.png].tsx`) — loader만 export
+- `public/fonts/JetBrainsMono-Regular.ttf` (woff2 외 ttf 별도, Satori 미지원 woff2)
+- `public/wasm/yoga.wasm` (Satori standalone 초기화)
+- 정적 fallback PNG (`public/og/fallback.png` 또는 in-memory 생성)
+- DI Container에 `renderProjectOg` / `renderBlogOg` 등록
+
+### Out of Scope
+- 페이지별 `og:image` meta export (T019)
+- 디자인 토큰 사용한 OG 템플릿의 다크/라이트 분기 (단일 템플릿으로 시작)
+
+## Acceptance Criteria (PRD AC 인용)
+- [ ] **AC-F011-1**: `/og/projects/:slug.png` 또는 `/og/blog/:slug.png` 요청 → Satori가 frontmatter(title/date/tags)로 PNG 생성 → 1200×630 PNG + `Content-Type: image/png` + `Cache-Control: public, max-age=31536000, immutable`
+- [ ] **AC-F011-2**: 미존재 slug 요청 → loader 핸들러 → 404가 아니라 default fallback PNG(브랜드 로고 + "tkstar.dev")
+- [ ] **AC-F011-3**: Satori 렌더링 실패(폰트 binary 누락 등) → 정적 fallback PNG + Workers logs 에러 기록
+
+## Implementation Plan (TDD Cycle)
+
+### Red
+
+#### Application
+- `app/application/og/services/__tests__/render-project-og.service.test.ts`
+  - mock `OgImageRenderer.render` → `{title, date, tags}`로 호출 검증
+  - 정상 → PNG bytes 반환
+- `app/application/og/services/__tests__/render-post-og.service.test.ts`
+  - 동일 패턴
+
+#### Infrastructure
+- `app/infrastructure/og/__tests__/satori-og-renderer.test.ts`
+  - `env.ASSETS.fetch` mock — ttf/yoga.wasm 로드 시 정상 동작
+  - `satori` mock으로 PNG bytes 반환 검증
+  - 폰트 누락 시 fallback PNG 경로 + 에러 로그
+  - **AC-F011-1 size**: 출력 PNG의 magic header(`\x89PNG`) + IHDR width/height = 1200×630
+
+#### Resource Route
+- `app/presentation/routes/__tests__/og.projects.$slug.test.ts`
+  - loader 호출 → `Response` Content-Type / Cache-Control 헤더 검증 (AC-F011-1)
+  - 미존재 slug → fallback PNG (AC-F011-2)
+  - renderer throw → fallback PNG + console.error 검증 (AC-F011-3)
+
+### Green
+- 1 port + 2 services (Application)
+- 1 어댑터 (`satori-og-renderer.ts`)
+- 2 resource route loader
+- DI Container 확장
+- public assets 추가
+
+### Refactor
+- OG 템플릿 JSX를 별도 모듈(`app/infrastructure/og/templates/{project,post}.tsx`)로 분리
+- ttf/wasm 로드를 module-level cache로 1회만
+
+## Files to Create / Modify
+
+### Application — Port
+| Path | Responsibility |
+|------|---------------|
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/application/og/ports/og-image-renderer.port.ts` | `render(template, data): Promise<Uint8Array>` |
+
+### Application — Services
+| Path | Responsibility |
+|------|---------------|
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/application/og/services/render-project-og.service.ts` | project frontmatter → renderer.render |
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/application/og/services/render-post-og.service.ts` | post frontmatter → renderer.render |
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/application/og/services/__tests__/*.test.ts` | unit |
+
+### Infrastructure
+| Path | Responsibility |
+|------|---------------|
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/infrastructure/og/satori-og-renderer.ts` | satori/standalone + env.ASSETS.fetch |
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/infrastructure/og/templates/project.tsx` | OG 템플릿 JSX |
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/infrastructure/og/templates/post.tsx` | OG 템플릿 JSX |
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/infrastructure/og/__tests__/satori-og-renderer.test.ts` | unit |
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/infrastructure/config/container.ts` (수정) | `renderProjectOg`, `renderBlogOg` 추가 |
+
+### Presentation — Resource Routes
+| Path | Responsibility |
+|------|---------------|
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/presentation/routes/og.projects.$slug[.png].tsx` | loader → 1200×630 PNG |
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/presentation/routes/og.blog.$slug[.png].tsx` | loader → 1200×630 PNG |
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/presentation/routes/__tests__/og.projects.$slug.test.ts` | unit |
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/presentation/routes/__tests__/og.blog.$slug.test.ts` | unit |
+
+### Public Assets
+| Path | Responsibility |
+|------|---------------|
+| `/Users/tkstart/Desktop/project/tkstar-dev/public/fonts/JetBrainsMono-Regular.ttf` | Satori 입력 폰트 |
+| `/Users/tkstart/Desktop/project/tkstar-dev/public/wasm/yoga.wasm` | Satori standalone yoga binding |
+| `/Users/tkstart/Desktop/project/tkstar-dev/public/og/fallback.png` | 정적 fallback (1200×630, 브랜드 로고 + "tkstar.dev") |
+
+### Dependencies
+- `bun add satori @resvg/resvg-wasm` 또는 satori standalone 빌드 변형 검토. **권장**: `satori/standalone` + 별도 `@resvg/resvg-wasm`(또는 `pngjs`)로 PNG 인코딩.
+
+## Verification Steps
+
+### 자동
+- `bun run test` — 4개 테스트 셋(project og service, post og service, satori-og-renderer, og resource routes) 모두 Green
+- AC-F011-1/2/3 매핑 명시
+- PNG magic header + IHDR width/height assertion
+
+### 수동
+- `wrangler dev`에서 `/og/projects/example-project.png` 직접 접속 → 1200×630 PNG 다운로드 → 시각 확인
+- `/og/projects/missing-slug.png` → fallback PNG 응답
+- 폰트 파일을 임시로 삭제 후 요청 → fallback 응답 + Workers logs 에러
+- Twitter/Facebook OG validator로 production URL 검증 (T022 배포 후)
+
+### 측정
+- PNG 파일 size — 30~60KB 범위 (1200×630 PNG 기본)
+- Cold start 시 Satori 초기화 비용 — Workers logs로 측정 (Phase 6 Lighthouse에서 정식)
+
+## Dependencies
+- **Depends on**: T013 (Project Detail frontmatter), T014a (Blog list + posts available), T014b (Blog Detail frontmatter)
+- **Blocks**: T019 (SEO meta가 OG URL 등록)
+
+## Risks & Mitigations
+- **Risk**: Workers의 cpu time limit (10ms~50ms) 안에 Satori 렌더링이 끝나지 않을 수 있음.
+  - **Mitigation**: 첫 요청 시 ttf/yoga.wasm 로드 비용이 큼 → module-level cache. AC-F011-1의 `Cache-Control: immutable`로 CDN 영구 캐시 유도.
+- **Risk**: woff2가 Satori 미지원이라 ttf 별도 보관 필요.
+  - **Mitigation**: PROJECT-STRUCTURE.md에 명시. T005에서 woff2 self-host와 별개로 `JetBrainsMono-Regular.ttf` 추가.
+- **Risk**: yoga.wasm 동적 로드가 Workers WASM 정책에 막힘.
+  - **Mitigation**: PROJECT-STRUCTURE.md D5 결정 — `env.ASSETS.fetch(".../wasm/yoga.wasm")`로 우회.
+
+## References
+- PRD `F011`, AC-F011-1~3, `Tech Stack — Content Pipeline / Typography`
+- PROJECT-STRUCTURE.md `D5. Satori 폰트/WASM 바인딩` (line 587~)
+- ROADMAP.md `Phase 5` Task 018, 가정 A005 해소
+- [Satori](https://github.com/vercel/satori), [Cloudflare Static Assets Binding](https://developers.cloudflare.com/workers/static-assets/binding/)
+- [6 Pitfalls of Dynamic OG on Workers](https://dev.to/devoresyah/6-pitfalls-of-dynamic-og-image-generation-on-cloudflare-workers-satori-resvg-wasm-1kle)
+
+## Change History
+| Date | Changes | Author |
+|------|---------|--------|
+| - | - | - |

--- a/docs/tasks/T019-seo-sitemap-jsonld.md
+++ b/docs/tasks/T019-seo-sitemap-jsonld.md
@@ -1,0 +1,174 @@
+# Task 019 — F018 SEO Meta + Sitemap + Robots + JSON-LD (차등 인덱싱)
+
+| Field | Value |
+|-------|-------|
+| **Task ID** | T019 |
+| **Phase** | Phase 5 — SEO / OG / Indexing |
+| **Layer** | Application(`build-sitemap.service`) + Resource Route + Presentation(meta export) |
+| **Branch** | `feature/issue-N-seo-sitemap-jsonld` |
+| **Depends on** | T008, T010, T011, T012, T013, T014a, T014b, T015, T018 |
+| **Blocks** | T020 |
+| **PRD Features** | **F018** (SEO 메타 + Sitemap) |
+| **PRD AC** | — (정합성 검증, schema.org 표준) |
+| **예상 작업 시간** | 1.5d |
+| **Status** | Not Started |
+
+## Goal
+페이지별 `meta` export (title/description/canonical/og/twitter) + JSON-LD + `/sitemap.xml` + `/robots.txt`을 가동하고, **차등 인덱싱** 정책(App Terms/Privacy `noindex,follow`, 404 `noindex,nofollow`)을 적용한다.
+
+## Context
+- **Why**: 검색엔진 가시성의 정본. F018은 모든 페이지 cross-cutting concern이라 페이지별 meta export를 한꺼번에 추가하는 것이 효율적.
+- **Phase 진입/완료 연결**: 모든 페이지 task(T010~T015) + OG(T018) Done 후 시작. T019 Done 후 T020 검색엔진 등록.
+- **관련 PRD 섹션**: PRD `F018` Feature, `Menu Structure — 크롤러/검색엔진 인덱싱`, App Terms/Privacy SEO 정책, Not Found Fallback SEO 정책
+- **관련 PROJECT-STRUCTURE 디렉토리**: `app/application/seo/services/`, `app/presentation/routes/{sitemap[.xml].tsx, robots[.txt].tsx}`, `app/presentation/lib/jsonld.ts`, 모든 페이지 routes의 `meta` export
+
+## Scope
+
+### In Scope
+- `build-sitemap.service.ts` — index 가능 페이지(Home/About/Projects/Project Detail/Blog/Blog Detail/Contact/Legal Index)만 포함. App Terms/Privacy + 404 + OG resource route 제외
+- `/sitemap.xml`, `/robots.txt` resource route loader 본체
+- 11개 페이지의 `meta` export 추가 (title/description/canonical/og:*/twitter:*)
+- `app/presentation/lib/jsonld.ts` — schema.org 빌더 (Person, BlogPosting, CreativeWork, BreadcrumbList)
+- 차등 인덱싱:
+  - App Terms/Privacy meta `<meta name="robots" content="noindex, follow">` + canonical 유지
+  - 404 splat meta `<meta name="robots" content="noindex, nofollow">`
+- DI Container에 `buildSitemap` 등록
+
+### Out of Scope
+- Google/Naver site verification meta (T020)
+- Cloudflare Web Analytics (T020)
+- Bing Webmaster Tools (가정 A011, MVP 후)
+
+## Acceptance Criteria
+- [ ] `/sitemap.xml`이 well-formed XML 응답 + `<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">` + `<url><loc>...</loc>...</url>` 항목들
+- [ ] sitemap에 포함되는 페이지: Home / About / Projects 목록 / Project Detail (모든 slug) / Blog 목록 / Blog Detail (모든 slug) / Contact / Legal Index
+- [ ] sitemap에 **포함되지 않는** 페이지: App Terms / App Privacy / 404 (splat) / OG resource route / RSS / Sitemap / Robots 자체
+- [ ] `/robots.txt` 응답: `User-agent: *\nAllow: /\nSitemap: https://tkstar.dev/sitemap.xml`
+- [ ] 모든 페이지에 `meta` export(title/description/canonical/og:title/og:description/og:image/og:url/og:type/twitter:card) 정의
+- [ ] OG `og:image`는 T018의 `/og/{projects|blog}/:slug.png` URL 또는 정적 fallback
+- [ ] JSON-LD: Home/About → `Person`, Blog Detail → `BlogPosting`, Project Detail → `CreativeWork`(또는 `SoftwareSourceCode`), 모든 페이지 → `BreadcrumbList`
+- [ ] App Terms/Privacy meta `noindex, follow` + canonical 유지, sitemap.xml 미포함
+- [ ] 404 splat meta `noindex, nofollow` + 404 응답 코드 + sitemap.xml 미포함
+
+## Implementation Plan (TDD Cycle)
+
+### Red
+
+#### Application
+- `app/application/seo/services/__tests__/build-sitemap.service.test.ts`
+  - mock `listProjects`/`listPosts`/`listApps` → sitemap entries 생성
+  - 정적 라우트(`/about`, `/projects`, `/blog`, `/contact`, `/legal`) + 동적 slugs 모두 포함
+  - App Terms/Privacy + 404 + OG/RSS/Sitemap/Robots 자체 미포함
+  - well-formed XML 검증
+
+#### Resource Route
+- `app/presentation/routes/__tests__/sitemap.test.ts`
+  - `/sitemap.xml` loader → `Content-Type: application/xml`
+- `app/presentation/routes/__tests__/robots.test.ts`
+  - `/robots.txt` loader → `Content-Type: text/plain` + 정확한 본문
+
+#### Meta Export (페이지별)
+- `app/presentation/routes/__tests__/{about,projects.$slug,blog.$slug,contact,legal._index,legal.$app.terms,legal.$app.privacy,$}.meta.test.ts`
+  - 각 페이지 `meta` export 호출 → expected title/description/canonical/og/twitter 출력
+  - App Terms/Privacy: `robots = "noindex, follow"`
+  - splat: `robots = "noindex, nofollow"`
+
+#### JSON-LD
+- `app/presentation/lib/__tests__/jsonld.test.ts`
+  - `buildPersonLd({...})` → schema.org Person 객체
+  - `buildBlogPostingLd({...})` → BlogPosting
+  - `buildCreativeWorkLd({...})` → CreativeWork
+  - `buildBreadcrumbListLd([...])` → BreadcrumbList
+
+### Green
+- `build-sitemap.service.ts`
+- `sitemap[.xml].tsx`, `robots[.txt].tsx` resource route 본체
+- 11개 페이지에 `meta` export 추가
+- `app/presentation/lib/jsonld.ts` 헬퍼
+- 페이지에서 JSON-LD `<script type="application/ld+json">` 삽입
+
+### Refactor
+- `meta` export 공통 패턴(`buildMeta({title, description, ogImage, ...})`)을 `app/presentation/lib/meta.ts`로 추출
+- 페이지별 canonical URL 빌더 (`getCanonicalUrl(path)`)
+
+## Files to Create / Modify
+
+### Application — Service
+| Path | Responsibility |
+|------|---------------|
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/application/seo/services/build-sitemap.service.ts` | sitemap entries → XML |
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/application/seo/services/__tests__/build-sitemap.service.test.ts` | unit |
+
+### Presentation — Resource Routes (수정)
+| Path | Change |
+|------|--------|
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/presentation/routes/sitemap[.xml].tsx` | placeholder → 본체 |
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/presentation/routes/robots[.txt].tsx` | placeholder → 본체 |
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/presentation/routes/__tests__/sitemap.test.ts` | unit |
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/presentation/routes/__tests__/robots.test.ts` | unit |
+
+### Presentation — meta export (페이지별 11개)
+| Path | Change |
+|------|--------|
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/presentation/routes/_index.tsx` | `export const meta` 추가 (Home) |
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/presentation/routes/about.tsx` | meta + JSON-LD Person |
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/presentation/routes/projects._index.tsx` | meta |
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/presentation/routes/projects.$slug.tsx` | meta + JSON-LD CreativeWork + BreadcrumbList |
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/presentation/routes/blog._index.tsx` | meta |
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/presentation/routes/blog.$slug.tsx` | meta + JSON-LD BlogPosting + BreadcrumbList |
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/presentation/routes/contact.tsx` | meta |
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/presentation/routes/legal._index.tsx` | meta |
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/presentation/routes/legal.$app.terms.tsx` | meta `noindex, follow` |
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/presentation/routes/legal.$app.privacy.tsx` | meta `noindex, follow` |
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/presentation/routes/$.tsx` | meta `noindex, nofollow` + 404 status |
+
+### Presentation — Lib
+| Path | Responsibility |
+|------|---------------|
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/presentation/lib/jsonld.ts` | schema.org 빌더 |
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/presentation/lib/meta.ts` | `buildMeta` helper |
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/presentation/lib/__tests__/jsonld.test.ts` | unit |
+
+### Infrastructure — Config (수정)
+| Path | Change |
+|------|--------|
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/infrastructure/config/container.ts` | `buildSitemap` 추가 |
+
+## Verification Steps
+
+### 자동
+- `bun run test` — 모든 unit 테스트 Green
+- 11개 페이지 meta export 테스트 명시적 통과
+- App Terms/Privacy의 `noindex, follow` 명시적 검증
+- 404 splat의 `noindex, nofollow` 명시적 검증
+- sitemap.xml의 포함/제외 페이지 검증
+
+### 수동
+- `wrangler dev`에서 `/sitemap.xml`, `/robots.txt` 직접 접속 → well-formed
+- 각 페이지의 view-source에서 `<title>`, `<meta>`, `<link rel="canonical">`, `<script type="application/ld+json">` 노출 확인
+- [Google Rich Results Test](https://search.google.com/test/rich-results)로 JSON-LD 정합성 검증 (production URL — T022)
+- App Terms 페이지에서 `<meta name="robots" content="noindex, follow">` 노출
+
+### 측정
+- 없음
+
+## Dependencies
+- **Depends on**: T008 (`listProjects`/`listPosts`/`listApps`), T010~T013 + T014a + T014b + T015 (페이지별 meta export 추가), T018 (OG URL을 `og:image` 값으로 사용)
+- **Blocks**: T020 (Google/Naver verification meta가 root.tsx에 추가됨)
+
+## Risks & Mitigations
+- **Risk**: 페이지별 meta export가 11개로 많아 누락 위험.
+  - **Mitigation**: `buildMeta` helper로 공통 패턴 추출 → 페이지별 차이만 props로. PR 체크리스트에 11개 명시.
+- **Risk**: JSON-LD가 잘못되면 Search Console에서 warning.
+  - **Mitigation**: schema.org 표준 그대로 채택 + Rich Results Test 검증.
+
+## References
+- PRD `F018`, App Terms/Privacy SEO 정책, Not Found Fallback SEO 정책
+- ROADMAP.md `Phase 5` Task 019
+- [Sitemap protocol](https://www.sitemaps.org/protocol.html)
+- [schema.org Person/BlogPosting/CreativeWork/BreadcrumbList](https://schema.org/)
+
+## Change History
+| Date | Changes | Author |
+|------|---------|--------|
+| - | - | - |

--- a/docs/tasks/T020-search-engine-verification.md
+++ b/docs/tasks/T020-search-engine-verification.md
@@ -1,0 +1,116 @@
+# Task 020 — F019 검색엔진 등록 (Google + Naver) + Cloudflare Web Analytics (F013)
+
+| Field | Value |
+|-------|-------|
+| **Task ID** | T020 |
+| **Phase** | Phase 5 — SEO / OG / Indexing |
+| **Layer** | Presentation(root layout) + Infrastructure(analytics 스니펫) |
+| **Branch** | `feature/issue-N-search-engine-verification` |
+| **Depends on** | T019 |
+| **Blocks** | T021 |
+| **PRD Features** | **F019** (검색엔진 등록), **F013** (Cloudflare Web Analytics) |
+| **PRD AC** | — (배포 후 `site:tkstar.dev` 인덱싱 확인) |
+| **예상 작업 시간** | 0.5d |
+| **Status** | Not Started |
+
+## Goal
+환경변수(`GOOGLE_SITE_VERIFICATION`, `NAVER_SITE_VERIFICATION`)가 설정되어 있으면 root layout `<head>`에 verification meta 태그를 조건부 렌더하고, Cloudflare Web Analytics 스니펫을 삽입한다 (쿠키 없음).
+
+## Context
+- **Why**: 한국어 사이트는 Naver 등록이 사실상 필수. Google은 글로벌. Bing은 가정 A011로 MVP 후. Web Analytics는 트래픽 가시성 확보 (운영 판단용).
+- **Phase 진입/완료 연결**: T019 SEO meta가 갖춰진 후 시작. T020 Done 후 Phase 6 QA(T021).
+- **관련 PRD 섹션**: PRD `F019`, `F013`, `Tech Stack — SEO & Indexing`, A008 가정 (verification 토큰 wrangler vars)
+- **관련 PROJECT-STRUCTURE 디렉토리**: `app/root.tsx`, `app/infrastructure/analytics/cloudflare-web-analytics.ts`, `wrangler.toml` vars
+
+## Scope
+
+### In Scope
+- root layout에서 `env.GOOGLE_SITE_VERIFICATION` / `env.NAVER_SITE_VERIFICATION` env가 truthy일 때 `<meta>` 태그 조건부 렌더
+- Cloudflare Web Analytics `<script>` 스니펫 (env `CLOUDFLARE_ANALYTICS_TOKEN`)
+- `app/infrastructure/analytics/cloudflare-web-analytics.ts` — 스니펫 헬퍼 (서버사이드 token 주입)
+- `wrangler.toml`에 `GOOGLE_SITE_VERIFICATION`, `NAVER_SITE_VERIFICATION`, `CLOUDFLARE_ANALYTICS_TOKEN` (vars) 등록 (현재는 placeholder, T022에서 실제 값 주입)
+
+### Out of Scope
+- 실제 Search Console / Naver Search Advisor 도메인 등록 — T022 (배포 후)
+- Bing Webmaster Tools — A011 가정, MVP 후
+- DNS / 도메인 등록 — T022
+
+## Acceptance Criteria
+- [ ] `wrangler dev`에서 `GOOGLE_SITE_VERIFICATION = "abc123"` 설정 시 root `<head>`에 `<meta name="google-site-verification" content="abc123">` 렌더
+- [ ] env 미설정 시 verification meta 미렌더
+- [ ] `NAVER_SITE_VERIFICATION = "xyz789"` 설정 시 `<meta name="naver-site-verification" content="xyz789">` 렌더
+- [ ] `CLOUDFLARE_ANALYTICS_TOKEN = "token123"` 설정 시 root `<body>` 끝에 Cloudflare Web Analytics `<script>` 스니펫 삽입
+- [ ] Web Analytics가 쿠키를 설정하지 않음 (DevTools Application → Cookies 검증)
+- [ ] 가정 A008 — wrangler vars로 토큰 주입 패턴 확정. A011/A012는 MVP 후로 잔존.
+
+## Implementation Plan (TDD Cycle)
+
+### Red
+- `app/root.test.tsx` (또는 `app/__tests__/root.test.tsx`)
+  - `env.GOOGLE_SITE_VERIFICATION = "abc"`인 mock context → `<meta name="google-site-verification" content="abc">` 렌더
+  - `env.NAVER_SITE_VERIFICATION = "xyz"` → `<meta name="naver-site-verification">`
+  - env 모두 미설정 → verification meta 미렌더
+- `app/infrastructure/analytics/__tests__/cloudflare-web-analytics.test.ts`
+  - token 인자로 호출 → 정확한 스니펫 문자열 반환
+  - token undefined → 빈 문자열 또는 null 반환
+
+### Green
+- `app/root.tsx` 수정 — env에서 verification 값 읽고 conditional `<meta>` 렌더
+- `app/infrastructure/analytics/cloudflare-web-analytics.ts` — `getAnalyticsSnippet(token): string`
+- `wrangler.toml`에 vars 추가 (placeholder)
+
+### Refactor
+- root에서 verification + analytics 처리를 `<RootMetaHead env={env} />` 컴포넌트로 추출
+
+## Files to Create / Modify
+
+### Root (수정)
+| Path | Change |
+|------|--------|
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/root.tsx` | env 기반 verification meta + Cloudflare Web Analytics 스니펫 |
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/__tests__/root.test.tsx` | RTL + env mock |
+
+### Infrastructure
+| Path | Responsibility |
+|------|---------------|
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/infrastructure/analytics/cloudflare-web-analytics.ts` | 스니펫 헬퍼 |
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/infrastructure/analytics/__tests__/cloudflare-web-analytics.test.ts` | unit |
+
+### Config (수정)
+| Path | Change |
+|------|--------|
+| `/Users/tkstart/Desktop/project/tkstar-dev/wrangler.toml` | `[vars]`에 `GOOGLE_SITE_VERIFICATION`, `NAVER_SITE_VERIFICATION`, `CLOUDFLARE_ANALYTICS_TOKEN` 추가 (placeholder, T022에서 실제 값) |
+| `/Users/tkstart/Desktop/project/tkstar-dev/app/env.d.ts` | `Env`에 위 3개 추가 |
+
+## Verification Steps
+
+### 자동
+- `bun run test` — root + analytics 테스트 Green
+- env 분기 케이스 (set / unset) 모두 통과
+
+### 수동
+- `wrangler dev`에서 vars placeholder 값으로 verification meta + Web Analytics 스니펫이 view-source에 노출 확인
+- DevTools → Application → Cookies가 비어있음 (Web Analytics는 쿠키 없음)
+
+### 측정
+- 없음 (실제 Search Console 등록은 T022)
+
+## Dependencies
+- **Depends on**: T019 (SEO 정합성 확보 후)
+- **Blocks**: T021 (Phase 6 QA 진입)
+
+## Risks & Mitigations
+- **Risk**: Cloudflare Web Analytics 스니펫이 SSR/CSR 양쪽에서 동작 시 hydration mismatch.
+  - **Mitigation**: 스니펫은 SSR 출력만 — `<script defer src="...">` 형태로 `<body>` 끝에 1회 삽입, 클라이언트 hydration이 SSR HTML을 그대로 사용 → mismatch 없음.
+
+## References
+- PRD `F019`, `F013`, A008 가정
+- ROADMAP.md `Phase 5` Task 020, 가정 A008 해소(wrangler vars 패턴)
+- [Cloudflare Web Analytics docs](https://developers.cloudflare.com/web-analytics/)
+- [Google Search Console verification](https://support.google.com/webmasters/answer/9008080)
+- [Naver Search Advisor](https://searchadvisor.naver.com/)
+
+## Change History
+| Date | Changes | Author |
+|------|---------|--------|
+| - | - | - |

--- a/docs/tasks/T021-qa-pass-mvp.md
+++ b/docs/tasks/T021-qa-pass-mvp.md
@@ -1,0 +1,101 @@
+# Task 021 — 통합 QA + Lighthouse + Axe 접근성 점검 + 모든 PRD AC 통과 매트릭스
+
+| Field | Value |
+|-------|-------|
+| **Task ID** | T021 |
+| **Phase** | Phase 6 — Polish & Deploy |
+| **Layer** | 전 layer (회귀 테스트) |
+| **Branch** | `chore/qa-pass-mvp` |
+| **Depends on** | T020 |
+| **Blocks** | T022 |
+| **PRD Features** | F001~F019 전체 |
+| **PRD AC** | AC-F003-1/2/3, AC-F008-1/2/3/4, AC-F009-1/2/3, AC-F011-1/2/3, AC-F016-1/2/3/4/5 — **18개 AC 전수** |
+| **예상 작업 시간** | 1d |
+| **Status** | Not Started |
+
+## Goal
+배포 직전 통합 QA 단계. 모든 자동 테스트가 Green이고 coverage threshold(T003에서 정의한 lines 80 / branches 75 / functions 80 / statements 80)를 통과하며, Lighthouse(Perf ≥ 90, A11y ≥ 95, Best Practices ≥ 95, SEO ≥ 100), Axe 위반 0건이 보장됨을 확인한다. 18개 PRD AC 전체를 매트릭스로 회귀.
+
+## Context
+- **Why**: Phase 1~5에서 task 단위 AC는 모두 통과했지만 배포 전 회귀 매트릭스가 1회 더 필요. Lighthouse/Axe는 task 단위로 검증 불가능한 cross-cutting 품질 지표.
+- **Phase 진입/완료 연결**: T020 Done 후. T021 Done이 T022 배포의 진입 조건.
+- **관련 PRD 섹션**: PRD `Acceptance Criteria` 18개 AC 전체
+- **관련 PROJECT-STRUCTURE 디렉토리**: `docs/reports/qa-{date}.md`(수동 결과 기록)
+
+## Scope
+
+### In Scope
+- `bun run test:coverage` 실행 + threshold 통과 확인 (수치는 T003 vitest.config.ts에 정의)
+- Lighthouse 4 카테고리 점수 측정 (production preview build에서)
+- Axe 자동 스캔 (예: `@axe-core/cli` 또는 Chrome DevTools Lighthouse 통합)
+- 18개 AC 전수 회귀 매트릭스 — 각 AC를 자동 테스트 ID와 매핑하여 통과 표 작성
+- 키보드만 네비게이션 (Cmd+K → palette → 결과 진입 → Esc) 수동 검증
+- 다크/라이트 모드 시각 회귀 (스냅샷 또는 수동 비교)
+- 발견된 결함은 별도 `fix/issue-N-*` PR로 분리
+
+### Out of Scope
+- 실제 production 배포 (T022)
+- 도메인 연결 (T022)
+- Cloudflare Email Routing (T022)
+
+## Acceptance Criteria
+- [ ] `bun run test:coverage` 100% Green + threshold 통과 (lines ≥ 80%, branches ≥ 75%, functions ≥ 80%, statements ≥ 80%)
+- [ ] Lighthouse Performance ≥ 90
+- [ ] Lighthouse Accessibility ≥ 95
+- [ ] Lighthouse Best Practices ≥ 95
+- [ ] Lighthouse SEO ≥ 100
+- [ ] Axe-core 위반 0건 (모든 페이지)
+- [ ] 18개 AC 전수 회귀 매트릭스 PASS (`docs/reports/qa-{date}.md`)
+- [ ] 키보드 only 네비게이션 정상 (Cmd+K → palette → 결과 ↑↓ → ↵ → Esc)
+- [ ] 다크/라이트 모드 시각 회귀 통과
+
+## Implementation Plan (TDD Cycle)
+**N/A — chore branch policy.** QA 자체는 회귀 테스트 단계이며 새 코드를 거의 추가하지 않음. 발견된 결함은 별도 `fix/*` PR.
+
+## Files to Create / Modify
+
+### Reports
+| Path | Responsibility |
+|------|---------------|
+| `/Users/tkstart/Desktop/project/tkstar-dev/docs/reports/qa-2026-MM-DD.md` | QA 실행 결과 + 18개 AC 매트릭스 + Lighthouse 점수 + Axe 결과 |
+
+### CI Hook (선택)
+| Path | Change |
+|------|--------|
+| `/Users/tkstart/Desktop/project/tkstar-dev/.github/workflows/ci.yml` (선택, 별도 task로 분리해도 됨) | `bun run test:coverage` + Lighthouse CI / Axe CI 자동 실행 |
+
+## Verification Steps
+
+### 자동
+- `bun run test:coverage` exit 0 + threshold 통과
+- Lighthouse CLI(`bunx lighthouse https://localhost:8787 --quiet --output json`) 결과 4 카테고리 점수
+- `bunx @axe-core/cli` 또는 Pa11y로 모든 페이지 스캔
+
+### 수동
+- Chrome DevTools Lighthouse 탭에서 production preview(`bun run build && bunx wrangler pages dev` 또는 staging URL)에 대해 4 카테고리 측정
+- 키보드만 네비게이션 1 round
+- 다크 모드 → 라이트 모드 전환 시각 회귀
+
+### 측정
+- Lighthouse 4 카테고리 점수
+- coverage % (lines/branches/functions/statements)
+- Axe 위반 수
+
+## Dependencies
+- **Depends on**: T020 (모든 페이지 + SEO + analytics 가동)
+- **Blocks**: T022 (배포)
+
+## Risks & Mitigations
+- **Risk**: coverage threshold가 task별 분기를 놓치거나 mock 비중이 높아 실제 동작 검증이 약할 수 있음.
+  - **Mitigation**: T021에서 발견되면 `fix/*` PR로 보강. threshold 수치 자체는 T003에서 합의된 1인 정적 사이트 기준.
+- **Risk**: Lighthouse Performance ≥ 90이 cold start에서 깨질 수 있음.
+  - **Mitigation**: Cloudflare Workers의 cold start는 매우 짧음(~5ms). 측정은 warm state에서 3회 평균.
+
+## References
+- PRD `Acceptance Criteria` 18개 AC 전체
+- ROADMAP.md `Phase 6` Task 021 (Issue #6 coverage threshold 수치는 T003에서 정의)
+
+## Change History
+| Date | Changes | Author |
+|------|---------|--------|
+| - | - | - |

--- a/docs/tasks/T022-deploy-production.md
+++ b/docs/tasks/T022-deploy-production.md
@@ -1,0 +1,112 @@
+# Task 022 — Cloudflare Workers 배포 + 도메인 연결 + Email Routing + 검색엔진 인증 완료
+
+| Field | Value |
+|-------|-------|
+| **Task ID** | T022 |
+| **Phase** | Phase 6 — Polish & Deploy |
+| **Layer** | 운영 |
+| **Branch** | `chore/deploy-production` |
+| **Depends on** | T021 |
+| **Blocks** | none |
+| **PRD Features** | F019 (인증 완료), 운영 (도메인/이메일) |
+| **PRD AC** | — (운영 검증) |
+| **예상 작업 시간** | 1d (DNS 전파 대기 시간 별도) |
+| **Status** | Not Started |
+
+## Goal
+`bunx wrangler deploy`로 Cloudflare Workers에 첫 배포하고, `tkstar.dev` 도메인 연결 + Cloudflare Email Routing + Resend domain verification + Google/Naver Search Console 인증을 모두 완료한다. 가정 A010(도메인 등록 채널) 결정 + A008(실제 토큰 주입) 완료.
+
+## Context
+- **Why**: 사이트의 사용자 노출 시작점. 모든 Phase 1~5의 산출물이 production URL에서 동작해야 PRD 목표(B2B/B2C 수렴)를 달성.
+- **Phase 진입/완료 연결**: T021 QA 통과 후. T022 Done 후 실제 트래픽 수집(Cloudflare Web Analytics) 및 SEO 인덱싱 시작.
+- **관련 PRD 섹션**: PRD `Tech Stack — Hosting / Edge / Email Routing`, `F019`, A008/A010
+- **관련 PROJECT-STRUCTURE 디렉토리**: `wrangler.toml`, Cloudflare Dashboard 설정 (코드 변경 외)
+
+## Scope
+
+### In Scope
+- `bunx wrangler deploy` 첫 배포 → `tkstar-dev.workers.dev` 우선 동작 확인
+- 도메인 등록 채널 결정 (Cloudflare Registrar 또는 Porkbun → CF transfer) — A010 결정 시 기록
+- `tkstar.dev` 도메인 등록 + Cloudflare DNS 연결 + Workers Custom Domain 매핑
+- Cloudflare Email Routing 설정: `hello@tkstar.dev` → 개인 Gmail forward
+- Resend domain verification — DKIM/SPF DNS record 추가 + Resend dashboard에서 verified 상태 확인
+- Production secrets 주입: `bunx wrangler secret put RESEND_API_KEY` / `TURNSTILE_SECRET`
+- Production vars 갱신: `wrangler.toml`에 실제 `GOOGLE_SITE_VERIFICATION`, `NAVER_SITE_VERIFICATION`, `CLOUDFLARE_ANALYTICS_TOKEN` 값 (또는 dashboard vars)
+- KV namespace `RATE_LIMIT_KV` production id를 `wrangler.toml`에 확정 (T017에서 생성된 id 사용)
+- Google Search Console 도메인 소유권 인증 + `https://tkstar.dev/sitemap.xml` 제출
+- Naver Search Advisor `naver-site-verification` meta 검증 + sitemap 제출
+- 배포 후 `site:tkstar.dev` 검색으로 indexing 확인 (수일 ~ 수주 소요)
+
+### Out of Scope
+- Bing Webmaster Tools (가정 A011, MVP 후)
+- Motion 라이브러리 도입 (A012, MVP 후)
+
+## Acceptance Criteria
+- [ ] `bunx wrangler deploy` 성공 → `tkstar-dev.workers.dev` 첫 응답 정상
+- [ ] `tkstar.dev` 도메인 DNS가 Cloudflare를 가리키며 Workers Custom Domain 매핑 완료
+- [ ] `https://tkstar.dev` 접속 시 Home 정상 응답 (HTTPS, OG 미리보기 정상)
+- [ ] `hello@tkstar.dev` → 개인 Gmail로 forward 정상 (실제 메일 1통 송수신 검증)
+- [ ] Resend domain verification status: `verified`
+- [ ] Production Contact Form 제출 → Resend 발신 + 자동응답 메일 정상 (실제 1회 검증)
+- [ ] Google Search Console 도메인 소유권 인증 통과 + sitemap 제출 완료
+- [ ] Naver Search Advisor 인증 통과 + sitemap 제출 완료
+- [ ] (배포 후 수일~수주) `site:tkstar.dev` Google 검색에 최소 1개 페이지 indexing 확인
+
+## Implementation Plan (TDD Cycle)
+**N/A — chore branch policy.** 운영 task. 코드 변경은 wrangler.toml의 production 값 갱신 정도.
+
+## Files to Create / Modify
+
+### Config (수정)
+| Path | Change |
+|------|--------|
+| `/Users/tkstart/Desktop/project/tkstar-dev/wrangler.toml` | `[[kv_namespaces]]`의 `id`를 production id로 확정 / `[vars]`의 verification 토큰 값 확정 (또는 dashboard vars로 이관) / `routes` 또는 `custom_domains` 블록에 `tkstar.dev` 매핑 추가 |
+
+### Reports
+| Path | Responsibility |
+|------|---------------|
+| `/Users/tkstart/Desktop/project/tkstar-dev/docs/reports/deploy-2026-MM-DD.md` | 배포 결과 + DNS 설정 + Email Routing 검증 + Resend domain verification + Search Console 인증 결과 |
+
+## Verification Steps
+
+### 자동
+- `bunx wrangler deploy` exit 0
+- production URL `curl -I https://tkstar.dev` → 200 응답 + `Content-Type: text/html`
+- `curl https://tkstar.dev/sitemap.xml` → well-formed XML
+- `curl https://tkstar.dev/og/projects/example-project.png` → 1200×630 PNG (size 검증)
+
+### 수동
+- 브라우저에서 `https://tkstar.dev` 접속 → 모든 페이지 정상
+- Twitter/Facebook OG validator로 production URL 검증
+- 실제 hello@tkstar.dev로 메일 1통 발송 → 개인 Gmail 수신
+- Contact Form에서 실제 메일 1통 발송 → 본인 메일 + 자동응답 수신
+- Google Search Console 대시보드에서 sitemap "성공" 상태 확인
+- Naver Search Advisor 대시보드에서 sitemap "처리 완료" 상태 확인
+
+### 측정
+- production URL Lighthouse 점수 (T021 staging 측정 + production warm state 비교)
+
+## Dependencies
+- **Depends on**: T021 (QA 통과)
+- **Blocks**: 없음 (Post-MVP는 별도 issue)
+
+## Risks & Mitigations
+- **Risk**: DNS 전파에 24~48h 소요 → 검색엔진 인증이 즉시 안됨.
+  - **Mitigation**: 배포 D-1에 도메인 등록 + DNS 설정 선행, D-day에 인증 시도.
+- **Risk**: Resend domain verification에서 DKIM/SPF DNS record 누락.
+  - **Mitigation**: Resend dashboard 안내에 따라 5개 DNS record 추가 + verification 재시도.
+- **Risk**: Cloudflare Workers의 production secrets 누출 위험.
+  - **Mitigation**: `wrangler secret put`만 사용 (`wrangler.toml`에 secret 직접 기록 금지). git history에서 토큰 흔적 감사.
+
+## References
+- PRD `Tech Stack — Hosting / Edge / Email Routing`, `F019`
+- ROADMAP.md `Phase 6` Task 022, 가정 A008 완료, A010 결정
+- [Cloudflare Workers Custom Domains](https://developers.cloudflare.com/workers/configuration/routing/custom-domains/)
+- [Cloudflare Email Routing](https://developers.cloudflare.com/email-routing/)
+- [Resend domain verification](https://resend.com/docs/dashboard/domains/introduction)
+- [Google Search Console](https://search.google.com/search-console), [Naver Search Advisor](https://searchadvisor.naver.com/)
+
+## Change History
+| Date | Changes | Author |
+|------|---------|--------|
+| - | - | - |


### PR DESCRIPTION
## Summary
- PRD/PROJECT-STRUCTURE/ROADMAP 신규 작성 + 검증 리포트 첨부
- 24개 task 파일(`docs/tasks/T001~T022`) + README 인덱스 생성 — TDD-First, Inside-Out, PR-단위
- 디자인 정본(`docs/design-system/`) 커밋
- CLAUDE.md PR-only workflow 명시 + chore/docs phase 면제 정책 추가
- development-planner agent: `docs/tasks/` 경로 정정 + 자가 검증 루프 추가
- `.gitignore`에 `.claude/runtime/` 추가

## Test plan
- [ ] PRD/ROADMAP/PROJECT-STRUCTURE 상호 정합성 (검증 리포트 통과 확인)
- [ ] 24개 task 파일 모두 11 섹션 표준 구조 준수
- [ ] PRD F001~F019 (F015 제외) → task 매핑 누락 없음
- [ ] Acceptance Criteria(F003/F008/F009/F011/F016) → task 검증 항목에 매핑됨
- [ ] Assumptions Register A001~A012 phase 게이트 일치

🤖 Generated with [Claude Code](https://claude.com/claude-code)