### PR TITLE
🐛 fix(T006): development 브랜치에 T006 작업물 복구

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,7 +41,7 @@
 - **MDX** — 콘텐츠 작성 포맷
 - **shiki** — 코드블록 syntax highlight
 - **Satori** — 빌드/SSR 동적 OG 이미지 생성 (1200×630)
-- **Zod** — frontmatter 스키마 검증 (velite 내장)
+- **Zod 4.3.6** — Domain schema 검증 (Project / Post / AppLegalDoc / ContactSubmission) + velite frontmatter 검증 (단일 정본을 양쪽이 공유)
 - **rehype-slug** — on-this-page TOC 헤딩 anchor
 
 ### Search Index (F016 Cmd+K)

--- a/app/domain/_shared/zod-helpers.ts
+++ b/app/domain/_shared/zod-helpers.ts
@@ -1,0 +1,7 @@
+import { z } from "zod";
+
+const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}/;
+
+export const zNonEmptyString = () => z.string().min(1);
+
+export const zIso8601Date = () => z.string().regex(ISO_DATE_RE, "must be ISO 8601 (YYYY-MM-DD)");

--- a/app/domain/contact/__tests__/contact-submission.schema.test.ts
+++ b/app/domain/contact/__tests__/contact-submission.schema.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest";
+import { contactSubmissionSchema } from "../contact-submission.schema";
+
+const valid = {
+	name: "Taekyung Ha",
+	company: "Acme Inc.",
+	email: "foo@bar.com",
+	inquiry_type: "B2B" as const,
+	message: "a".repeat(50),
+	turnstile_token: "tk_test_token",
+};
+
+describe("contactSubmissionSchema (AC-F008-2/3)", () => {
+	it("정상 입력 통과", () => {
+		const result = contactSubmissionSchema.safeParse(valid);
+		expect(result.success).toBe(true);
+	});
+
+	it("AC-F008-2: foo@bar.com 통과", () => {
+		const result = contactSubmissionSchema.safeParse(valid);
+		expect(result.success).toBe(true);
+	});
+
+	it("AC-F008-2: foo@ reject", () => {
+		const result = contactSubmissionSchema.safeParse({ ...valid, email: "foo@" });
+		expect(result.success).toBe(false);
+	});
+
+	it("AC-F008-2: bar.com reject", () => {
+		const result = contactSubmissionSchema.safeParse({
+			...valid,
+			email: "bar.com",
+		});
+		expect(result.success).toBe(false);
+	});
+
+	it("AC-F008-3: 메시지 9자 reject", () => {
+		const result = contactSubmissionSchema.safeParse({
+			...valid,
+			message: "a".repeat(9),
+		});
+		expect(result.success).toBe(false);
+	});
+
+	it("AC-F008-3: 메시지 10자 통과", () => {
+		const result = contactSubmissionSchema.safeParse({
+			...valid,
+			message: "a".repeat(10),
+		});
+		expect(result.success).toBe(true);
+	});
+
+	it("AC-F008-3: 메시지 5000자 통과", () => {
+		const result = contactSubmissionSchema.safeParse({
+			...valid,
+			message: "a".repeat(5000),
+		});
+		expect(result.success).toBe(true);
+	});
+
+	it("AC-F008-3: 메시지 5001자 reject", () => {
+		const result = contactSubmissionSchema.safeParse({
+			...valid,
+			message: "a".repeat(5001),
+		});
+		expect(result.success).toBe(false);
+	});
+
+	it("inquiry_type: B2C / etc 통과", () => {
+		const r1 = contactSubmissionSchema.safeParse({ ...valid, inquiry_type: "B2C" });
+		const r2 = contactSubmissionSchema.safeParse({ ...valid, inquiry_type: "etc" });
+		expect(r1.success).toBe(true);
+		expect(r2.success).toBe(true);
+	});
+
+	it("inquiry_type 외 값 reject", () => {
+		const result = contactSubmissionSchema.safeParse({
+			...valid,
+			inquiry_type: "consulting",
+		});
+		expect(result.success).toBe(false);
+	});
+
+	it("company는 optional (undefined 통과)", () => {
+		const { company: _c, ...rest } = valid;
+		const result = contactSubmissionSchema.safeParse(rest);
+		expect(result.success).toBe(true);
+	});
+
+	it("turnstile_token 누락 시 reject", () => {
+		const { turnstile_token: _t, ...rest } = valid;
+		const result = contactSubmissionSchema.safeParse(rest);
+		expect(result.success).toBe(false);
+	});
+});

