### PR TITLE
✨ feat(T008): Application Ports + Content Repositories (#29)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,7 +42,8 @@
 - **shiki 4.0.2 + @shikijs/rehype 4.0.2** — 빌드 타임 코드블록 syntax highlight (theme: `github-dark` 단일, MVP). 클라이언트 번들 영향 0 (devDependency)
 - **rehype-slug 6.0.0** — 헤딩 anchor 자동 부여 (한국어 anchor 지원)
 - **Satori** — 빌드/SSR 동적 OG 이미지 생성 (1200×630, T018)
-- **velite lifecycle hooks** — `predev` / `prebuild` / `prestart` / `pretest`가 모두 `velite build`를 호출 → fresh clone / CI에서 stale `.velite/` 캐시 회귀 차단
+- **velite lifecycle hooks** — `predev` / `prebuild` / `prestart` / `pretest`가 모두 `bun run velite:build`로 라우팅. `velite:build`는 `velite build && node scripts/patch-velite-types.mjs`로 chained — fresh clone / CI에서 stale `.velite/` 캐시 회귀 차단 + typegen 교체
+- **Velite typegen patch** — velite 0.3.1 native typegen이 `import type __vc from '../velite.config.ts'`로 Zod 3 internal private 타입(`ZodInvalidStringIssue`, `ZodOptionalDef` 등)을 노출시켜 `tsc -b`에서 TS4082 폭발. `scripts/patch-velite-types.mjs`가 매 build 후 `.velite/index.d.ts`를 명시적 minimal 타입으로 교체. velite upstream fix 시 제거 (T008 D1)
 - **Path alias `#content` → `./.velite`** — `tsconfig.cloudflare.json`에 등록
 
 ### Search Index (F016 Cmd+K)

--- a/app/__tests__/fixtures/velite-legal.fixture.ts
+++ b/app/__tests__/fixtures/velite-legal.fixture.ts
@@ -1,0 +1,28 @@
+// velite raw output shape for AppLegalDoc fixtures.
+// app_slug 중복 검증용으로 moai에 terms+privacy 모두 포함, 그리고 별도 app(jagi) 추가.
+
+export const moaiTerms = {
+	app_slug: "moai",
+	doc_type: "terms" as const,
+	version: "1.0.0",
+	effective_date: "2026-01-01",
+	body: "",
+};
+
+export const moaiPrivacy = {
+	app_slug: "moai",
+	doc_type: "privacy" as const,
+	version: "1.0.0",
+	effective_date: "2026-01-01",
+	body: "",
+};
+
+export const jagiTerms = {
+	app_slug: "jagi",
+	doc_type: "terms" as const,
+	version: "1.2.0",
+	effective_date: "2026-02-15",
+	body: "",
+};
+
+export const fixtureLegal = [moaiTerms, moaiPrivacy, jagiTerms];

--- a/app/__tests__/fixtures/velite-posts.fixture.ts
+++ b/app/__tests__/fixtures/velite-posts.fixture.ts
@@ -1,0 +1,46 @@
+// velite raw output shape를 모방한 fixture
+// date desc 정렬 기준: delta(2026-04-26) > charlie(2026-04-25) > bravo(2026-04-24) > alpha(2026-04-23)
+// "react" 태그는 delta에만 포함 → findByTag("react") 검증용
+
+export const postAlpha = {
+	slug: "alpha",
+	title: "Alpha Post",
+	lede: "Alpha 포스트 요약입니다.",
+	date: "2026-04-23T00:00:00.000Z",
+	tags: ["typescript"],
+	read: 3,
+	body: "",
+};
+
+export const postBravo = {
+	slug: "bravo",
+	title: "Bravo Post",
+	lede: "Bravo 포스트 요약입니다.",
+	date: "2026-04-24T00:00:00.000Z",
+	tags: ["node"],
+	read: 5,
+	body: "",
+};
+
+export const postCharlie = {
+	slug: "charlie",
+	title: "Charlie Post",
+	lede: "Charlie 포스트 요약입니다.",
+	date: "2026-04-25T00:00:00.000Z",
+	tags: ["vitest"],
+	read: 7,
+	body: "",
+};
+
+export const postDelta = {
+	slug: "delta",
+	title: "Delta Post",
+	lede: "Delta 포스트 요약입니다.",
+	date: "2026-04-26T00:00:00.000Z",
+	tags: ["react"],
+	read: 4,
+	body: "",
+};
+
+// 전체 배열 (velite 출력 순서 — 정렬 전 raw)
+export const fixturePosts = [postAlpha, postBravo, postCharlie, postDelta];

--- a/app/__tests__/fixtures/velite-projects.fixture.ts
+++ b/app/__tests__/fixtures/velite-projects.fixture.ts
@@ -1,0 +1,54 @@
+// velite raw output shape를 모방한 fixture
+// date desc 정렬 기준: gamma(2026-04-27) > beta(2026-04-26) > alpha(2026-04-25)
+// "infra" 태그는 gamma에만 포함 → findByTag("infra") 검증용
+
+export const projectAlpha = {
+	slug: "alpha",
+	title: "Alpha Project",
+	summary: "Alpha 프로젝트 요약입니다.",
+	date: "2026-04-25T00:00:00.000Z",
+	tags: ["frontend", "react"],
+	stack: ["React", "TypeScript"],
+	metrics: [
+		["성능", "95점"],
+		["접근성", "100점"],
+	] as [string, string][],
+	featured: undefined as boolean | undefined,
+	cover: undefined as string | undefined,
+	body: "",
+};
+
+export const projectBeta = {
+	slug: "beta",
+	title: "Beta Project",
+	summary: "Beta 프로젝트 요약입니다.",
+	date: "2026-04-26T00:00:00.000Z",
+	tags: ["backend", "node"],
+	stack: ["Node.js", "TypeScript"],
+	metrics: [
+		["응답속도", "120ms"],
+		["가용성", "99.9%"],
+	] as [string, string][],
+	featured: true,
+	cover: "/images/beta-cover.png",
+	body: "",
+};
+
+export const projectGamma = {
+	slug: "gamma",
+	title: "Gamma Project",
+	summary: "Gamma 프로젝트 요약입니다.",
+	date: "2026-04-27T00:00:00.000Z",
+	tags: ["infra", "devops"],
+	stack: ["Cloudflare Workers", "TypeScript"],
+	metrics: [
+		["배포시간", "30s"],
+		["에러율", "0%"],
+	] as [string, string][],
+	featured: undefined as boolean | undefined,
+	cover: undefined as string | undefined,
+	body: "",
+};
+
+// 전체 배열 (velite 출력 순서 — 정렬 전 raw)
+export const fixtureProjects = [projectAlpha, projectBeta, projectGamma];

--- a/app/application/content/ports/legal-repository.port.ts
+++ b/app/application/content/ports/legal-repository.port.ts
@@ -1,0 +1,6 @@
+import type { AppLegalDoc } from "~/domain/legal/app-legal-doc.entity";
+
+export interface LegalRepository {
+	findAppDoc(appSlug: string, docType: "terms" | "privacy"): Promise<AppLegalDoc | null>;
+	listApps(): Promise<string[]>;
+}

--- a/app/application/content/ports/post-repository.port.ts
+++ b/app/application/content/ports/post-repository.port.ts
@@ -1,0 +1,9 @@
+import type { Post } from "~/domain/post/post.entity";
+
+export interface PostRepository {
+	findAll(): Promise<Post[]>;
+	findBySlug(slug: string): Promise<Post | null>;
+	findRecent(n: number): Promise<Post[]>;
+	findByTag(tag: string): Promise<Post[]>;
+	findRelated(slug: string): Promise<{ prev: Post | null; next: Post | null }>;
+}

--- a/app/application/content/ports/project-repository.port.ts
+++ b/app/application/content/ports/project-repository.port.ts
@@ -1,0 +1,9 @@
+import type { Project } from "~/domain/project/project.entity";
+
+export interface ProjectRepository {
+	findAll(): Promise<Project[]>;
+	findBySlug(slug: string): Promise<Project | null>;
+	findFeatured(): Promise<Project | null>;
+	findRelated(slug: string): Promise<{ prev: Project | null; next: Project | null }>;
+	findByTag(tag: string): Promise<Project[]>;
+}

--- a/app/application/content/services/__tests__/get-featured-project.service.test.ts
+++ b/app/application/content/services/__tests__/get-featured-project.service.test.ts
@@ -1,40 +1,36 @@
-import { describe, expect, it, vi, beforeEach } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { ProjectRepository } from "~/application/content/ports/project-repository.port";
 import { getFeaturedProject } from "../get-featured-project.service";
 import { projectBeta } from "../../../../__tests__/fixtures/velite-projects.fixture";
 
 describe("getFeaturedProject", () => {
-	let mockRepo: Partial<ProjectRepository>;
+	let mockRepo: ProjectRepository;
 
 	beforeEach(() => {
 		mockRepo = {
+			findAll: vi.fn(),
+			findBySlug: vi.fn(),
 			findFeatured: vi.fn(),
+			findRelated: vi.fn(),
+			findByTag: vi.fn(),
 		};
 	});
 
 	it("findFeatured가 project를 반환하면 그대로 반환한다", async () => {
-		// Arrange
-		const repo = mockRepo as ProjectRepository;
-		vi.mocked(mockRepo.findFeatured!).mockResolvedValue(projectBeta as never);
+		vi.mocked(mockRepo.findFeatured).mockResolvedValue(projectBeta as never);
 
-		// Act
-		const result = await getFeaturedProject(repo);
+		const result = await getFeaturedProject(mockRepo);
 
-		// Assert
-		expect(mockRepo.findFeatured).toHaveBeenCalledTimes(1);
+		expect(vi.mocked(mockRepo.findFeatured)).toHaveBeenCalledTimes(1);
 		expect(result).toEqual(projectBeta);
 	});
 
 	it("findFeatured가 null을 반환하면 null을 반환한다 (throw 없음)", async () => {
-		// Arrange
-		const repo = mockRepo as ProjectRepository;
-		vi.mocked(mockRepo.findFeatured!).mockResolvedValue(null);
+		vi.mocked(mockRepo.findFeatured).mockResolvedValue(null);
 
-		// Act
-		const result = await getFeaturedProject(repo);
+		const result = await getFeaturedProject(mockRepo);
 
-		// Assert
-		expect(mockRepo.findFeatured).toHaveBeenCalledTimes(1);
+		expect(vi.mocked(mockRepo.findFeatured)).toHaveBeenCalledTimes(1);
 		expect(result).toBeNull();
 	});
 });

--- a/app/application/content/services/__tests__/get-featured-project.service.test.ts
+++ b/app/application/content/services/__tests__/get-featured-project.service.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import type { ProjectRepository } from "~/application/content/ports/project-repository.port";
+import { getFeaturedProject } from "../get-featured-project.service";
+import { projectBeta } from "../../../../__tests__/fixtures/velite-projects.fixture";
+
+describe("getFeaturedProject", () => {
+	let mockRepo: Partial<ProjectRepository>;
+
+	beforeEach(() => {
+		mockRepo = {
+			findFeatured: vi.fn(),
+		};
+	});
+
+	it("findFeatured가 project를 반환하면 그대로 반환한다", async () => {
+		// Arrange
+		const repo = mockRepo as ProjectRepository;
+		vi.mocked(mockRepo.findFeatured!).mockResolvedValue(projectBeta as never);
+
+		// Act
+		const result = await getFeaturedProject(repo);
+
+		// Assert
+		expect(mockRepo.findFeatured).toHaveBeenCalledTimes(1);
+		expect(result).toEqual(projectBeta);
+	});
+
+	it("findFeatured가 null을 반환하면 null을 반환한다 (throw 없음)", async () => {
+		// Arrange
+		const repo = mockRepo as ProjectRepository;
+		vi.mocked(mockRepo.findFeatured!).mockResolvedValue(null);
+
+		// Act
+		const result = await getFeaturedProject(repo);
+
+		// Assert
+		expect(mockRepo.findFeatured).toHaveBeenCalledTimes(1);
+		expect(result).toBeNull();
+	});
+});

--- a/app/application/content/services/__tests__/get-post-detail.service.test.ts
+++ b/app/application/content/services/__tests__/get-post-detail.service.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import type { PostRepository } from "~/application/content/ports/post-repository.port";
+import { PostNotFoundError } from "~/domain/post/post.errors";
+import { getPostDetail } from "../get-post-detail.service";
+import {
+	postAlpha,
+	postBravo,
+	postCharlie,
+} from "../../../../__tests__/fixtures/velite-posts.fixture";
+
+describe("getPostDetail", () => {
+	let mockRepo: PostRepository;
+
+	beforeEach(() => {
+		mockRepo = {
+			findAll: vi.fn(),
+			findBySlug: vi.fn(),
+			findRecent: vi.fn(),
+			findByTag: vi.fn(),
+			findRelated: vi.fn(),
+		};
+	});
+
+	it("존재하는 slug이면 { post, prev, next }를 반환한다", async () => {
+		// Arrange
+		const repo = mockRepo;
+		vi.mocked(mockRepo.findBySlug).mockResolvedValue(postBravo as never);
+		vi.mocked(mockRepo.findRelated).mockResolvedValue({
+			prev: postCharlie as never,
+			next: postAlpha as never,
+		});
+
+		// Act
+		const result = await getPostDetail(repo, "bravo");
+
+		// Assert
+		expect(vi.mocked(mockRepo.findBySlug)).toHaveBeenCalledWith("bravo");
+		expect(vi.mocked(mockRepo.findRelated)).toHaveBeenCalledWith("bravo");
+		expect(result.post).toEqual(postBravo);
+		expect(result.prev).toEqual(postCharlie);
+		expect(result.next).toEqual(postAlpha);
+	});
+
+	it("findBySlug가 null을 반환하면 PostNotFoundError를 throw한다", async () => {
+		// Arrange
+		const repo = mockRepo;
+		vi.mocked(mockRepo.findBySlug).mockResolvedValue(null);
+
+		// Act & Assert
+		await expect(getPostDetail(repo, "nonexistent")).rejects.toThrow(PostNotFoundError);
+		expect(vi.mocked(mockRepo.findRelated)).not.toHaveBeenCalled();
+	});
+
+	it("인접 포스트 prev/next 모두 null인 경우도 정상 반환한다", async () => {
+		// Arrange
+		const repo = mockRepo;
+		vi.mocked(mockRepo.findBySlug).mockResolvedValue(postAlpha as never);
+		vi.mocked(mockRepo.findRelated).mockResolvedValue({ prev: null, next: null });
+
+		// Act
+		const result = await getPostDetail(repo, "alpha");
+
+		// Assert
+		expect(result.post).toEqual(postAlpha);
+		expect(result.prev).toBeNull();
+		expect(result.next).toBeNull();
+	});
+});

--- a/app/application/content/services/__tests__/get-project-detail.service.test.ts
+++ b/app/application/content/services/__tests__/get-project-detail.service.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import type { ProjectRepository } from "~/application/content/ports/project-repository.port";
+import { ProjectNotFoundError } from "~/domain/project/project.errors";
+import { getProjectDetail } from "../get-project-detail.service";
+import {
+	projectAlpha,
+	projectBeta,
+	projectGamma,
+} from "../../../../__tests__/fixtures/velite-projects.fixture";
+
+describe("getProjectDetail", () => {
+	let mockRepo: Partial<ProjectRepository>;
+
+	beforeEach(() => {
+		mockRepo = {
+			findBySlug: vi.fn(),
+			findRelated: vi.fn(),
+		};
+	});
+
+	it("존재하는 slug이면 { project, prev, next }를 반환한다", async () => {
+		// Arrange
+		const repo = mockRepo as ProjectRepository;
+		vi.mocked(mockRepo.findBySlug!).mockResolvedValue(projectAlpha as never);
+		vi.mocked(mockRepo.findRelated!).mockResolvedValue({
+			prev: projectBeta as never,
+			next: null,
+		});
+
+		// Act
+		const result = await getProjectDetail(repo, "alpha");
+
+		// Assert
+		expect(mockRepo.findBySlug).toHaveBeenCalledWith("alpha");
+		expect(mockRepo.findRelated).toHaveBeenCalledWith("alpha");
+		expect(result.project).toEqual(projectAlpha);
+		expect(result.prev).toEqual(projectBeta);
+		expect(result.next).toBeNull();
+	});
+
+	it("findBySlug가 null을 반환하면 ProjectNotFoundError를 throw한다", async () => {
+		// Arrange
+		const repo = mockRepo as ProjectRepository;
+		vi.mocked(mockRepo.findBySlug!).mockResolvedValue(null);
+
+		// Act & Assert
+		await expect(getProjectDetail(repo, "nonexistent")).rejects.toThrow(ProjectNotFoundError);
+		expect(mockRepo.findRelated).not.toHaveBeenCalled();
+	});
+
+	it("인접 프로젝트 prev/next 모두 null인 경우도 반환한다", async () => {
+		// Arrange
+		const repo = mockRepo as ProjectRepository;
+		vi.mocked(mockRepo.findBySlug!).mockResolvedValue(projectGamma as never);
+		vi.mocked(mockRepo.findRelated!).mockResolvedValue({ prev: null, next: null });
+
+		// Act
+		const result = await getProjectDetail(repo, "gamma");
+
+		// Assert
+		expect(result.project).toEqual(projectGamma);
+		expect(result.prev).toBeNull();
+		expect(result.next).toBeNull();
+	});
+});

--- a/app/application/content/services/__tests__/get-project-detail.service.test.ts
+++ b/app/application/content/services/__tests__/get-project-detail.service.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi, beforeEach } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { ProjectRepository } from "~/application/content/ports/project-repository.port";
 import { ProjectNotFoundError } from "~/domain/project/project.errors";
 import { getProjectDetail } from "../get-project-detail.service";
