### PR TITLE
🔧 chore: enforce PR base=development via pre-pr-base-guard hook

### DIFF
--- a/.claude/hooks/git-release.sh
+++ b/.claude/hooks/git-release.sh
@@ -84,7 +84,10 @@ echo ""
 
 # ─── Step 2: Create Release PR ───
 echo "[2/5] Creating release PR..."
-PR_CMD=(gh pr create --base "$PRODUCTION_BRANCH" --head "$INTEGRATION_BRANCH" --title "🚀 Release $VERSION")
+# HARNESS_PR_BASE_MAIN_OK=1 prefix is the sanctioned escape hatch read by
+# pre-pr-base-guard.sh — it allows the only legitimate `gh pr create
+# --base $PRODUCTION_BRANCH` invocation: integration → production release.
+PR_CMD=(env HARNESS_PR_BASE_MAIN_OK=1 gh pr create --base "$PRODUCTION_BRANCH" --head "$INTEGRATION_BRANCH" --title "🚀 Release $VERSION")
 if [[ -n "$BODY" ]]; then
     PR_CMD+=(--body "$BODY")
 else

--- a/.claude/hooks/pre-pr-base-guard.sh
+++ b/.claude/hooks/pre-pr-base-guard.sh
@@ -1,0 +1,137 @@
+#!/bin/bash
+# pre-pr-base-guard.sh — PreToolUse hook on Bash commands.
+#
+# Blocks `gh pr create` when the PR base is not the integration branch
+# (`development`). Reason: `gh pr create` defaults to the GitHub repo's
+# default branch (typically `main`) when `--base` is omitted, and a single
+# misclick can land work on the production branch instead of the integration
+# branch — which is exactly how PR #22 leaked T006 onto `main` only,
+# bypassing `development` entirely.
+#
+# This hook is a complement to `git-pr-create.sh`, which already pins
+# `--base $(config integrationBranch)`. The wrapper covers the harness path;
+# this hook closes the raw-command escape route (agent or human typing
+# `gh pr create` directly).
+#
+# Decision logic (first match wins):
+#
+#   1. Command is not `gh pr create` → exit 0 (out of scope).
+#   2. Env-var bypass `HARNESS_PR_BASE_MAIN_OK=1` is present at the start of
+#      the command line → exit 0 (release flow). `git-release.sh` opts in by
+#      prefixing its `gh pr create` call.
+#   3. `--base <integrationBranch>` (default `development`) is explicitly
+#      present in the argv → exit 0.
+#   4. Anything else (no `--base`, or `--base main`, etc.) → deny with
+#      instructions to either pass `--base development` or use the wrapper.
+#
+# Argv parsing is intentionally narrow: the hook reads argv tokens left to
+# right, accepts both `--base <branch>` and `--base=<branch>` forms, and
+# bails out with class "other" if the command is anything other than
+# `gh pr create`. Quoted bodies (e.g. `--body "..."`) are skipped because we
+# only look at flag names, not values, except for `--base` itself.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/config.sh
+source "$SCRIPT_DIR/lib/config.sh"
+
+INPUT=$(cat)
+CMD=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
+[[ -z "$CMD" ]] && exit 0
+
+INTEGRATION_BRANCH=$(config_get '.integrationBranch' 'development')
+
+# Tab-separated awk output:
+#   CLASS         — "gh_pr_create" | "other"
+#   BYPASS        — 1 if HARNESS_PR_BASE_MAIN_OK=1 prefix is present
+#   BASE_VALUE    — value of --base if found (empty otherwise)
+#   BASE_PRESENT  — 1 if --base appeared (even with empty/odd value)
+CLASSIFY=$(printf '%s' "$CMD" | awk -v ib="$INTEGRATION_BRANCH" '
+  BEGIN {
+    class = "other"
+    bypass = 0
+    base_value = ""
+    base_present = 0
+    OFS = "\t"
+  }
+  {
+    n = split($0, words, /[[:space:]]+/)
+
+    # Strip leading env-var assignments and detect the bypass.
+    argc = 0
+    for (i = 1; i <= n; i++) {
+      w = words[i]
+      if (w == "") continue
+      if (argc == 0 && w ~ /^[A-Za-z_][A-Za-z0-9_]*=/) {
+        if (w == "HARNESS_PR_BASE_MAIN_OK=1") bypass = 1
+        continue
+      }
+      argc++
+      argv[argc] = w
+    }
+
+    # Need at least `gh pr create` (3 tokens).
+    if (argc < 3) {
+      print class, bypass, base_value, base_present
+      exit 0
+    }
+    if (argv[1] != "gh" || argv[2] != "pr" || argv[3] != "create") {
+      print class, bypass, base_value, base_present
+      exit 0
+    }
+    class = "gh_pr_create"
+
+    # Scan for --base / --base=<value>. First match wins.
+    for (i = 4; i <= argc; i++) {
+      t = argv[i]
+      if (t == "--base") {
+        base_present = 1
+        if (i + 1 <= argc) base_value = argv[i + 1]
+        break
+      }
+      if (t ~ /^--base=/) {
+        base_present = 1
+        sub(/^--base=/, "", t)
+        base_value = t
+        break
+      }
+    }
+
+    print class, bypass, base_value, base_present
+  }
+')
+
+IFS=$'\t' read -r CLASS BYPASS BASE_VALUE BASE_PRESENT <<<"$CLASSIFY"
+
+# Out of scope.
+[[ "$CLASS" != "gh_pr_create" ]] && exit 0
+
+# Env-var bypass — release flow (`git-release.sh`) opts in this way.
+[[ "$BYPASS" == "1" ]] && exit 0
+
+# Strip surrounding quotes that might leak through awk word splitting.
+BASE_VALUE="${BASE_VALUE#\"}"; BASE_VALUE="${BASE_VALUE%\"}"
+BASE_VALUE="${BASE_VALUE#\'}"; BASE_VALUE="${BASE_VALUE%\'}"
+
+if [[ "$BASE_PRESENT" == "1" && "$BASE_VALUE" == "$INTEGRATION_BRANCH" ]]; then
+  exit 0
+fi
+
+# Build context-dependent reason message.
+if [[ "$BASE_PRESENT" == "0" ]]; then
+  REASON_DETAIL="Command is missing \`--base\`. \`gh pr create\` falls back to the GitHub default branch (often \`main\`), which is exactly how PR #22 leaked T006 onto \`main\` only."
+else
+  REASON_DETAIL="Command targets \`--base ${BASE_VALUE}\`. Only \`--base ${INTEGRATION_BRANCH}\` is allowed by default."
+fi
+
+REASON="PR base must be the integration branch \`${INTEGRATION_BRANCH}\` (CLAUDE.md §Git Integration). ${REASON_DETAIL} Required flow: (1) preferred — call the wrapper \`.claude/hooks/git-pr-create.sh --title ... --body ... [--issue N]\`, which pins \`--base ${INTEGRATION_BRANCH}\` for you; (2) if you must invoke \`gh pr create\` directly, pass \`--base ${INTEGRATION_BRANCH}\` explicitly. Release flow (development → main) is the only legitimate exception and is handled by \`.claude/hooks/git-release.sh\`, which opts in via the \`HARNESS_PR_BASE_MAIN_OK=1\` env prefix — do NOT set this variable manually for routine work; it exists so release tooling has a sanctioned escape hatch."
+
+jq -n --arg reason "$REASON" '{
+  hookSpecificOutput: {
+    hookEventName: "PreToolUse",
+    permissionDecision: "deny",
+    permissionDecisionReason: $reason
+  }
+}'
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -69,6 +69,11 @@
 						"type": "command",
 						"command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/pre-merge-ask.sh",
 						"timeout": 5