--- a/app/domain/contact/contact-submission.schema.ts
+++ b/app/domain/contact/contact-submission.schema.ts
@@ -1,0 +1,11 @@
+import { z } from "zod";
+import { zNonEmptyString } from "../_shared/zod-helpers";
+
+export const contactSubmissionSchema = z.object({
+	name: zNonEmptyString(),
+	company: z.string().optional(),
+	email: z.email(),
+	inquiry_type: z.enum(["B2B", "B2C", "etc"]),
+	message: z.string().min(10).max(5000),
+	turnstile_token: zNonEmptyString(),
+});

--- a/app/domain/contact/contact-submission.vo.ts
+++ b/app/domain/contact/contact-submission.vo.ts
@@ -1,0 +1,4 @@
+import type { z } from "zod";
+import type { contactSubmissionSchema } from "./contact-submission.schema";
+
+export type ContactSubmission = z.infer<typeof contactSubmissionSchema>;

--- a/app/domain/contact/contact.errors.ts
+++ b/app/domain/contact/contact.errors.ts
@@ -1,0 +1,6 @@
+export class InvalidContactSubmissionError extends Error {
+	constructor(issues: string) {
+		super(`Invalid contact submission: ${issues}`);
+		this.name = "InvalidContactSubmissionError";
+	}
+}

--- a/app/domain/legal/__tests__/app-legal-doc.schema.test.ts
+++ b/app/domain/legal/__tests__/app-legal-doc.schema.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import { appLegalDocSchema } from "../app-legal-doc.schema";
+
+const validFrontmatter = {
+	app_slug: "tkstar-app",
+	doc_type: "terms" as const,
+	version: "1.0.0",
+	effective_date: "2026-04-01",
+};
+
+describe("appLegalDocSchema", () => {
+	it("doc_type: terms 통과", () => {
+		const result = appLegalDocSchema.safeParse(validFrontmatter);
+		expect(result.success).toBe(true);
+	});
+
+	it("doc_type: privacy 통과", () => {
+		const result = appLegalDocSchema.safeParse({
+			...validFrontmatter,
+			doc_type: "privacy",
+		});
+		expect(result.success).toBe(true);
+	});
+
+	it("doc_type: foo 등 임의 값 reject", () => {
+		const result = appLegalDocSchema.safeParse({
+			...validFrontmatter,
+			doc_type: "foo",
+		});
+		expect(result.success).toBe(false);
+	});
+
+	it("effective_date가 ISO 8601 위반 시 reject", () => {
+		const result = appLegalDocSchema.safeParse({
+			...validFrontmatter,
+			effective_date: "2026/04/01",
+		});
+		expect(result.success).toBe(false);
+	});
+
+	it("version은 free string (SemVer 강제 X)", () => {
+		const result = appLegalDocSchema.safeParse({
+			...validFrontmatter,
+			version: "draft-2026-q2",
+		});
+		expect(result.success).toBe(true);
+	});
+
+	it("app_slug 누락 시 reject", () => {
+		const { app_slug: _a, ...rest } = validFrontmatter;
+		const result = appLegalDocSchema.safeParse(rest);
+		expect(result.success).toBe(false);
+	});
+});

--- a/app/domain/legal/app-legal-doc.entity.ts
+++ b/app/domain/legal/app-legal-doc.entity.ts
@@ -1,0 +1,4 @@
+import type { z } from "zod";
+import type { appLegalDocSchema } from "./app-legal-doc.schema";
+
+export type AppLegalDoc = z.infer<typeof appLegalDocSchema>;

--- a/app/domain/legal/app-legal-doc.schema.ts
+++ b/app/domain/legal/app-legal-doc.schema.ts
@@ -1,0 +1,9 @@
+import { z } from "zod";
+import { zIso8601Date, zNonEmptyString } from "../_shared/zod-helpers";
+
+export const appLegalDocSchema = z.object({
+	app_slug: zNonEmptyString(),
+	doc_type: z.enum(["terms", "privacy"]),
+	version: zNonEmptyString(),
+	effective_date: zIso8601Date(),
+});

