### PR TITLE
📝 docs: mark T001/T002 complete in ROADMAP + task file

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -54,7 +54,7 @@ tkstarDev는 다음 핵심 가치를 단일 도메인에서 달성한다:
 > **진입 조건**: PRD/PROJECT-STRUCTURE 정본 확정 (현재 시점)
 > **완료 조건 (DoD)**: `bun run typecheck`, `bun run lint`, `bun run test`, `bun run dev`(또는 `bun run start`), `bunx wrangler dev`가 모두 무오류 통과. `app/{domain,application,infrastructure,presentation}/` 4-layer 디렉토리가 placeholder index와 함께 존재.
 
-- [ ] **Task 001: 프로젝트 스캐폴딩 + Bun + TypeScript + Biome 셋업**
+- [x] **Task 001: 프로젝트 스캐폴딩 + Bun + TypeScript + Biome 셋업** ✅
   - **Must** Read: [tasks/T001-scaffold-bun-rr7-biome.md](tasks/T001-scaffold-bun-rr7-biome.md)
   - blockedBy: none
   - blocks: Task 002, Task 003
@@ -69,7 +69,7 @@ tkstarDev는 다음 핵심 가치를 단일 도메인에서 달성한다:
     - `.gitignore` 보강 (`.velite/`, `.react-router/`, `node_modules/`, `dist/`, `.wrangler/`)
   - PR 1개 / 브랜치: `chore/scaffold-bun-rr7-biome`
 
-- [ ] **Task 002: Clean Architecture 4-layer 디렉토리 골격 + path alias**
+- [x] **Task 002: Clean Architecture 4-layer 디렉토리 골격 + path alias** ✅
   - **Must** Read: [tasks/T002-ca-4layer-skeleton.md](tasks/T002-ca-4layer-skeleton.md)
   - blockedBy: Task 001
   - blocks: Task 004, Task 006, Task 007, Task 008, Task 009

--- a/docs/tasks/T002-ca-4layer-skeleton.md
+++ b/docs/tasks/T002-ca-4layer-skeleton.md
@@ -11,7 +11,7 @@
 | **PRD Features** | — (구조) |
 | **PRD AC** | — |
 | **예상 작업 시간** | 0.5d |
-| **Status** | Not Started |
+| **Status** | Done |
 
 ## Goal
 PROJECT-STRUCTURE.md에 명시된 Clean Architecture 4-layer(`app/{domain,application,infrastructure,presentation}/`) 디렉토리 골격을 빈 placeholder와 함께 생성하고, path alias가 모든 layer에 정상 동작하도록 한다.
@@ -36,13 +36,13 @@ PROJECT-STRUCTURE.md에 명시된 Clean Architecture 4-layer(`app/{domain,applic
 - `velite.config.ts` / `vite.config.ts` — T003/T007
 
 ## Acceptance Criteria
-- [ ] `app/domain/{project,post,legal,contact,theme}/` 디렉토리가 모두 존재 (각각 `.gitkeep` 또는 `index.ts`)
-- [ ] `app/application/{content,contact,search,og,feed,seo}/{ports,services}/` 디렉토리가 모두 존재
-- [ ] `app/infrastructure/{config,content,email,captcha,og,search,analytics}/` 디렉토리가 모두 존재
-- [ ] `app/presentation/{components,hooks,lib,layouts,routes}/` 디렉토리가 모두 존재
-- [ ] `test/{fixtures,utils}/` 디렉토리가 존재
-- [ ] `bun run typecheck`가 path alias `~/domain/*` 등을 모두 인식
-- [ ] `app/README.md`에 의존성 방향이 1줄 이상으로 문서화
+- [x] `app/domain/{project,post,legal,contact,theme}/` 디렉토리가 모두 존재 (각각 `.gitkeep` 또는 `index.ts`)
+- [x] `app/application/{content,contact,search,og,feed,seo}/{ports,services}/` 디렉토리가 모두 존재
+- [x] `app/infrastructure/{config,content,email,captcha,og,search,analytics}/` 디렉토리가 모두 존재
+- [x] `app/presentation/{components,hooks,lib,layouts,routes}/` 디렉토리가 모두 존재
+- [x] `test/{fixtures,utils}/` 디렉토리가 존재
+- [x] `bun run typecheck`가 path alias `~/domain/*` 등을 모두 인식
+- [x] `app/README.md`에 의존성 방향이 1줄 이상으로 문서화
 
 ## Implementation Plan (TDD Cycle)
 **N/A — chore branch policy.** 디렉토리 구조 자체는 테스트 대상이 아님. `bun run typecheck` 통과로 path alias 정합성을 검증.
@@ -133,4 +133,4 @@ PROJECT-STRUCTURE.md에 명시된 Clean Architecture 4-layer(`app/{domain,applic
 ## Change History
 | Date | Changes | Author |
 |------|---------|--------|
-| - | - | - |
+| 2026-04-28 | T002 PR (#10) — 28개 `.gitkeep` placeholder 생성, T001 split tsconfig 구조에 맞춰 path alias를 `tsconfig.cloudflare.json`에 추가 (태스크 문서의 `tsconfig.app.json` 명세 적응), `app/README.md` 의존성 방향 문서화, Status=Done | TaekyungHa |


### PR DESCRIPTION
## Summary

- `docs/ROADMAP.md`: Task 001 (#7) / Task 002 (#10) 체크박스 `[ ]` → `[x]` + ✅
- `docs/tasks/T002-ca-4layer-skeleton.md`:
  - Status `Not Started` → `Done`
  - AC 6/6 `[x]`
  - Change History 1행 추가 (T001 split tsconfig 적응 사유 명시)

## Notes

- T001 task 파일은 PR #7 시점에 이미 갱신됨 — 이번엔 ROADMAP 체크박스만 보강.
- "진행 현황 요약" Phase 0 항목은 T003 미완이므로 미체크 유지.
- `docs/*` 브랜치 carve-out으로 Phase 1/2 스킵 — PR 리뷰가 안전망.

## Test plan

- [x] 변경 범위가 `docs/**`로 한정됨 (`git diff --stat` 검증)

---
Related: #11