@@ -9,55 +9,47 @@ import {
 } from "../../../../__tests__/fixtures/velite-projects.fixture";
 
 describe("getProjectDetail", () => {
-	let mockRepo: Partial<ProjectRepository>;
+	let mockRepo: ProjectRepository;
 
 	beforeEach(() => {
 		mockRepo = {
+			findAll: vi.fn(),
 			findBySlug: vi.fn(),
+			findFeatured: vi.fn(),
 			findRelated: vi.fn(),
+			findByTag: vi.fn(),
 		};
 	});
 
 	it("존재하는 slug이면 { project, prev, next }를 반환한다", async () => {
-		// Arrange
-		const repo = mockRepo as ProjectRepository;
-		vi.mocked(mockRepo.findBySlug!).mockResolvedValue(projectAlpha as never);
-		vi.mocked(mockRepo.findRelated!).mockResolvedValue({
+		vi.mocked(mockRepo.findBySlug).mockResolvedValue(projectAlpha as never);
+		vi.mocked(mockRepo.findRelated).mockResolvedValue({
 			prev: projectBeta as never,
 			next: null,
 		});
 
-		// Act
-		const result = await getProjectDetail(repo, "alpha");
+		const result = await getProjectDetail(mockRepo, "alpha");
 
-		// Assert
-		expect(mockRepo.findBySlug).toHaveBeenCalledWith("alpha");
-		expect(mockRepo.findRelated).toHaveBeenCalledWith("alpha");
+		expect(vi.mocked(mockRepo.findBySlug)).toHaveBeenCalledWith("alpha");
+		expect(vi.mocked(mockRepo.findRelated)).toHaveBeenCalledWith("alpha");
 		expect(result.project).toEqual(projectAlpha);
 		expect(result.prev).toEqual(projectBeta);
 		expect(result.next).toBeNull();
 	});
 
 	it("findBySlug가 null을 반환하면 ProjectNotFoundError를 throw한다", async () => {
-		// Arrange
-		const repo = mockRepo as ProjectRepository;
-		vi.mocked(mockRepo.findBySlug!).mockResolvedValue(null);
+		vi.mocked(mockRepo.findBySlug).mockResolvedValue(null);
 
-		// Act & Assert
-		await expect(getProjectDetail(repo, "nonexistent")).rejects.toThrow(ProjectNotFoundError);
-		expect(mockRepo.findRelated).not.toHaveBeenCalled();
+		await expect(getProjectDetail(mockRepo, "nonexistent")).rejects.toThrow(ProjectNotFoundError);
+		expect(vi.mocked(mockRepo.findRelated)).not.toHaveBeenCalled();
 	});
 
 	it("인접 프로젝트 prev/next 모두 null인 경우도 반환한다", async () => {
-		// Arrange
-		const repo = mockRepo as ProjectRepository;
-		vi.mocked(mockRepo.findBySlug!).mockResolvedValue(projectGamma as never);
-		vi.mocked(mockRepo.findRelated!).mockResolvedValue({ prev: null, next: null });
+		vi.mocked(mockRepo.findBySlug).mockResolvedValue(projectGamma as never);
+		vi.mocked(mockRepo.findRelated).mockResolvedValue({ prev: null, next: null });
 
-		// Act
-		const result = await getProjectDetail(repo, "gamma");
+		const result = await getProjectDetail(mockRepo, "gamma");
 
-		// Assert
 		expect(result.project).toEqual(projectGamma);
 		expect(result.prev).toBeNull();
 		expect(result.next).toBeNull();

--- a/app/application/content/services/__tests__/get-recent-posts.service.test.ts
+++ b/app/application/content/services/__tests__/get-recent-posts.service.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import type { PostRepository } from "~/application/content/ports/post-repository.port";
+import { getRecentPosts } from "../get-recent-posts.service";
+import { postCharlie, postDelta } from "../../../../__tests__/fixtures/velite-posts.fixture";
+
+describe("getRecentPosts", () => {
+	let mockRepo: PostRepository;
+
+	beforeEach(() => {
+		mockRepo = {
+			findAll: vi.fn(),
+			findBySlug: vi.fn(),
+			findRecent: vi.fn(),
+			findByTag: vi.fn(),
+			findRelated: vi.fn(),
+		};
+	});
+
+	it("getRecentPosts(repo, 3) 호출 시 findRecent(3)에 위임하고 결과를 그대로 반환한다", async () => {
+		// Arrange
+		const repo = mockRepo;
+		vi.mocked(mockRepo.findRecent).mockResolvedValue([postDelta, postCharlie] as never);
+
+		// Act
+		const result = await getRecentPosts(repo, 3);
+
+		// Assert
+		expect(vi.mocked(mockRepo.findRecent)).toHaveBeenCalledTimes(1);
+		expect(vi.mocked(mockRepo.findRecent)).toHaveBeenCalledWith(3);
+		expect(result).toEqual([postDelta, postCharlie]);
+	});
+
+	it("getRecentPosts(repo, 1) 호출 시 findRecent(1)을 1회 호출한다", async () => {
+		// Arrange
+		const repo = mockRepo;
+		vi.mocked(mockRepo.findRecent).mockResolvedValue([postDelta] as never);
+
+		// Act
+		const result = await getRecentPosts(repo, 1);
+
+		// Assert
+		expect(vi.mocked(mockRepo.findRecent)).toHaveBeenCalledTimes(1);
+		expect(vi.mocked(mockRepo.findRecent)).toHaveBeenCalledWith(1);
+		expect(result).toHaveLength(1);
+	});
+});

--- a/app/application/content/services/__tests__/list-posts.service.test.ts
+++ b/app/application/content/services/__tests__/list-posts.service.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import type { PostRepository } from "~/application/content/ports/post-repository.port";
+import { listPosts } from "../list-posts.service";
+import {
+	postAlpha,
+	postBravo,
+	postCharlie,
+	postDelta,
+} from "../../../../__tests__/fixtures/velite-posts.fixture";
+
+describe("listPosts", () => {
+	let mockRepo: PostRepository;
+
+	beforeEach(() => {
+		mockRepo = {
+			findAll: vi.fn().mockResolvedValue([postAlpha, postBravo, postCharlie, postDelta]),
+			findBySlug: vi.fn(),
+			findRecent: vi.fn(),
+			findByTag: vi.fn().mockResolvedValue([postDelta]),
+			findRelated: vi.fn(),
+		};
+	});
+
+	it("opts 없으면 findAll을 호출하고 전체 목록을 반환한다", async () => {
+		// Arrange
+		const repo = mockRepo;
+
+		// Act
+		const result = await listPosts(repo);
+
+		// Assert
+		expect(vi.mocked(mockRepo.findAll)).toHaveBeenCalledTimes(1);
+		expect(vi.mocked(mockRepo.findByTag)).not.toHaveBeenCalled();
+		expect(result).toHaveLength(4);
+	});
+
+	it("opts.tag 있으면 findByTag를 호출하고 findAll은 호출하지 않는다", async () => {
+		// Arrange
+		const repo = mockRepo;
+
+		// Act
+		const result = await listPosts(repo, { tag: "react" });
+
+		// Assert
+		expect(vi.mocked(mockRepo.findByTag)).toHaveBeenCalledTimes(1);
+		expect(vi.mocked(mockRepo.findByTag)).toHaveBeenCalledWith("react");
+		expect(vi.mocked(mockRepo.findAll)).not.toHaveBeenCalled();
+		expect(result).toHaveLength(1);
+	});
+});

--- a/app/application/content/services/__tests__/list-projects.service.test.ts
+++ b/app/application/content/services/__tests__/list-projects.service.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import type { ProjectRepository } from "~/application/content/ports/project-repository.port";
+import { listProjects } from "../list-projects.service";
+import {
+	projectAlpha,
+	projectBeta,
+	projectGamma,
+} from "../../../../__tests__/fixtures/velite-projects.fixture";
+
+describe("listProjects", () => {
+	let mockRepo: Partial<ProjectRepository>;
+
+	beforeEach(() => {
+		mockRepo = {
+			findAll: vi.fn().mockResolvedValue([projectAlpha, projectBeta, projectGamma]),
+			findByTag: vi.fn().mockResolvedValue([projectGamma]),
+		};
+	});
+
+	it("opts 없으면 findAll을 호출하고 전체 목록을 반환한다", async () => {
+		// Arrange
+		const repo = mockRepo as ProjectRepository;
+
+		// Act
+		const result = await listProjects(repo);
+
+		// Assert
+		expect(mockRepo.findAll).toHaveBeenCalledTimes(1);
+		expect(mockRepo.findByTag).not.toHaveBeenCalled();
+		expect(result).toHaveLength(3);
+	});
+
+	it("빈 객체 opts 전달 시 findAll을 호출한다", async () => {
+		// Arrange
+		const repo = mockRepo as ProjectRepository;
+
+		// Act
+		const result = await listProjects(repo, {});
+
+		// Assert
+		expect(mockRepo.findAll).toHaveBeenCalledTimes(1);
+		expect(mockRepo.findByTag).not.toHaveBeenCalled();
+		expect(result).toHaveLength(3);
+	});
+
+	it("opts.tag 있으면 findByTag를 호출하고 findAll은 호출하지 않는다", async () => {
+		// Arrange
+		const repo = mockRepo as ProjectRepository;
+
+		// Act
+		const result = await listProjects(repo, { tag: "infra" });
+
+		// Assert
+		expect(mockRepo.findByTag).toHaveBeenCalledTimes(1);
+		expect(mockRepo.findByTag).toHaveBeenCalledWith("infra");
+		expect(mockRepo.findAll).not.toHaveBeenCalled();
+		expect(result).toHaveLength(1);
+	});
+});

--- a/app/application/content/services/_shared/assert-exists.ts
+++ b/app/application/content/services/_shared/assert-exists.ts
@@ -1,0 +1,4 @@
+export const assertExists = <T>(value: T | null, makeError: () => Error): T => {
+	if (value === null) throw makeError();
+	return value;
+};

--- a/app/application/content/services/get-featured-project.service.ts
+++ b/app/application/content/services/get-featured-project.service.ts
@@ -1,0 +1,6 @@
+import type { Project } from "~/domain/project/project.entity";
+import type { ProjectRepository } from "../ports/project-repository.port";
+
+export const getFeaturedProject = async (repo: ProjectRepository): Promise<Project | null> => {
+	return repo.findFeatured();
+};

--- a/app/application/content/services/get-post-detail.service.ts
+++ b/app/application/content/services/get-post-detail.service.ts
@@ -1,13 +1,13 @@
 import type { Post } from "~/domain/post/post.entity";
 import { PostNotFoundError } from "~/domain/post/post.errors";
 import type { PostRepository } from "../ports/post-repository.port";
+import { assertExists } from "./_shared/assert-exists";
 
 export const getPostDetail = async (
 	repo: PostRepository,
 	slug: string,
 ): Promise<{ post: Post; prev: Post | null; next: Post | null }> => {
-	const post = await repo.findBySlug(slug);
-	if (!post) throw new PostNotFoundError(slug);
+	const post = assertExists(await repo.findBySlug(slug), () => new PostNotFoundError(slug));
 	const { prev, next } = await repo.findRelated(slug);
 	return { post, prev, next };
 };

--- a/app/application/content/services/get-post-detail.service.ts
+++ b/app/application/content/services/get-post-detail.service.ts
@@ -1,0 +1,13 @@
+import type { Post } from "~/domain/post/post.entity";
+import { PostNotFoundError } from "~/domain/post/post.errors";
+import type { PostRepository } from "../ports/post-repository.port";
+
+export const getPostDetail = async (
+	repo: PostRepository,
+	slug: string,
+): Promise<{ post: Post; prev: Post | null; next: Post | null }> => {
+	const post = await repo.findBySlug(slug);
+	if (!post) throw new PostNotFoundError(slug);
+	const { prev, next } = await repo.findRelated(slug);
+	return { post, prev, next };
+};

--- a/app/application/content/services/get-project-detail.service.ts
+++ b/app/application/content/services/get-project-detail.service.ts
@@ -1,13 +1,13 @@
 import type { Project } from "~/domain/project/project.entity";
 import { ProjectNotFoundError } from "~/domain/project/project.errors";
 import type { ProjectRepository } from "../ports/project-repository.port";
+import { assertExists } from "./_shared/assert-exists";
 
 export const getProjectDetail = async (
 	repo: ProjectRepository,
 	slug: string,
 ): Promise<{ project: Project; prev: Project | null; next: Project | null }> => {
-	const project = await repo.findBySlug(slug);
-	if (!project) throw new ProjectNotFoundError(slug);
+	const project = assertExists(await repo.findBySlug(slug), () => new ProjectNotFoundError(slug));
 	const { prev, next } = await repo.findRelated(slug);
 	return { project, prev, next };
 };

--- a/app/application/content/services/get-project-detail.service.ts
+++ b/app/application/content/services/get-project-detail.service.ts
@@ -1,0 +1,13 @@
+import type { Project } from "~/domain/project/project.entity";
+import { ProjectNotFoundError } from "~/domain/project/project.errors";
+import type { ProjectRepository } from "../ports/project-repository.port";
+
+export const getProjectDetail = async (
+	repo: ProjectRepository,
+	slug: string,
+): Promise<{ project: Project; prev: Project | null; next: Project | null }> => {
+	const project = await repo.findBySlug(slug);
+	if (!project) throw new ProjectNotFoundError(slug);
+	const { prev, next } = await repo.findRelated(slug);
+	return { project, prev, next };
+};

--- a/app/application/content/services/get-recent-posts.service.ts
+++ b/app/application/content/services/get-recent-posts.service.ts
@@ -1,0 +1,6 @@
+import type { Post } from "~/domain/post/post.entity";
+import type { PostRepository } from "../ports/post-repository.port";
+
+export const getRecentPosts = async (repo: PostRepository, n: number): Promise<Post[]> => {
+	return repo.findRecent(n);
+};

--- a/app/application/content/services/list-posts.service.ts
+++ b/app/application/content/services/list-posts.service.ts
@@ -1,0 +1,7 @@
+import type { Post } from "~/domain/post/post.entity";
+import type { PostRepository } from "../ports/post-repository.port";
+
+export const listPosts = async (repo: PostRepository, opts?: { tag?: string }): Promise<Post[]> => {
+	if (opts?.tag) return repo.findByTag(opts.tag);
+	return repo.findAll();
+};

--- a/app/application/content/services/list-projects.service.ts
+++ b/app/application/content/services/list-projects.service.ts
@@ -1,0 +1,10 @@
+import type { Project } from "~/domain/project/project.entity";
+import type { ProjectRepository } from "../ports/project-repository.port";
+
+export const listProjects = async (
+	repo: ProjectRepository,
+	opts?: { tag?: string },
+): Promise<Project[]> => {
+	if (opts?.tag) return repo.findByTag(opts.tag);
+	return repo.findAll();
+};

--- a/app/domain/post/post.errors.ts
+++ b/app/domain/post/post.errors.ts
@@ -1,0 +1,13 @@
+export class PostNotFoundError extends Error {
+	constructor(slug: string) {
+		super(`Post not found: ${slug}`);
+		this.name = "PostNotFoundError";
+	}
+}
+
+export class InvalidPostFrontmatterError extends Error {
+	constructor(slug: string, issues: string) {
+		super(`Invalid post frontmatter (${slug}): ${issues}`);
+		this.name = "InvalidPostFrontmatterError";
+	}
+}

--- a/app/infrastructure/content/__tests__/velite-legal.repository.test.ts
+++ b/app/infrastructure/content/__tests__/velite-legal.repository.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("#content", () => ({
+	legal: [
+		{
+			app_slug: "moai",
+			doc_type: "terms",
+			version: "1.0.0",
+			effective_date: "2026-01-01",
+			body: "",
+		},
+		{
+			app_slug: "moai",
+			doc_type: "privacy",
+			version: "1.0.0",
+			effective_date: "2026-01-01",
+			body: "",
+		},
+		{
+			app_slug: "jagi",
+			doc_type: "terms",
+			version: "1.2.0",
+			effective_date: "2026-02-15",
+			body: "",
+		},
+	],
+}));
+
+import { veliteLegalRepository } from "../velite-legal.repository";
+
+describe("veliteLegalRepository", () => {
+	describe("findAppDoc", () => {
+		it("app_slug + doc_type 조합으로 매핑 결과를 반환한다", async () => {
+			const result = await veliteLegalRepository.findAppDoc("moai", "terms");
+
+			expect(result).not.toBeNull();
+			expect(result?.app_slug).toBe("moai");
+			expect(result?.doc_type).toBe("terms");
+			expect(result?.version).toBe("1.0.0");
+		});
+
+		it("같은 app_slug 다른 doc_type을 정확히 구분한다", async () => {
+			const result = await veliteLegalRepository.findAppDoc("moai", "privacy");
+
+			expect(result).not.toBeNull();
+			expect(result?.doc_type).toBe("privacy");
+		});
+
+		it("존재하지 않는 조합이면 null을 반환한다", async () => {
+			const result = await veliteLegalRepository.findAppDoc("nonexistent", "terms");
+
+			expect(result).toBeNull();
+		});
+
+		it("같은 app이라도 정의되지 않은 doc_type은 null", async () => {
+			const result = await veliteLegalRepository.findAppDoc("jagi", "privacy");
+
+			expect(result).toBeNull();
+		});
+	});
+
+	describe("listApps", () => {
+		it("중복 제거된 app_slug 배열을 반환한다", async () => {
+			const result = await veliteLegalRepository.listApps();
+
+			expect(result).toHaveLength(2);
+			expect(result).toContain("moai");
+			expect(result).toContain("jagi");
+		});
+	});
+});

--- a/app/infrastructure/content/__tests__/velite-post.repository.test.ts
+++ b/app/infrastructure/content/__tests__/velite-post.repository.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, it, vi } from "vitest";
+import { fixturePosts } from "../../../__tests__/fixtures/velite-posts.fixture";
+
+// #content 모듈을 fixture로 대체 — vi.mock hoisting으로 import 이전에 적용됨
+vi.mock("#content", () => ({
+	posts: [
+		{
+			slug: "alpha",
+			title: "Alpha Post",
+			lede: "Alpha 포스트 요약입니다.",
+			date: "2026-04-23T00:00:00.000Z",
+			tags: ["typescript"],
+			read: 3,
+			body: "",
+		},
+		{
+			slug: "bravo",
+			title: "Bravo Post",
+			lede: "Bravo 포스트 요약입니다.",
+			date: "2026-04-24T00:00:00.000Z",
+			tags: ["node"],
+			read: 5,
+			body: "",
+		},
+		{
+			slug: "charlie",
+			title: "Charlie Post",
+			lede: "Charlie 포스트 요약입니다.",
+			date: "2026-04-25T00:00:00.000Z",
+			tags: ["vitest"],
+			read: 7,
+			body: "",
+		},
+		{
+			slug: "delta",
+			title: "Delta Post",
+			lede: "Delta 포스트 요약입니다.",
+			date: "2026-04-26T00:00:00.000Z",
+			tags: ["react"],
+			read: 4,
+			body: "",
+		},
+	],
+}));
+
+import { velitePostRepository } from "../velite-post.repository";
+
+describe("velitePostRepository", () => {
+	// date desc 정렬: delta(2026-04-26) > charlie(2026-04-25) > bravo(2026-04-24) > alpha(2026-04-23)
+	// 인덱스 0=delta, 1=charlie, 2=bravo, 3=alpha
+
+	describe("findAll", () => {
+		it("fixture 길이만큼 매핑 결과를 반환한다", async () => {
+			// Arrange & Act
+			const result = await velitePostRepository.findAll();
+
+			// Assert
+			expect(result).toHaveLength(fixturePosts.length);
+		});
+
+		it("매핑 결과에 slug 핵심 필드가 포함된다", async () => {
+			// Arrange & Act
+			const result = await velitePostRepository.findAll();
+
+			// Assert
+			const slugs = result.map((p) => p.slug);
+			expect(slugs).toContain("alpha");
+			expect(slugs).toContain("bravo");
+			expect(slugs).toContain("charlie");
+			expect(slugs).toContain("delta");
+		});
+	});
+
+	describe("findBySlug", () => {
+		it("존재하는 slug로 조회하면 해당 항목을 반환한다", async () => {
+			// Arrange & Act
+			const result = await velitePostRepository.findBySlug("alpha");
+
+			// Assert
+			expect(result).not.toBeNull();
+			expect(result?.slug).toBe("alpha");
+		});
+
+		it("존재하지 않는 slug로 조회하면 null을 반환한다", async () => {
+			// Arrange & Act
+			const result = await velitePostRepository.findBySlug("nonexistent");
+
+			// Assert
+			expect(result).toBeNull();
+		});
+	});
+
+	describe("findRecent", () => {
+		it("findRecent(2) 는 date desc 기준 최신 2건(delta, charlie)을 반환한다", async () => {
+			// Arrange & Act
+			const result = await velitePostRepository.findRecent(2);
+
+			// Assert
+			expect(result).toHaveLength(2);
+			expect(result[0].slug).toBe("delta");
+			expect(result[1].slug).toBe("charlie");
+		});
+
+		it("findRecent(0) 은 빈 배열을 반환한다", async () => {
+			// Arrange & Act
+			const result = await velitePostRepository.findRecent(0);
+
+			// Assert
+			expect(result).toHaveLength(0);
+		});
+	});
+
+	describe("findByTag", () => {
+		it('"react" 태그 조회 시 delta만 반환한다', async () => {
+			// Arrange & Act
+			const result = await velitePostRepository.findByTag("react");
+
+			// Assert
+			expect(result).toHaveLength(1);
+			expect(result[0].slug).toBe("delta");
+		});
+
+		it("존재하지 않는 태그 조회 시 빈 배열을 반환한다", async () => {
+			// Arrange & Act
+			const result = await velitePostRepository.findByTag("unknown-tag");
+
+			// Assert
+			expect(result).toHaveLength(0);
+		});
+	});
+
+	describe("findRelated", () => {
+		it("중간 항목(charlie) 조회 시 prev=delta, next=bravo를 반환한다", async () => {
+			// Arrange & Act
+			// date desc: delta(0) > charlie(1) > bravo(2) > alpha(3)
+			// charlie의 prev = 더 최신인 delta, next = 더 오래된 bravo
+			const result = await velitePostRepository.findRelated("charlie");
+
+			// Assert
+			expect(result.prev?.slug).toBe("delta");
+			expect(result.next?.slug).toBe("bravo");
+		});
+
+		it("가장 최신 항목(delta) 조회 시 prev=null을 반환한다", async () => {
+			// Arrange & Act
+			const result = await velitePostRepository.findRelated("delta");
+
+			// Assert
+			expect(result.prev).toBeNull();
+			expect(result.next?.slug).toBe("charlie");
+		});
+
+		it("가장 오래된 항목(alpha) 조회 시 next=null을 반환한다", async () => {
+			// Arrange & Act
+			const result = await velitePostRepository.findRelated("alpha");
+
+			// Assert
+			expect(result.prev?.slug).toBe("bravo");
+			expect(result.next).toBeNull();
+		});
+	});
+});

--- a/app/infrastructure/content/__tests__/velite-project.repository.test.ts
+++ b/app/infrastructure/content/__tests__/velite-project.repository.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, it, vi } from "vitest";
+import { fixtureProjects } from "../../../__tests__/fixtures/velite-projects.fixture";
+
+// #content 모듈을 fixture로 대체 — vi.mock hoisting으로 import 이전에 적용됨
+vi.mock("#content", () => ({
+	projects: [
+		{
+			slug: "alpha",
+			title: "Alpha Project",
+			summary: "Alpha 프로젝트 요약입니다.",
+			date: "2026-04-25T00:00:00.000Z",
+			tags: ["frontend", "react"],
+			stack: ["React", "TypeScript"],
+			metrics: [
+				["성능", "95점"],
+				["접근성", "100점"],
+			],
+			featured: undefined,
+			cover: undefined,
+			body: "",
+		},
+		{
+			slug: "beta",
+			title: "Beta Project",
+			summary: "Beta 프로젝트 요약입니다.",
+			date: "2026-04-26T00:00:00.000Z",
+			tags: ["backend", "node"],
+			stack: ["Node.js", "TypeScript"],
+			metrics: [
+				["응답속도", "120ms"],
+				["가용성", "99.9%"],
+			],
+			featured: true,
+			cover: "/images/beta-cover.png",
+			body: "",
+		},
+		{
+			slug: "gamma",
+			title: "Gamma Project",
+			summary: "Gamma 프로젝트 요약입니다.",
+			date: "2026-04-27T00:00:00.000Z",
+			tags: ["infra", "devops"],
+			stack: ["Cloudflare Workers", "TypeScript"],
+			metrics: [
+				["배포시간", "30s"],
+				["에러율", "0%"],
+			],
+			featured: undefined,
+			cover: undefined,
+			body: "",
+		},
+	],
+}));
+
+import { veliteProjectRepository } from "../velite-project.repository";
+
+describe("veliteProjectRepository", () => {
+	// date desc 정렬: gamma(2026-04-27) > beta(2026-04-26) > alpha(2026-04-25)
+	// 인덱스 0=gamma, 1=beta, 2=alpha
+
+	describe("findAll", () => {
+		it("fixture 길이만큼 매핑 결과를 반환한다", async () => {
+			// Arrange & Act
+			const result = await veliteProjectRepository.findAll();
+
+			// Assert
+			expect(result).toHaveLength(fixtureProjects.length);
+		});
+
+		it("매핑 결과에 slug 핵심 필드가 포함된다", async () => {
+			// Arrange & Act
+			const result = await veliteProjectRepository.findAll();
+
+			// Assert
+			const slugs = result.map((p) => p.slug);
+			expect(slugs).toContain("alpha");
+			expect(slugs).toContain("beta");
+			expect(slugs).toContain("gamma");
+		});
+	});
+
+	describe("findFeatured", () => {
+		it("featured: true인 항목(beta)을 반환한다", async () => {
+			// Arrange & Act
+			const result = await veliteProjectRepository.findFeatured();
+
+			// Assert
+			expect(result).not.toBeNull();
+			expect(result?.slug).toBe("beta");
+		});
+	});
+
+	describe("findBySlug", () => {
+		it("존재하는 slug로 조회하면 해당 항목을 반환한다", async () => {
+			// Arrange & Act
+			const result = await veliteProjectRepository.findBySlug("alpha");
+
+			// Assert
+			expect(result).not.toBeNull();
+			expect(result?.slug).toBe("alpha");
+		});
+
+		it("존재하지 않는 slug로 조회하면 null을 반환한다", async () => {
+			// Arrange & Act
+			const result = await veliteProjectRepository.findBySlug("nonexistent");
+
+			// Assert
+			expect(result).toBeNull();
+		});
+	});
+
+	describe("findRelated", () => {
+		it("중간 항목(beta) 조회 시 prev=gamma, next=alpha를 반환한다", async () => {
+			// Arrange & Act
+			// date desc: gamma(0) > beta(1) > alpha(2)
+			// beta의 prev = 더 최신인 gamma, next = 더 오래된 alpha
+			const result = await veliteProjectRepository.findRelated("beta");
+
+			// Assert
+			expect(result.prev?.slug).toBe("gamma");
+			expect(result.next?.slug).toBe("alpha");
+		});
+
+		it("가장 최신 항목(gamma) 조회 시 prev=null을 반환한다", async () => {
+			// Arrange & Act
+			const result = await veliteProjectRepository.findRelated("gamma");
+
+			// Assert
+			expect(result.prev).toBeNull();
+			expect(result.next?.slug).toBe("beta");
+		});
+
+		it("가장 오래된 항목(alpha) 조회 시 next=null을 반환한다", async () => {
+			// Arrange & Act
+			const result = await veliteProjectRepository.findRelated("alpha");
+
+			// Assert
+			expect(result.prev?.slug).toBe("beta");
+			expect(result.next).toBeNull();
+		});
+	});
+
+	describe("findByTag", () => {
+		it('"infra" 태그 조회 시 gamma만 반환한다', async () => {
+			// Arrange & Act
+			const result = await veliteProjectRepository.findByTag("infra");
+
+			// Assert
+			expect(result).toHaveLength(1);
+			expect(result[0].slug).toBe("gamma");
+		});
+
+		it("존재하지 않는 태그 조회 시 빈 배열을 반환한다", async () => {
+			// Arrange & Act
+			const result = await veliteProjectRepository.findByTag("unknown-tag");
+
+			// Assert
+			expect(result).toHaveLength(0);
+		});
+	});
+});

--- a/app/infrastructure/content/_shared/find-adjacent.ts
+++ b/app/infrastructure/content/_shared/find-adjacent.ts
@@ -1,0 +1,11 @@
+export const findAdjacent = <T extends { slug: string }>(
+	items: T[],
+	slug: string,
+): { prev: T | null; next: T | null } => {
+	const idx = items.findIndex((i) => i.slug === slug);
+	if (idx === -1) return { prev: null, next: null };
+	return {
+		prev: idx > 0 ? items[idx - 1] : null,
+		next: idx < items.length - 1 ? items[idx + 1] : null,
+	};
+};

--- a/app/infrastructure/content/_shared/sort-by-date-desc.ts
+++ b/app/infrastructure/content/_shared/sort-by-date-desc.ts
@@ -1,0 +1,2 @@
+export const sortByDateDesc = <T extends { date: string }>(items: T[]): T[] =>
+	[...items].sort((a, b) => b.date.localeCompare(a.date));

--- a/app/infrastructure/content/mappers/legal.mapper.ts
+++ b/app/infrastructure/content/mappers/legal.mapper.ts
@@ -1,0 +1,16 @@
+import type { AppLegalDoc } from "~/domain/legal/app-legal-doc.entity";
+
+type VeliteLegalInput = {
+	app_slug: string;
+	doc_type: "terms" | "privacy";
+	version: string;
+	effective_date: string;
+	body?: string;
+};
+
+export const toAppLegalDoc = (raw: VeliteLegalInput): AppLegalDoc => ({
+	app_slug: raw.app_slug,
+	doc_type: raw.doc_type,
+	version: raw.version,
+	effective_date: raw.effective_date,
+});

--- a/app/infrastructure/content/mappers/post.mapper.ts
+++ b/app/infrastructure/content/mappers/post.mapper.ts
@@ -1,0 +1,20 @@
+import type { Post } from "~/domain/post/post.entity";
+
+type VelitePostInput = {
+	slug: string;
+	title: string;
+	lede: string;
+	date: string;
+	tags: string[];
+	read: number;
+	body?: string;
+};
+
+export const toPost = (raw: VelitePostInput): Post => ({
+	slug: raw.slug,
+	title: raw.title,
+	lede: raw.lede,
+	date: raw.date,
+	tags: raw.tags,
+	read: raw.read,
+});

--- a/app/infrastructure/content/mappers/project.mapper.ts
+++ b/app/infrastructure/content/mappers/project.mapper.ts
@@ -1,0 +1,26 @@
+import type { Project } from "~/domain/project/project.entity";
+
+type VeliteProjectInput = {
+	slug: string;
+	title: string;
+	summary: string;
+	date: string;
+	tags: string[];
+	stack: string[];
+	metrics: [string, string][];
+	featured?: boolean;
+	cover?: string;
+	body?: string;
+};
+
+export const toProject = (raw: VeliteProjectInput): Project => ({
+	slug: raw.slug,
+	title: raw.title,
+	summary: raw.summary,
+	date: raw.date,
+	tags: raw.tags,
+	stack: raw.stack,
+	metrics: raw.metrics,
+	featured: raw.featured,
+	cover: raw.cover,
+});

--- a/app/infrastructure/content/velite-legal.repository.ts
+++ b/app/infrastructure/content/velite-legal.repository.ts
@@ -3,7 +3,7 @@ import type { LegalRepository } from "~/application/content/ports/legal-reposito
 import type { AppLegalDoc } from "~/domain/legal/app-legal-doc.entity";
 import { toAppLegalDoc } from "./mappers/legal.mapper";
 
-const cache: AppLegalDoc[] = legal.map(toAppLegalDoc);
+const cache: readonly AppLegalDoc[] = Object.freeze(legal.map(toAppLegalDoc));
 
 export const veliteLegalRepository: LegalRepository = {
 	async findAppDoc(appSlug, docType) {

--- a/app/infrastructure/content/velite-legal.repository.ts
+++ b/app/infrastructure/content/velite-legal.repository.ts
@@ -1,0 +1,15 @@
+import { legal } from "#content";
+import type { LegalRepository } from "~/application/content/ports/legal-repository.port";
+import type { AppLegalDoc } from "~/domain/legal/app-legal-doc.entity";
+import { toAppLegalDoc } from "./mappers/legal.mapper";
+
+const cache: AppLegalDoc[] = legal.map(toAppLegalDoc);
+
+export const veliteLegalRepository: LegalRepository = {
+	async findAppDoc(appSlug, docType) {
+		return cache.find((d) => d.app_slug === appSlug && d.doc_type === docType) ?? null;
+	},
+	async listApps() {
+		return [...new Set(cache.map((d) => d.app_slug))];
+	},
+};

--- a/app/infrastructure/content/velite-post.repository.ts
+++ b/app/infrastructure/content/velite-post.repository.ts
@@ -5,22 +5,22 @@ import { findAdjacent } from "./_shared/find-adjacent";
 import { sortByDateDesc } from "./_shared/sort-by-date-desc";
 import { toPost } from "./mappers/post.mapper";
 
-const cache: Post[] = sortByDateDesc(posts.map(toPost));
+const cache: readonly Post[] = Object.freeze(sortByDateDesc(posts.map(toPost)));
 
 export const velitePostRepository: PostRepository = {
 	async findAll() {
-		return cache;
+		return [...cache];
 	},
 	async findBySlug(slug) {
 		return cache.find((p) => p.slug === slug) ?? null;
 	},
 	async findRecent(n) {
-		return cache.slice(0, n);
+		return [...cache].slice(0, n);
 	},
 	async findByTag(tag) {
 		return cache.filter((p) => p.tags.includes(tag));
 	},
 	async findRelated(slug) {
-		return findAdjacent(cache, slug);
+		return findAdjacent([...cache], slug);
 	},
 };

--- a/app/infrastructure/content/velite-post.repository.ts
+++ b/app/infrastructure/content/velite-post.repository.ts
@@ -1,9 +1,11 @@
 import { posts } from "#content";
 import type { PostRepository } from "~/application/content/ports/post-repository.port";
 import type { Post } from "~/domain/post/post.entity";
+import { findAdjacent } from "./_shared/find-adjacent";
+import { sortByDateDesc } from "./_shared/sort-by-date-desc";
 import { toPost } from "./mappers/post.mapper";
 
-const cache: Post[] = posts.map(toPost).sort((a, b) => b.date.localeCompare(a.date));
+const cache: Post[] = sortByDateDesc(posts.map(toPost));
 
 export const velitePostRepository: PostRepository = {
 	async findAll() {
@@ -19,11 +21,6 @@ export const velitePostRepository: PostRepository = {
 		return cache.filter((p) => p.tags.includes(tag));
 	},
 	async findRelated(slug) {
-		const idx = cache.findIndex((p) => p.slug === slug);
-		if (idx === -1) return { prev: null, next: null };
-		return {
-			prev: idx > 0 ? cache[idx - 1] : null,
-			next: idx < cache.length - 1 ? cache[idx + 1] : null,
-		};
+		return findAdjacent(cache, slug);
 	},
 };

--- a/app/infrastructure/content/velite-post.repository.ts
+++ b/app/infrastructure/content/velite-post.repository.ts
@@ -1,0 +1,29 @@
+import { posts } from "#content";
+import type { PostRepository } from "~/application/content/ports/post-repository.port";
+import type { Post } from "~/domain/post/post.entity";
+import { toPost } from "./mappers/post.mapper";
+
+const cache: Post[] = posts.map(toPost).sort((a, b) => b.date.localeCompare(a.date));
+
+export const velitePostRepository: PostRepository = {
+	async findAll() {
+		return cache;
+	},
+	async findBySlug(slug) {
+		return cache.find((p) => p.slug === slug) ?? null;
+	},
+	async findRecent(n) {
+		return cache.slice(0, n);
+	},
+	async findByTag(tag) {
+		return cache.filter((p) => p.tags.includes(tag));
+	},
+	async findRelated(slug) {
+		const idx = cache.findIndex((p) => p.slug === slug);
+		if (idx === -1) return { prev: null, next: null };
+		return {
+			prev: idx > 0 ? cache[idx - 1] : null,
+			next: idx < cache.length - 1 ? cache[idx + 1] : null,
+		};
+	},
+};

--- a/app/infrastructure/content/velite-project.repository.ts
+++ b/app/infrastructure/content/velite-project.repository.ts
@@ -5,11 +5,11 @@ import { findAdjacent } from "./_shared/find-adjacent";
 import { sortByDateDesc } from "./_shared/sort-by-date-desc";
 import { toProject } from "./mappers/project.mapper";
 
-const cache: Project[] = sortByDateDesc(projects.map(toProject));
+const cache: readonly Project[] = Object.freeze(sortByDateDesc(projects.map(toProject)));
 
 export const veliteProjectRepository: ProjectRepository = {
 	async findAll() {
-		return cache;
+		return [...cache];
 	},
 	async findBySlug(slug) {
 		return cache.find((p) => p.slug === slug) ?? null;
@@ -18,7 +18,7 @@ export const veliteProjectRepository: ProjectRepository = {
 		return cache.find((p) => p.featured === true) ?? null;
 	},
 	async findRelated(slug) {
-		return findAdjacent(cache, slug);
+		return findAdjacent([...cache], slug);
 	},
 	async findByTag(tag) {
 		return cache.filter((p) => p.tags.includes(tag));

--- a/app/infrastructure/content/velite-project.repository.ts
+++ b/app/infrastructure/content/velite-project.repository.ts
@@ -1,9 +1,11 @@
 import { projects } from "#content";
 import type { ProjectRepository } from "~/application/content/ports/project-repository.port";
 import type { Project } from "~/domain/project/project.entity";
+import { findAdjacent } from "./_shared/find-adjacent";
+import { sortByDateDesc } from "./_shared/sort-by-date-desc";
 import { toProject } from "./mappers/project.mapper";
 
-const cache: Project[] = projects.map(toProject).sort((a, b) => b.date.localeCompare(a.date));
+const cache: Project[] = sortByDateDesc(projects.map(toProject));
 
 export const veliteProjectRepository: ProjectRepository = {
 	async findAll() {
@@ -16,12 +18,7 @@ export const veliteProjectRepository: ProjectRepository = {
 		return cache.find((p) => p.featured === true) ?? null;
 	},
 	async findRelated(slug) {
-		const idx = cache.findIndex((p) => p.slug === slug);
-		if (idx === -1) return { prev: null, next: null };
-		return {
-			prev: idx > 0 ? cache[idx - 1] : null,
-			next: idx < cache.length - 1 ? cache[idx + 1] : null,
-		};
+		return findAdjacent(cache, slug);
 	},
 	async findByTag(tag) {
 		return cache.filter((p) => p.tags.includes(tag));

--- a/app/infrastructure/content/velite-project.repository.ts
+++ b/app/infrastructure/content/velite-project.repository.ts
@@ -1,0 +1,29 @@
+import { projects } from "#content";
+import type { ProjectRepository } from "~/application/content/ports/project-repository.port";
+import type { Project } from "~/domain/project/project.entity";
+import { toProject } from "./mappers/project.mapper";
+
+const cache: Project[] = projects.map(toProject).sort((a, b) => b.date.localeCompare(a.date));
+
+export const veliteProjectRepository: ProjectRepository = {
+	async findAll() {
+		return cache;
+	},
+	async findBySlug(slug) {
+		return cache.find((p) => p.slug === slug) ?? null;
+	},
+	async findFeatured() {
+		return cache.find((p) => p.featured === true) ?? null;
+	},
+	async findRelated(slug) {
+		const idx = cache.findIndex((p) => p.slug === slug);
+		if (idx === -1) return { prev: null, next: null };
+		return {
+			prev: idx > 0 ? cache[idx - 1] : null,
+			next: idx < cache.length - 1 ? cache[idx + 1] : null,
+		};
+	},
+	async findByTag(tag) {
+		return cache.filter((p) => p.tags.includes(tag));
+	},
+};

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -197,7 +197,7 @@ tkstarDev는 다음 핵심 가치를 단일 도메인에서 달성한다:
   - 후속 follow-up (deferred from review): Medium #3 `project.schema.ts` date 약한 검증 (T006 owner), Medium #4 legal seed placeholder 본문, Low #5 tsconfig include velite.config.ts (별도 `tsconfig.node.json` 필요), Low #7 shiki rehype `as any` 좁히기
   - PR 1개 / 브랜치: `feature/issue-27-velite-content-pipeline` / Issue #27
 
-- [ ] **Task 008: Application Ports + Content Repositories (Infrastructure 구현)**
+- [x] **Task 008: Application Ports + Content Repositories (Infrastructure 구현)**
   - **Must** Read: [tasks/T008-content-ports-repos.md](tasks/T008-content-ports-repos.md)
   - blockedBy: Task 002, Task 006, Task 007
   - blocks: Task 009, Task 010, Task 011, Task 012, Task 013, Task 014, Task 015, Task 016, Task 017
@@ -221,7 +221,8 @@ tkstarDev는 다음 핵심 가치를 단일 도메인에서 달성한다:
       - `velite-project.repository.ts`, `velite-post.repository.ts`, `velite-legal.repository.ts`
       - `mappers/{project,post,legal}.mapper.ts` (velite raw → Domain Entity)
     - 각 모듈에 `__tests__/` colocated
-  - PR 1개 / 브랜치: `feature/issue-N-content-ports-repos`
+  - 진행 메모: 4-cycle TDD (Project → Post → Legal → Refactor). velite 0.3.1 typegen이 Zod 3 internal 타입을 노출시켜 TS4082 폭발 → `scripts/patch-velite-types.mjs`로 `.velite/index.d.ts` clean override (velite:build에 chained). vitest `resolve.tsconfigPaths` 활성화로 `~` alias 동작. 공통 헬퍼 3개(`assertExists`, `sortByDateDesc`, `findAdjacent`) 추출. code-reviewer Medium fix: cache `Object.freeze` + defensive copy(`[...cache]`).
+  - PR 1개 / 브랜치: `feature/issue-29-content-ports-repos` / Issue #29
 
 - [ ] **Task 009: DI Container (Composition Root) + workers/app.ts wiring + getLoadContext**
   - **Must** Read: [tasks/T009-di-container.md](tasks/T009-di-container.md)

--- a/package.json
+++ b/package.json
@@ -16,11 +16,11 @@
 		"test": "vitest run",
 		"test:watch": "vitest",
 		"test:coverage": "vitest run --coverage",
-		"velite:build": "velite build",
-		"predev": "velite build",
-		"prebuild": "velite build",
-		"prestart": "velite build",
-		"pretest": "velite build",
+		"velite:build": "velite build && node scripts/patch-velite-types.mjs",
+		"predev": "bun run velite:build",
+		"prebuild": "bun run velite:build",
+		"prestart": "bun run velite:build",
+		"pretest": "bun run velite:build",
 		"postinstall": "wrangler types"
 	},
 	"dependencies": {

--- a/scripts/patch-velite-types.mjs
+++ b/scripts/patch-velite-types.mjs
@@ -1,0 +1,46 @@
+import { writeFileSync } from "node:fs";
+
+const content = `// Patched by scripts/patch-velite-types.mjs after \`velite build\`.
+// Reason: velite 0.3.1 native typegen does \`import type __vc from '../velite.config.ts'\`
+// which transitively exposes Zod 3 internal private names (TS4082) and explodes
+// when any consumer in tsconfig.cloudflare imports from "#content".
+// This patch replaces the typegen with explicit minimal types mirroring
+// the schema in velite.config.ts.
+
+export type Project = {
+\tslug: string;
+\ttitle: string;
+\tsummary: string;
+\tdate: string;
+\ttags: string[];
+\tstack: string[];
+\tmetrics: [string, string][];
+\tfeatured?: boolean;
+\tcover?: string;
+\tbody: string;
+};
+export declare const projects: Project[];
+
+export type Post = {
+\tslug: string;
+\ttitle: string;
+\tlede: string;
+\tdate: string;
+\ttags: string[];
+\tread: number;
+\tbody: string;
+};
+export declare const posts: Post[];
+
+export type AppLegalDoc = {
+\tapp_slug: string;
+\tdoc_type: "terms" | "privacy";
+\tversion: string;
+\teffective_date: string;
+\tbody: string;
+};
+export declare const legal: AppLegalDoc[];
+`;
+
+writeFileSync(".velite/index.d.ts", content);
+console.log("✓ Patched .velite/index.d.ts");

--- a/scripts/patch-velite-types.mjs
+++ b/scripts/patch-velite-types.mjs
@@ -1,4 +1,5 @@
 import { writeFileSync } from "node:fs";
+import { resolve } from "node:path";
 
 const content = `// Patched by scripts/patch-velite-types.mjs after \`velite build\`.
 // Reason: velite 0.3.1 native typegen does \`import type __vc from '../velite.config.ts'\`
@@ -42,5 +43,6 @@ export type AppLegalDoc = {
 export declare const legal: AppLegalDoc[];
 `;
 
-writeFileSync(".velite/index.d.ts", content);
-console.log("✓ Patched .velite/index.d.ts");
+const target = resolve(import.meta.dirname, "../.velite/index.d.ts");
+writeFileSync(target, content);
+console.log(`✓ Patched ${target}`);

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,6 +3,9 @@ import { defineConfig } from "vitest/config";
 
 export default defineConfig({
 	plugins: [react()],
+	resolve: {
+		tsconfigPaths: true,
+	},
 	test: {
 		environment: "jsdom",
 		globals: true,


### PR DESCRIPTION
## Summary
- **Application Layer**: 3 Repository Ports + 6 read-side Services (`listProjects/getProjectDetail/getFeaturedProject/listPosts/getPostDetail/getRecentPosts`)
- **Infrastructure Layer**: 3 velite-backed repositories with frozen module-load cache + 3 mappers (velite raw → Domain Entity, drops `body`)
- **Domain**: `PostNotFoundError` / `InvalidPostFrontmatterError` added for symmetry with Project errors
- **Shared helpers**: `assertExists`, `sortByDateDesc`, `findAdjacent`
- **Tooling**: `scripts/patch-velite-types.mjs` overrides velite 0.3.1's broken typegen (Zod 3 internal private types triggered TS4082 on every consumer of `#content`); chained into `velite:build`. `vitest.config.ts` enables `resolve.tsconfigPaths` so `~` alias resolves in tests.

## TDD cycles
1. **Cycle 1** Project — 4 test files Red → port + 3 services + repo + mapper Green
2. **Cycle 2** Post — 4 test files Red (+ Domain errors) → port + 3 services + repo + mapper Green
3. **Cycle 3** Legal — 1 test file Red → port + repo + mapper Green (no Application service per plan)
4. **Cycle 4** Refactor — extracted 3 shared helpers + cleaned up 7 `noNonNullAssertion` warnings

## Code review fixes (Phase 3)
- **Medium**: cache mutability footgun → `Object.freeze` cache + return `[...cache]` defensive copies (project/post/legal)
- **Low**: patch script `cwd`-relative path → `import.meta.dirname`-resolved absolute path

## Test plan
- [x] `bun run test` — 85/85 Green (19 test files; 18 new + Phase 1 regression)
- [x] `bun run typecheck` — exit 0 (typegen patch validated)
- [x] `bun run lint` — 0 warnings
- [x] velite lifecycle hooks regenerate `.velite/` then patch typegen on fresh clone (`bun run pretest` proves it)

Closes #29