--- a/app/domain/post/__tests__/post.schema.test.ts
+++ b/app/domain/post/__tests__/post.schema.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { postSchema } from "../post.schema";
+
+const validFrontmatter = {
+	slug: "rr7-ssr-edge",
+	title: "RR7 SSR on Cloudflare Workers",
+	lede: "Edge-rendering React Router 7 with bindings",
+	date: "2026-04-28",
+	tags: ["rr7", "cloudflare"],
+	read: 7,
+};
+
+describe("postSchema", () => {
+	it("정상 frontmatter 통과", () => {
+		const result = postSchema.safeParse(validFrontmatter);
+		expect(result.success).toBe(true);
+	});
+
+	it("read가 number가 아니면 reject", () => {
+		const result = postSchema.safeParse({ ...validFrontmatter, read: "7" });
+		expect(result.success).toBe(false);
+	});
+
+	it("date가 ISO 8601 위반 시 reject", () => {
+		const result = postSchema.safeParse({
+			...validFrontmatter,
+			date: "April 28, 2026",
+		});
+		expect(result.success).toBe(false);
+	});
+
+	it("필수 필드(title) 누락 시 reject", () => {
+		const { title: _t, ...rest } = validFrontmatter;
+		const result = postSchema.safeParse(rest);
+		expect(result.success).toBe(false);
+	});
+});

--- a/app/domain/post/post.entity.ts
+++ b/app/domain/post/post.entity.ts
@@ -1,0 +1,4 @@
+import type { z } from "zod";
+import type { postSchema } from "./post.schema";
+
+export type Post = z.infer<typeof postSchema>;

--- a/app/domain/post/post.schema.ts
+++ b/app/domain/post/post.schema.ts
@@ -1,0 +1,11 @@
+import { z } from "zod";
+import { zIso8601Date, zNonEmptyString } from "../_shared/zod-helpers";
+
+export const postSchema = z.object({
+	slug: zNonEmptyString(),
+	title: zNonEmptyString(),
+	lede: zNonEmptyString(),
+	date: zIso8601Date(),
+	tags: z.array(z.string()),
+	read: z.number(),
+});

--- a/app/domain/project/__tests__/project.schema.test.ts
+++ b/app/domain/project/__tests__/project.schema.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import { projectSchema } from "../project.schema";
+
+const validFrontmatter = {
+	slug: "tkstar-dev",
+	title: "tkstar.dev",
+	summary: "Personal brand site",
+	date: "2026-04",
+	tags: ["portfolio", "rr7"],
+	stack: ["React Router 7", "Cloudflare Workers"],
+	metrics: [
+		["LCP", "1.2s"],
+		["TTFB", "180ms"],
+	] as [string, string][],
+};
+
+describe("projectSchema", () => {
+	it("정상 frontmatter 통과 (필수 필드만)", () => {
+		const result = projectSchema.safeParse(validFrontmatter);
+		expect(result.success).toBe(true);
+	});
+
+	it("featured: true / cover 포함도 통과 (optional)", () => {
+		const result = projectSchema.safeParse({
+			...validFrontmatter,
+			featured: true,
+			cover: "/images/cover.png",
+		});
+		expect(result.success).toBe(true);
+	});
+
+	it("featured 미포함도 통과 (optional)", () => {
+		const result = projectSchema.safeParse(validFrontmatter);
+		expect(result.success).toBe(true);
+	});
+
+	it("slug 누락 시 reject", () => {
+		const { slug: _slug, ...rest } = validFrontmatter;
+		const result = projectSchema.safeParse(rest);
+		expect(result.success).toBe(false);
+	});
+
+	it("metrics가 [string, string][] 형태 위반 시 reject", () => {
+		const result = projectSchema.safeParse({
+			...validFrontmatter,
+			metrics: [["LCP", 1.2]],
+		});
+		expect(result.success).toBe(false);
+	});
+
+	it("tags가 string[]가 아닐 때 reject", () => {
+		const result = projectSchema.safeParse({
+			...validFrontmatter,
+			tags: "portfolio",
+		});
+		expect(result.success).toBe(false);
+	});
+});

--- a/app/domain/project/project.entity.ts
+++ b/app/domain/project/project.entity.ts
@@ -1,0 +1,4 @@
+import type { z } from "zod";
+import type { projectSchema } from "./project.schema";
+
+export type Project = z.infer<typeof projectSchema>;

--- a/app/domain/project/project.errors.ts
+++ b/app/domain/project/project.errors.ts
@@ -1,0 +1,13 @@
+export class ProjectNotFoundError extends Error {
+	constructor(slug: string) {
+		super(`Project not found: ${slug}`);
+		this.name = "ProjectNotFoundError";
+	}
+}
+
+export class InvalidProjectFrontmatterError extends Error {
+	constructor(slug: string, issues: string) {
+		super(`Invalid project frontmatter (${slug}): ${issues}`);
+		this.name = "InvalidProjectFrontmatterError";
+	}
+}