+					},
+					{
+						"type": "command",
+						"command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/pre-pr-base-guard.sh",
+						"timeout": 5
 					}
 				]
 			}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,6 +92,10 @@
 - **Trivial doc-only changes**: GitHub Issue may be skipped (open a PR only). All other changes must create an Issue first.
 - **Plan phase on `chore/*` and `docs/*` branches**: the harness-pipeline's Phase 1 (Plan) and Phase 2 (TDD) are **not required** for these branch types. They carry non-behavioral changes (harness tooling, documentation, chores) that do not warrant a full Red/Green cycle. `plan-enforcement.sh` detects the branch prefix and suppresses its reminder; `abac-phase-policy.sh` already permits `.claude/**` / `docs/**` / `**/*.md` edits without `plan_approved`. PR review remains the safety net on these paths. `feature/*` and `fix/*` still follow the full 5-phase pipeline.
 - **Merge method**: `gh pr merge <N> --squash --delete-branch`. After merge, sync locally with `git checkout development && git pull --ff-only`.
+- **PR base = `development` (mandatory)**: every PR opened from a `feature/*` / `fix/*` / `docs/*` / `chore/*` branch MUST target `--base development`. The repo's GitHub default branch is `main` (production), and `gh pr create` without `--base` silently falls back to it — that is exactly how PR #22 (T006) leaked onto `main` and never reached `development`. Two-layer enforcement:
+  1. **Wrapper (preferred)**: `.claude/hooks/git-pr-create.sh` pins `--base $(config integrationBranch)` automatically. Always use it.
+  2. **Hook gate (defense-in-depth)**: `.claude/hooks/pre-pr-base-guard.sh` (PreToolUse:Bash) denies any direct `gh pr create` whose `--base` is missing or not equal to `development`.
+  - **Release flow exception**: `development → main` (production sync) is the only legitimate non-`development` base. It is performed by `.claude/hooks/git-release.sh`, which prefixes its `gh pr create` call with `HARNESS_PR_BASE_MAIN_OK=1` to opt in. Do NOT set this env var manually for routine work; it exists so release tooling has a sanctioned escape hatch.
 - **Self-check before a direct push**: "Is this really an exception?" — the answer is always "No". There are no exceptions.
 
 ## Workflow