--- a/app/domain/project/project.schema.ts
+++ b/app/domain/project/project.schema.ts
@@ -1,0 +1,14 @@
+import { z } from "zod";
+import { zNonEmptyString } from "../_shared/zod-helpers";
+
+export const projectSchema = z.object({
+	slug: zNonEmptyString(),
+	title: zNonEmptyString(),
+	summary: zNonEmptyString(),
+	date: zNonEmptyString(),
+	tags: z.array(z.string()),
+	stack: z.array(z.string()),
+	metrics: z.array(z.tuple([z.string(), z.string()])),
+	featured: z.boolean().optional(),
+	cover: z.string().optional(),
+});

--- a/app/domain/theme/theme-preference.vo.ts
+++ b/app/domain/theme/theme-preference.vo.ts
@@ -1,0 +1,1 @@
+export type ThemePreference = "dark" | "light";

--- a/bun.lock
+++ b/bun.lock
@@ -9,6 +9,7 @@
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
         "react-router": "7.14.0",
+        "zod": "^4.3.6",
       },
       "devDependencies": {
         "@biomejs/biome": "2.4.13",
@@ -903,6 +904,8 @@
     "youch": ["youch@4.1.0-beta.10", "", { "dependencies": { "@poppinss/colors": "^4.1.5", "@poppinss/dumper": "^0.6.4", "@speed-highlight/core": "^1.2.7", "cookie": "^1.0.2", "youch-core": "^0.3.3" } }, "sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ=="],
 
     "youch-core": ["youch-core@0.3.3", "", { "dependencies": { "@poppinss/exception": "^1.2.2", "error-stack-parser-es": "^1.0.5" } }, "sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA=="],
+
+    "zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
     "@babel/core/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -149,7 +149,7 @@ tkstarDev는 다음 핵심 가치를 단일 도메인에서 달성한다:
   - TDD: `useTheme.test.ts` (system 추종 / 강제 전환 / localStorage persist) — `__tests__/`
   - PR 1개 / 브랜치: `feature/issue-N-theme-tokens`
 
-- [ ] **Task 006: Domain Schemas — Project / Post / AppLegalDoc / ContactSubmission / ThemePreference**
+- [x] **Task 006: Domain Schemas — Project / Post / AppLegalDoc / ContactSubmission / ThemePreference**
   - **Must** Read: [tasks/T006-domain-schemas.md](tasks/T006-domain-schemas.md)
   - blockedBy: Task 002
   - blocks: Task 007, Task 008, Task 009

--- a/docs/tasks/T006-domain-schemas.md
+++ b/docs/tasks/T006-domain-schemas.md
@@ -11,7 +11,7 @@
 | **PRD Features** | F002, F004, F005, F006, F007, F008, F010, F014, F017 (read-side 데이터 모델) |
 | **PRD AC** | AC-F008-2 (RFC 5322), AC-F008-3 (메시지 10~5000자) — `ContactSubmission` schema에 정의 |
 | **예상 작업 시간** | 1d |
-| **Status** | Not Started |
+| **Status** | ✅ Done |
 
 ## Goal
 Clean Architecture의 가장 안쪽 레이어인 Domain에 5개 콘텐츠/입력 모델의 Zod 스키마를 정의한다. 이 스키마는 velite frontmatter 검증(T007)과 Application 유스케이스(T008/T017) 양쪽이 단일 정본으로 공유한다. A001(About 자격증), A003(AppLegalDoc version/effective_date) 가정도 이 단계에서 해소.
@@ -38,14 +38,14 @@ Clean Architecture의 가장 안쪽 레이어인 Domain에 5개 콘텐츠/입력
 - ContactSubmission을 사용하는 Form/Action (T017)
 
 ## Acceptance Criteria
-- [ ] `app/domain/project/project.schema.ts`가 정상 frontmatter (slug/title/summary/date/tags/stack/metrics/featured?/cover?)를 통과시킨다
-- [ ] `app/domain/post/post.schema.ts`가 정상 frontmatter (slug/title/lede/date/tags/read)를 통과시킨다
-- [ ] `app/domain/legal/app-legal-doc.schema.ts`가 정상 frontmatter (app_slug/doc_type/version/effective_date)를 통과시킨다
-- [ ] `app/domain/contact/contact-submission.schema.ts`가 RFC 5322 위반 이메일을 reject (AC-F008-2)
-- [ ] `app/domain/contact/contact-submission.schema.ts`가 메시지 10자 미만 / 5000자 초과를 reject (AC-F008-3)
-- [ ] `app/domain/theme/theme-preference.vo.ts`가 `"dark" | "light"` literal type을 export
-- [ ] 모든 5개 모듈의 `__tests__/`가 정상값 통과 + 이상값 reject 케이스를 포함하여 100% Green
-- [ ] `bun run test` + `bun run typecheck` 통과
+- [x] `app/domain/project/project.schema.ts`가 정상 frontmatter (slug/title/summary/date/tags/stack/metrics/featured?/cover?)를 통과시킨다
+- [x] `app/domain/post/post.schema.ts`가 정상 frontmatter (slug/title/lede/date/tags/read)를 통과시킨다
+- [x] `app/domain/legal/app-legal-doc.schema.ts`가 정상 frontmatter (app_slug/doc_type/version/effective_date)를 통과시킨다
+- [x] `app/domain/contact/contact-submission.schema.ts`가 RFC 5322 위반 이메일을 reject (AC-F008-2)
+- [x] `app/domain/contact/contact-submission.schema.ts`가 메시지 10자 미만 / 5000자 초과를 reject (AC-F008-3)
+- [x] `app/domain/theme/theme-preference.vo.ts`가 `"dark" | "light"` literal type을 export
+- [x] 모든 5개 모듈의 `__tests__/`가 정상값 통과 + 이상값 reject 케이스를 포함하여 100% Green (28/28 pass)
+- [x] `bun run test` + `bun run typecheck` 통과
 
 ## Implementation Plan (TDD Cycle)
 
@@ -158,4 +158,4 @@ Clean Architecture의 가장 안쪽 레이어인 Domain에 5개 콘텐츠/입력
 ## Change History
 | Date | Changes | Author |
 |------|---------|--------|
-| - | - | - |
+| 2026-04-28 | T006 완료 — Project / Post / AppLegalDoc / ContactSubmission / ThemePreference 5종 Zod 스키마 + entity/errors. AC-F008-2 (RFC 5322 reject) / AC-F008-3 (10~5000자) 단위 테스트 직접 매핑. A001 / A003 가정 해소. `_shared/zod-helpers.ts`로 zNonEmptyString / zIso8601Date 공통 추출 (zRfc5322Email은 P1 review에서 인라인화). 28/28 tests Green. Branch `feature/issue-21-domain-schemas`. Issue #21. | TaekyungHa |

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
 		"isbot": "^5.1.36",
 		"react": "^19.2.4",
 		"react-dom": "^19.2.4",
-		"react-router": "7.14.0"
+		"react-router": "7.14.0",
+		"zod": "^4.3.6"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "2.4.13",


### PR DESCRIPTION
## Context

PR #22(T006 Domain schemas)의 base가 `main`으로 잘못 설정되어 머지된 결과, T006 작업물이 `main`에만 존재하고 `development`에는 누락된 상태였다.

```
8045a31 (공통 조상, PR #4)
├── main:        +959ab33 (T006, PR #22)
└── development: +#7,#10,#12,#14,#15,#18,#20 → e64b338 (T005)
```

## Recovery

`959ab33`(T006 squash 머지 커밋)을 development 기준 새 브랜치에 cherry-pick.

- `package.json` 충돌(zod 라인) 해결 — zod `^4.3.6` 채택
- `bun install`로 lockfile 동기화 확인 (no changes)

## Verification

- `bun run test` → 42 tests passed (T006 schema tests 28건 + 기존 14건)
- `bun run typecheck` → pass
- `bun run lint` → No fixes applied

## Cherry-picked content

- `app/domain/{project,post,legal,contact,theme}/` 5개 도메인 모듈 (entity/schema/errors/vo)
- `app/domain/_shared/zod-helpers.ts`
- 각 모듈 `__tests__/` (Zod 정상/이상 케이스)
- `package.json`/`bun.lock`: `zod ^4.3.6` 추가
- `CLAUDE.md`: zod 4.3.6 기록
- `docs/ROADMAP.md`: T006 ✅ 마킹
- `docs/tasks/T006-domain-schemas.md`: AC 체크박스 + Change History

## Follow-up

별도 issue로 트래킹: PR base 보호 강화(`gh pr create` PreToolUse hook + GitHub branch ruleset + CLAUDE.md 정책 명시).

---
Related: #23