### PR DESCRIPTION
## Context

PR #22(T006)가 `--base main`으로 잘못 머지되어 development에 T006 작업물이 누락됐던 사고의 재발 방지. `gh pr create`는 `--base` 미명시 시 GitHub 기본 브랜치(`main`)로 폴백하기 때문에, 단 한 번의 클릭/타이핑 실수로 production에 직행할 수 있다.

## Two-layer defense

**L1 — wrapper (이미 존재)**: `.claude/hooks/git-pr-create.sh`가 `--base $(config integrationBranch)`로 강제 → harness 정상 흐름은 안전.

**L2 — hook gate (신설)**: `.claude/hooks/pre-pr-base-guard.sh` (PreToolUse:Bash)가 `gh pr create` 직접 호출 시 base를 검사:
- `--base development` 명시 → 통과
- `--base=development` 형태도 허용
- `--base` 미명시 또는 다른 값 → deny + 사용 안내
- escape hatch: `HARNESS_PR_BASE_MAIN_OK=1` env prefix (release flow에서만 사용)

## Changes

- `.claude/hooks/pre-pr-base-guard.sh` 신설 — argv 파싱(env-prefix / `--base` / `--base=` 모두 처리)
- `.claude/settings.json` — PreToolUse Bash hooks에 등록 (pre-merge-ask 다음 위치)
- `.claude/hooks/git-release.sh` — `gh pr create` 호출에 `env HARNESS_PR_BASE_MAIN_OK=1` prefix 추가 (release 통로 sanction)
- `CLAUDE.md` §Git Integration — PR base 정책 + 2층 방어 + release 예외 명시

## Smoke tests (수동 검증)

| Case | 결과 |
|------|------|
| `gh pr create --title foo` (base 미명시) | ✅ deny |
| `gh pr create --base development --title foo` | ✅ pass |
| `gh pr create --base main --head development` (release escape 없음) | ✅ deny |
| `HARNESS_PR_BASE_MAIN_OK=1 gh pr create --base main --head development` | ✅ pass |
| `gh pr create --base=development --title foo` | ✅ pass |
| `git status` (out-of-scope) | ✅ pass |

## Quality gates

- `bun run lint` ✅
- `bun run test` ✅ 42/42

## Follow-up (사용자 직접)

GitHub Branch Ruleset(L3): main 브랜치에 "Restrict PRs from `development` or `release/*` only"를 적용하면 UI/외부 도구를 통한 우회까지 차단됨.