### PR TITLE
feat(T010): Home Page (F001 Hero + F017 Featured/Recent)

### DIFF
--- a/app/app.css
+++ b/app/app.css
@@ -22,6 +22,12 @@
 	--spacing-gutter: 18px;
 	--container-measure: 720px;
 	--height-topbar: 52px;
+
+	/* motion — 정본의 transition: all 120ms ease (prototype.css 전반) */
+	--duration-120: 120ms;
+
+	/* hatch — 정본 styles.css의 --hatch (dark/light 분기) */
+	--color-hatch: oklch(95% 0 0 / 0.04);
 }
 
 @custom-variant dark (&:where([data-theme="dark"], [data-theme="dark"] *));
@@ -38,6 +44,7 @@
 	--color-accent: oklch(48% 0.14 155);
 	--color-accent-warm: oklch(55% 0.14 65);
 	--color-warn: oklch(55% 0.14 30);
+	--color-hatch: oklch(20% 0 0 / 0.05);
 }
 
 @font-face {

--- a/app/presentation/components/home/FeaturedProjectCard.tsx
+++ b/app/presentation/components/home/FeaturedProjectCard.tsx
@@ -2,35 +2,29 @@ import { Link } from "react-router";
 
 import type { Project } from "../../../domain/project/project.entity";
 
-// 정본 매핑 정리:
-// - prototype.css:257-264 .card / .card.hover → bg-bg-elev border-line rounded-lg p-4 + hover:border-accent (transition-colors 120ms)
-// - prototype.css:287-302 .cover → 16:9 비율 + repeating-linear-gradient(45deg, hatch) + var(--proto-elev) 배경 + line border + faint 텍스트 "cover · 16:9"
-// - prototype.css:209-218 .pill2 → border line-strong + rounded-full + font-mono text-[11px] text-muted tracking-[0.02em] + px-2 py-0.5
-// - prototype.css:163-170 .h2 → font-mono font-semibold clamp(1.25rem,3.4vw,1.5rem) leading-[1.2] tracking-[-0.01em]
-// - prototype.css:177-181 .body + .dim → text-muted text-sm leading-[1.7]
-// 가이드라인은 a11y 측면에서 cover 이미지 alt=""(decorative)로 두고 h2 title이 의미 전달.
-
 type Props = { project: Project };
 
-// .cover hatch 패턴 — 정본의 var(--hatch)는 dark/light에서 각각 rgba(232,235,239,0.04) / rgba(26,28,32,0.05).
-// app.css 토큰에 --hatch가 아직 없어 Tailwind arbitrary 값으로 직접 expressed (oklab color-mix로 토큰 친화적 톤).
-// Tailwind v4 arbitrary CSS image 문법으로 module-scope 상수에 고정 — per-render allocation 회피 (§3.0).
 const COVER_HATCH_CLASS =
-	"bg-bg-elev bg-[image:repeating-linear-gradient(45deg,color-mix(in_oklab,var(--color-fg)_4%,transparent)_0_8px,transparent_8px_16px)]";
+	"bg-bg-elev bg-[image:repeating-linear-gradient(45deg,var(--color-hatch)_0_8px,transparent_8px_16px)]";
 
 export default function FeaturedProjectCard({ project }: Props) {
 	return (
 		<Link
 			to={`/projects/${project.slug}`}
-			className="block rounded-lg border border-line bg-bg-elev p-4 text-fg no-underline transition-colors duration-120 ease-out hover:border-accent focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent motion-reduce:transition-none"
+			className="block rounded-lg border border-line bg-bg-elev p-4 text-fg no-underline transition-colors duration-[var(--duration-120)] ease-out hover:border-accent focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent motion-reduce:transition-none"
 		>
-			{/* .cover — 16:9, hatch 패턴 placeholder. cover URL 존재 시 img로 대체하되 항상 testid='cover' wrapper 유지. */}
 			<div
 				data-testid="cover"
-				className="mb-3 aspect-video w-full overflow-hidden rounded-sm border border-line"
+				className="mb-3 aspect-video w-full overflow-hidden rounded-md border border-line"
 			>
 				{project.cover ? (
-					<img src={project.cover} alt="" className="h-full w-full object-cover" />
+					<img
+						src={project.cover}
+						alt=""
+						loading="eager"
+						decoding="async"
+						className="h-full w-full object-cover"
+					/>
 				) : (
 					<div
 						className={`flex h-full w-full items-center justify-center font-mono text-[11px] text-faint tracking-[0.06em] ${COVER_HATCH_CLASS}`}
@@ -40,7 +34,6 @@ export default function FeaturedProjectCard({ project }: Props) {
 				)}
 			</div>
 
-			{/* .cluster — pill2 stack tags (mb-1.5는 정본 marginBottom: 6) */}
 			<div className="mb-1.5 flex flex-wrap gap-2">
 				{project.stack.map((s) => (
 					<span
@@ -52,12 +45,10 @@ export default function FeaturedProjectCard({ project }: Props) {
 				))}
 			</div>
 
-			{/* .h2 — 정본의 line-height 1.2 + tracking -0.01em */}
 			<h2 className="m-0 font-mono font-semibold text-[clamp(1.25rem,3.4vw,1.5rem)] leading-[1.2] tracking-[-0.01em]">
 				{project.title}
 			</h2>
 
-			{/* .body.dim — margin: '6px 0 0' */}
 			<p className="m-0 mt-1.5 text-muted text-sm leading-[1.7]">{project.summary}</p>
 		</Link>
 	);

--- a/app/presentation/components/home/FeaturedProjectCard.tsx
+++ b/app/presentation/components/home/FeaturedProjectCard.tsx
@@ -1,0 +1,64 @@
+import { Link } from "react-router";
+
+import type { Project } from "../../../domain/project/project.entity";
+
+// 정본 매핑 정리:
+// - prototype.css:257-264 .card / .card.hover → bg-bg-elev border-line rounded-lg p-4 + hover:border-accent (transition-colors 120ms)
+// - prototype.css:287-302 .cover → 16:9 비율 + repeating-linear-gradient(45deg, hatch) + var(--proto-elev) 배경 + line border + faint 텍스트 "cover · 16:9"
+// - prototype.css:209-218 .pill2 → border line-strong + rounded-full + font-mono text-[11px] text-muted tracking-[0.02em] + px-2 py-0.5
+// - prototype.css:163-170 .h2 → font-mono font-semibold clamp(1.25rem,3.4vw,1.5rem) leading-[1.2] tracking-[-0.01em]
+// - prototype.css:177-181 .body + .dim → text-muted text-sm leading-[1.7]
+// 가이드라인은 a11y 측면에서 cover 이미지 alt=""(decorative)로 두고 h2 title이 의미 전달.
+
+type Props = { project: Project };
+
+// .cover hatch 패턴 — 정본의 var(--hatch)는 dark/light에서 각각 rgba(232,235,239,0.04) / rgba(26,28,32,0.05).
+// app.css 토큰에 --hatch가 아직 없어 Tailwind arbitrary 값으로 직접 expressed (oklab color-mix로 토큰 친화적 톤).
+// Tailwind v4 arbitrary CSS image 문법으로 module-scope 상수에 고정 — per-render allocation 회피 (§3.0).
+const COVER_HATCH_CLASS =
+	"bg-bg-elev bg-[image:repeating-linear-gradient(45deg,color-mix(in_oklab,var(--color-fg)_4%,transparent)_0_8px,transparent_8px_16px)]";
+
+export default function FeaturedProjectCard({ project }: Props) {
+	return (
+		<Link
+			to={`/projects/${project.slug}`}
+			className="block rounded-lg border border-line bg-bg-elev p-4 text-fg no-underline transition-colors duration-120 ease-out hover:border-accent focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent motion-reduce:transition-none"
+		>
+			{/* .cover — 16:9, hatch 패턴 placeholder. cover URL 존재 시 img로 대체하되 항상 testid='cover' wrapper 유지. */}
+			<div
+				data-testid="cover"
+				className="mb-3 aspect-video w-full overflow-hidden rounded-sm border border-line"
+			>
+				{project.cover ? (
+					<img src={project.cover} alt="" className="h-full w-full object-cover" />
+				) : (
+					<div
+						className={`flex h-full w-full items-center justify-center font-mono text-[11px] text-faint tracking-[0.06em] ${COVER_HATCH_CLASS}`}
+					>
+						cover · 16:9
+					</div>
+				)}
+			</div>
+
+			{/* .cluster — pill2 stack tags (mb-1.5는 정본 marginBottom: 6) */}
+			<div className="mb-1.5 flex flex-wrap gap-2">
+				{project.stack.map((s) => (
+					<span
+						key={s}
+						className="inline-block rounded-full border border-line-strong px-2 py-0.5 font-mono text-[11px] text-muted tracking-[0.02em]"
+					>
+						{s}
+					</span>
+				))}
+			</div>
+
+			{/* .h2 — 정본의 line-height 1.2 + tracking -0.01em */}
+			<h2 className="m-0 font-mono font-semibold text-[clamp(1.25rem,3.4vw,1.5rem)] leading-[1.2] tracking-[-0.01em]">
+				{project.title}
+			</h2>
+
+			{/* .body.dim — margin: '6px 0 0' */}
+			<p className="m-0 mt-1.5 text-muted text-sm leading-[1.7]">{project.summary}</p>
+		</Link>
+	);
+}

--- a/app/presentation/components/home/HeroWhoami.tsx
+++ b/app/presentation/components/home/HeroWhoami.tsx
@@ -1,26 +1,21 @@
 import { Link } from "react-router";
 import { useCommandPalette } from "../../hooks/useCommandPalette";
 
-// 정본 prototype.css의 .btn / .btn.primary / .btn.ghost 클래스를 Tailwind v4 토큰으로 1:1 포팅.
-// module top-level 상수로 두어 per-render allocation 회피 (§3.0).
 const BTN_BASE =
-	"inline-flex items-center gap-2 rounded-sm border px-4 py-2.5 font-mono text-[13px] font-medium transition-colors duration-120 ease-out motion-reduce:transition-none focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent";
+	"inline-flex items-center gap-2 rounded-md border px-4 py-2.5 font-mono text-[13px] font-medium duration-[var(--duration-120)] ease-out motion-reduce:transition-none focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent";
 
-const BTN_DEFAULT = `${BTN_BASE} border-line-strong bg-transparent text-fg hover:border-accent hover:text-accent`;
+const BTN_DEFAULT = `${BTN_BASE} transition-colors border-line-strong bg-transparent text-fg hover:border-accent hover:text-accent`;
 
-// .btn.primary — 다크/라이트 양쪽에서 정본 색 분배 (text-bg는 토큰이 자동 반전: dark #0d0f12, light #f4f1ea).
-const BTN_PRIMARY = `${BTN_BASE} border-accent bg-accent text-bg hover:brightness-110`;
+const BTN_PRIMARY = `${BTN_BASE} transition-[color,background-color,border-color,filter] border-accent bg-accent text-bg hover:brightness-[1.08]`;
 
-// .btn.ghost — text-muted + border-line (정본 .btn.ghost와 1:1).
-const BTN_GHOST = `${BTN_BASE} border-line bg-transparent text-muted hover:border-accent hover:text-accent`;
+const BTN_GHOST = `${BTN_BASE} transition-colors border-line bg-transparent text-muted hover:border-accent hover:text-accent`;
 
 export default function HeroWhoami() {
 	const { open } = useCommandPalette();
 
 	return (
-		<section aria-labelledby="hero-heading" className="flex flex-col">
-			{/* PromptLine — 정본 .prompt 1:1 (tkstar@dev:~$ whoami) */}
-			<div className="mb-3 flex items-baseline gap-0 font-mono text-faint text-xs">
+		<section aria-labelledby="hero-heading" className="flex flex-col gap-3 sm:gap-[22px]">
+			<div className="flex items-baseline gap-0 font-mono text-faint text-xs">
 				<span className="text-accent">tkstar@dev</span>
 				<span className="text-faint">:</span>
 				<span className="text-accent-warm">~</span>
@@ -28,7 +23,6 @@ export default function HeroWhoami() {
 				<span className="text-fg">whoami</span>
 			</div>
 
-			{/* .h1 — clamp(28px,6vw,44px), letter-spacing -0.02em, line-height 1.1 */}
 			<h1
 				id="hero-heading"
 				className="m-0 font-mono font-bold leading-[1.1] tracking-[-0.02em] text-[clamp(1.75rem,6vw,2.75rem)]"
@@ -37,14 +31,12 @@ export default function HeroWhoami() {
 				<span className="text-muted">ship </span>fast<span className="text-muted">.</span>
 			</h1>
 
-			{/* .body.dim — fg→muted, 14px, line-height 1.7, maxWidth 540px */}
-			<p className="mt-3 max-w-[540px] text-muted text-sm leading-[1.7]">
+			<p className="m-0 max-w-[540px] text-muted text-sm leading-[1.7]">
 				1인 개발자 김태곤. 풀스택 · 제품 설계부터 운영까지 혼자서. 웹/앱을 처음부터 끝까지 짓고
 				굴립니다.
 			</p>
 
-			{/* .cluster + gap 8 */}
-			<div className="mt-5 flex flex-wrap items-center gap-2">
+			<div className="mt-2 flex flex-wrap items-center gap-2">
 				<button type="button" onClick={open} className={BTN_PRIMARY}>
 					›&nbsp;&nbsp;검색해서 이동
 				</button>

--- a/app/presentation/components/home/HeroWhoami.tsx
+++ b/app/presentation/components/home/HeroWhoami.tsx
@@ -1,0 +1,60 @@
+import { Link } from "react-router";
+import { useCommandPalette } from "../../hooks/useCommandPalette";
+
+// 정본 prototype.css의 .btn / .btn.primary / .btn.ghost 클래스를 Tailwind v4 토큰으로 1:1 포팅.
+// module top-level 상수로 두어 per-render allocation 회피 (§3.0).
+const BTN_BASE =
+	"inline-flex items-center gap-2 rounded-sm border px-4 py-2.5 font-mono text-[13px] font-medium transition-colors duration-120 ease-out motion-reduce:transition-none focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent";
+
+const BTN_DEFAULT = `${BTN_BASE} border-line-strong bg-transparent text-fg hover:border-accent hover:text-accent`;
+
+// .btn.primary — 다크/라이트 양쪽에서 정본 색 분배 (text-bg는 토큰이 자동 반전: dark #0d0f12, light #f4f1ea).
+const BTN_PRIMARY = `${BTN_BASE} border-accent bg-accent text-bg hover:brightness-110`;
+
+// .btn.ghost — text-muted + border-line (정본 .btn.ghost와 1:1).
+const BTN_GHOST = `${BTN_BASE} border-line bg-transparent text-muted hover:border-accent hover:text-accent`;
+
+export default function HeroWhoami() {
+	const { open } = useCommandPalette();
+
+	return (
+		<section aria-labelledby="hero-heading" className="flex flex-col">
+			{/* PromptLine — 정본 .prompt 1:1 (tkstar@dev:~$ whoami) */}
+			<div className="mb-3 flex items-baseline gap-0 font-mono text-faint text-xs">
+				<span className="text-accent">tkstar@dev</span>
+				<span className="text-faint">:</span>
+				<span className="text-accent-warm">~</span>
+				<span className="mr-1.5 text-faint">$</span>
+				<span className="text-fg">whoami</span>
+			</div>
+
+			{/* .h1 — clamp(28px,6vw,44px), letter-spacing -0.02em, line-height 1.1 */}
+			<h1
+				id="hero-heading"
+				className="m-0 font-mono font-bold leading-[1.1] tracking-[-0.02em] text-[clamp(1.75rem,6vw,2.75rem)]"
+			>
+				ship <span className="text-accent">solo</span>.<br />
+				<span className="text-muted">ship </span>fast<span className="text-muted">.</span>
+			</h1>
+
+			{/* .body.dim — fg→muted, 14px, line-height 1.7, maxWidth 540px */}
+			<p className="mt-3 max-w-[540px] text-muted text-sm leading-[1.7]">
+				1인 개발자 김태곤. 풀스택 · 제품 설계부터 운영까지 혼자서. 웹/앱을 처음부터 끝까지 짓고
+				굴립니다.
+			</p>
+
+			{/* .cluster + gap 8 */}
+			<div className="mt-5 flex flex-wrap items-center gap-2">
+				<button type="button" onClick={open} className={BTN_PRIMARY}>
+					›&nbsp;&nbsp;검색해서 이동
+				</button>
+				<Link to="/about" className={BTN_DEFAULT}>
+					/about
+				</Link>
+				<Link to="/projects" className={BTN_GHOST}>
+					/projects
+				</Link>
+			</div>
+		</section>
+	);
+}

--- a/app/presentation/components/home/RecentPostsList.tsx
+++ b/app/presentation/components/home/RecentPostsList.tsx
@@ -1,0 +1,59 @@
+import { Link } from "react-router";
+
+import type { Post } from "../../../domain/post/post.entity";
+
+// 정본 매핑 정리:
+// - prototype.css:319-340 .row-link → grid grid-cols-[88px_1fr_auto] gap-2.5 py-3.5 border-b border-line
+//   font-mono text-[13px] items-baseline no-underline text-fg + transition-colors 120ms + hover:text-accent
+//   모바일(<560px) → grid-cols-[1fr_auto] + .date col-span-full font-size 10px
+// - .row-link 내부: .date faint 11px / .title fg font-medium / .meta faint 11px
+// - prototype.css:479 .stack default 12px gap, 본 컴포넌트는 row-link border-b로 구분되므로 gap-0
+// - .btn.ghost (prototype.css) → inline-flex items-center gap-2 px-4 py-2.5 border border-line rounded-md
+//   bg-transparent text-muted font-mono text-[13px] font-medium + transition-colors 120ms
+//   hover → border-accent text-accent
+//
+// className은 module top-level 상수로 추출 — per-render allocation 회피 (§3.0).
+// HeroWhoami / FeaturedProjectCard 패턴과 동일.
+
+const ROW_LINK_CLASS =
+	"grid grid-cols-[1fr_auto] sm:grid-cols-[88px_1fr_auto] gap-2.5 py-3.5 border-b border-line font-mono text-[13px] items-baseline no-underline text-fg transition-colors duration-120 ease-out hover:text-accent focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent motion-reduce:transition-none";
+
+const ROW_DATE_CLASS = "text-faint text-[10px] sm:text-[11px] col-span-full sm:col-span-1";
+
+const ROW_TITLE_CLASS = "text-fg font-medium";
+
+const ROW_META_CLASS = "text-faint text-[11px]";
+
+const GHOST_BTN_CLASS =
+	"inline-flex items-center gap-2 rounded-sm border border-line bg-transparent px-4 py-2.5 font-mono text-[13px] font-medium text-muted transition-colors duration-120 ease-out hover:border-accent hover:text-accent focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent motion-reduce:transition-none";
+
+type Props = { posts: Post[] };
+
+export default function RecentPostsList({ posts }: Props) {
+	return (
+		<>
+			{/* .stack { gap: 0 } — row-link border-b가 구분선 역할 */}
+			<div className="flex flex-col gap-0">
+				{posts.map((p) => (
+					<Link
+						key={p.slug}
+						to={`/blog/${p.slug}`}
+						data-testid="post-row"
+						className={ROW_LINK_CLASS}
+					>
+						<span className={ROW_DATE_CLASS}>{p.date}</span>
+						<span className={ROW_TITLE_CLASS}>{p.title}</span>
+						<span className={ROW_META_CLASS}>{p.read}</span>
+					</Link>
+				))}
+			</div>
+
+			{/* "모두 보기 →" 링크는 posts 길이와 무관하게 항상 렌더 (테스트 5) */}
+			<div className="mt-4">
+				<Link to="/blog" className={GHOST_BTN_CLASS}>
+					모두 보기 →
+				</Link>
+			</div>
+		</>
+	);
+}

--- a/app/presentation/components/home/RecentPostsList.tsx
+++ b/app/presentation/components/home/RecentPostsList.tsx
@@ -2,37 +2,24 @@ import { Link } from "react-router";
 
 import type { Post } from "../../../domain/post/post.entity";
 
-// 정본 매핑 정리:
-// - prototype.css:319-340 .row-link → grid grid-cols-[88px_1fr_auto] gap-2.5 py-3.5 border-b border-line
-//   font-mono text-[13px] items-baseline no-underline text-fg + transition-colors 120ms + hover:text-accent
-//   모바일(<560px) → grid-cols-[1fr_auto] + .date col-span-full font-size 10px
-// - .row-link 내부: .date faint 11px / .title fg font-medium / .meta faint 11px
-// - prototype.css:479 .stack default 12px gap, 본 컴포넌트는 row-link border-b로 구분되므로 gap-0
-// - .btn.ghost (prototype.css) → inline-flex items-center gap-2 px-4 py-2.5 border border-line rounded-md
-//   bg-transparent text-muted font-mono text-[13px] font-medium + transition-colors 120ms
-//   hover → border-accent text-accent
-//
-// className은 module top-level 상수로 추출 — per-render allocation 회피 (§3.0).
-// HeroWhoami / FeaturedProjectCard 패턴과 동일.
-
 const ROW_LINK_CLASS =
-	"grid grid-cols-[1fr_auto] sm:grid-cols-[88px_1fr_auto] gap-2.5 py-3.5 border-b border-line font-mono text-[13px] items-baseline no-underline text-fg transition-colors duration-120 ease-out hover:text-accent focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent motion-reduce:transition-none";
+	"grid grid-cols-[1fr_auto] min-[560px]:grid-cols-[88px_1fr_auto] gap-2.5 py-3.5 border-b border-line font-mono text-[13px] items-baseline no-underline text-fg transition-colors duration-[var(--duration-120)] ease-out hover:text-accent focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent motion-reduce:transition-none";
 
-const ROW_DATE_CLASS = "text-faint text-[10px] sm:text-[11px] col-span-full sm:col-span-1";
+const ROW_DATE_CLASS =
+	"text-muted text-[11px] min-[560px]:text-[11px] col-span-full min-[560px]:col-span-1";
 
 const ROW_TITLE_CLASS = "text-fg font-medium";
 
-const ROW_META_CLASS = "text-faint text-[11px]";
+const ROW_META_CLASS = "text-muted text-[11px]";
 
 const GHOST_BTN_CLASS =
-	"inline-flex items-center gap-2 rounded-sm border border-line bg-transparent px-4 py-2.5 font-mono text-[13px] font-medium text-muted transition-colors duration-120 ease-out hover:border-accent hover:text-accent focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent motion-reduce:transition-none";
+	"inline-flex items-center gap-2 rounded-md border border-line bg-transparent px-4 py-2.5 font-mono text-[13px] font-medium text-muted transition-colors duration-[var(--duration-120)] ease-out hover:border-accent hover:text-accent focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent motion-reduce:transition-none";
 
 type Props = { posts: Post[] };
 
 export default function RecentPostsList({ posts }: Props) {
 	return (
 		<>
-			{/* .stack { gap: 0 } — row-link border-b가 구분선 역할 */}
 			<div className="flex flex-col gap-0">
 				{posts.map((p) => (
 					<Link
@@ -43,12 +30,11 @@ export default function RecentPostsList({ posts }: Props) {
 					>
 						<span className={ROW_DATE_CLASS}>{p.date}</span>
 						<span className={ROW_TITLE_CLASS}>{p.title}</span>
-						<span className={ROW_META_CLASS}>{p.read}</span>
+						<span className={ROW_META_CLASS}>{p.read} min</span>
 					</Link>
 				))}
 			</div>
 
-			{/* "모두 보기 →" 링크는 posts 길이와 무관하게 항상 렌더 (테스트 5) */}
 			<div className="mt-4">
 				<Link to="/blog" className={GHOST_BTN_CLASS}>
 					모두 보기 →

--- a/app/presentation/components/home/__tests__/FeaturedProjectCard.test.tsx
+++ b/app/presentation/components/home/__tests__/FeaturedProjectCard.test.tsx
@@ -1,0 +1,101 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
+import { describe, expect, it } from "vitest";
+
+import type { Project } from "../../../../domain/project/project.entity";
+
+import FeaturedProjectCard from "../FeaturedProjectCard";
+
+// 테스트 픽스처
+const mockProject: Project = {
+	slug: "whiteboard-rt",
+	title: "Realtime Whiteboard",
+	summary: "다인원 실시간 화이트보드 with CRDT.",
+	date: "2026-03-01",
+	tags: ["b2c"],
+	stack: ["ts", "react", "cf-do"],
+	metrics: [],
+	featured: true,
+	cover: "/images/whiteboard-cover.png",
+};
+const mockProjectNoCover: Project = { ...mockProject, cover: undefined };
+
+describe("FeaturedProjectCard", () => {
+	it("카드 전체가 /projects/:slug 링크로 감싸진다", () => {
+		// Arrange
+		render(
+			<MemoryRouter>
+				<FeaturedProjectCard project={mockProject} />
+			</MemoryRouter>,
+		);
+
+		// Act
+		const links = screen.getAllByRole("link");
+
+		// Assert — 링크가 정확히 1개이고 href가 올바르다
+		expect(links).toHaveLength(1);
+		expect(links[0]).toHaveAttribute("href", "/projects/whiteboard-rt");
+	});
+
+	it("h2 heading으로 프로젝트 제목이 렌더된다", () => {
+		// Arrange
+		render(
+			<MemoryRouter>
+				<FeaturedProjectCard project={mockProject} />
+			</MemoryRouter>,
+		);
+
+		// Act & Assert
+		expect(screen.getByRole("heading", { level: 2 })).toHaveTextContent("Realtime Whiteboard");
+	});
+
+	it("프로젝트 summary가 렌더된다", () => {
+		// Arrange
+		render(
+			<MemoryRouter>
+				<FeaturedProjectCard project={mockProject} />
+			</MemoryRouter>,
+		);
+
+		// Act & Assert
+		expect(screen.getByText(/다인원 실시간 화이트보드/)).toBeInTheDocument();
+	});
+
+	it("stack pill이 3개 모두 렌더된다", () => {
+		// Arrange
+		render(
+			<MemoryRouter>
+				<FeaturedProjectCard project={mockProject} />
+			</MemoryRouter>,
+		);
+
+		// Act & Assert
+		expect(screen.getByText("ts")).toBeInTheDocument();
+		expect(screen.getByText("react")).toBeInTheDocument();
+		expect(screen.getByText("cf-do")).toBeInTheDocument();
+	});
+
+	it("cover가 있을 때 cover 영역이 렌더된다", () => {
+		// Arrange
+		render(
+			<MemoryRouter>
+				<FeaturedProjectCard project={mockProject} />
+			</MemoryRouter>,
+		);
+
+		// Act & Assert — cover testid 영역 존재 확인
+		expect(screen.getByTestId("cover")).toBeInTheDocument();
+	});
+
+	it("cover가 없을 때도 placeholder cover 영역이 렌더된다", () => {
+		// Arrange
+		render(
+			<MemoryRouter>
+				<FeaturedProjectCard project={mockProjectNoCover} />
+			</MemoryRouter>,
+		);
+
+		// Act & Assert — cover 없어도 16:9 placeholder 영역 유지
+		expect(screen.getByTestId("cover")).toBeInTheDocument();
+	});
+});

--- a/app/presentation/components/home/__tests__/HeroWhoami.test.tsx
+++ b/app/presentation/components/home/__tests__/HeroWhoami.test.tsx
@@ -1,0 +1,94 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const openSpy = vi.fn();
+vi.mock("../../../hooks/useCommandPalette", () => ({
+	useCommandPalette: () => ({ open: openSpy }),
+}));
+
+import HeroWhoami from "../HeroWhoami";
+
+describe("HeroWhoami", () => {
+	beforeEach(() => {
+		openSpy.mockClear();
+	});
+
+	it("h1에 'ship solo.'와 'ship fast.' 텍스트가 모두 포함된다", () => {
+		// Arrange
+		render(
+			<MemoryRouter>
+				<HeroWhoami />
+			</MemoryRouter>,
+		);
+
+		// Act
+		const heading = screen.getByRole("heading", { level: 1 });
+
+		// Assert
+		const normalizedText = heading.textContent?.replace(/\s+/g, " ").trim() ?? "";
+		expect(normalizedText).toMatch(/ship solo\./i);
+		expect(normalizedText).toMatch(/ship fast\./i);
+	});
+
+	it("부제 텍스트 '1인 개발자 김태곤'이 렌더된다", () => {
+		// Arrange
+		render(
+			<MemoryRouter>
+				<HeroWhoami />
+			</MemoryRouter>,
+		);
+
+		// Act & Assert
+		expect(screen.getByText(/1인 개발자 김태곤/)).toBeInTheDocument();
+	});
+
+	it("'검색해서 이동' 버튼이 type='button'이고, 클릭 시 open이 1회 호출된다", () => {
+		// Arrange
+		render(
+			<MemoryRouter>
+				<HeroWhoami />
+			</MemoryRouter>,
+		);
+		const button = screen.getByRole("button", { name: /검색해서 이동/ });
+
+		// Assert — 버튼 속성 확인
+		expect(button).toHaveAttribute("type", "button");
+
+		// Act
+		fireEvent.click(button);
+
+		// Assert — open spy 1회 호출
+		expect(openSpy).toHaveBeenCalledTimes(1);
+	});
+
+	it("/about 링크가 존재하고 href='/about'이다", () => {
+		// Arrange
+		render(
+			<MemoryRouter>
+				<HeroWhoami />
+			</MemoryRouter>,
+		);
+
+		// Act
+		const aboutLink = screen.getByRole("link", { name: "/about" });
+
+		// Assert
+		expect(aboutLink).toHaveAttribute("href", "/about");
+	});
+
+	it("/projects 링크가 존재하고 href='/projects'이다", () => {
+		// Arrange
+		render(
+			<MemoryRouter>
+				<HeroWhoami />
+			</MemoryRouter>,
+		);
+
+		// Act
+		const projectsLink = screen.getByRole("link", { name: "/projects" });
+
+		// Assert
+		expect(projectsLink).toHaveAttribute("href", "/projects");
+	});
+});

--- a/app/presentation/components/home/__tests__/RecentPostsList.test.tsx
+++ b/app/presentation/components/home/__tests__/RecentPostsList.test.tsx
@@ -1,0 +1,113 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
+import { describe, expect, it } from "vitest";
+
+import type { Post } from "../../../../domain/post/post.entity";
+
+import RecentPostsList from "../RecentPostsList";
+
+// 테스트 픽스처
+const mockPosts: Post[] = [
+	{
+		slug: "post-1",
+		title: "첫 번째 글",
+		lede: "lede 1",
+		date: "2026-04-01",
+		tags: ["dev"],
+		read: 5,
+	},
+	{
+		slug: "post-2",
+		title: "두 번째 글",
+		lede: "lede 2",
+		date: "2026-03-20",
+		tags: ["dev"],
+		read: 8,
+	},
+	{
+		slug: "post-3",
+		title: "세 번째 글",
+		lede: "lede 3",
+		date: "2026-03-05",
+		tags: ["dev"],
+		read: 12,
+	},
+];
+
+describe("RecentPostsList", () => {
+	it("posts 배열 길이만큼 row가 렌더된다", () => {
+		// Arrange
+		render(
+			<MemoryRouter>
+				<RecentPostsList posts={mockPosts} />
+			</MemoryRouter>,
+		);
+
+		// Act
+		const rows = screen.getAllByTestId("post-row");
+
+		// Assert
+		expect(rows).toHaveLength(3);
+	});
+
+	it("첫 번째 row에 date와 title이 렌더된다", () => {
+		// Arrange
+		render(
+			<MemoryRouter>
+				<RecentPostsList posts={mockPosts} />
+			</MemoryRouter>,
+		);
+
+		// Act & Assert
+		expect(screen.getByText("첫 번째 글")).toBeInTheDocument();
+		expect(screen.getByText("2026-04-01")).toBeInTheDocument();
+	});
+
+	it("각 row가 /blog/:slug 링크로 렌더된다", () => {
+		// Arrange
+		render(
+			<MemoryRouter>
+				<RecentPostsList posts={mockPosts} />
+			</MemoryRouter>,
+		);
+
+		// Act
+		const firstLink = screen.getByRole("link", { name: /첫 번째 글/ });
+
+		// Assert
+		expect(firstLink).toHaveAttribute("href", "/blog/post-1");
+	});
+
+	it('"모두 보기 →" 링크가 /blog로 렌더된다', () => {
+		// Arrange
+		render(
+			<MemoryRouter>
+				<RecentPostsList posts={mockPosts} />
+			</MemoryRouter>,
+		);
+
+		// Act
+		const viewAllLink = screen.getByRole("link", { name: /모두 보기/ });
+
+		// Assert
+		expect(viewAllLink).toBeInTheDocument();
+		expect(viewAllLink).toHaveAttribute("href", "/blog");
+	});
+
+	it('빈 배열 전달 시 row는 0개이고 "모두 보기 →" 링크는 유지된다', () => {
+		// Arrange
+		render(
+			<MemoryRouter>
+				<RecentPostsList posts={[]} />
+			</MemoryRouter>,
+		);
+
+		// Act
+		const rows = screen.queryAllByTestId("post-row");
+		const viewAllLink = screen.getByRole("link", { name: /모두 보기/ });
+
+		// Assert
+		expect(rows).toHaveLength(0);
+		expect(viewAllLink).toBeInTheDocument();
+	});
+});

--- a/app/presentation/hooks/useCommandPalette.ts
+++ b/app/presentation/hooks/useCommandPalette.ts
@@ -1,0 +1,8 @@
+// T010 placeholder. T016에서 실제 Command Palette open 로직으로 교체.
+export const useCommandPalette = (): { open: () => void } => {
+	return {
+		open: () => {
+			/* T016 wires real palette */
+		},
+	};
+};

--- a/app/presentation/routes/__tests__/_index.test.tsx
+++ b/app/presentation/routes/__tests__/_index.test.tsx
@@ -1,0 +1,214 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { createRoutesStub } from "react-router";
+import type { Project } from "../../../domain/project/project.entity";
+import type { Post } from "../../../domain/post/post.entity";
+import IndexRoute, { loader } from "../_index";
+
+// ---------------------------------------------------------------------------
+// 테스트 픽스처
+// ---------------------------------------------------------------------------
+
+const mockFeatured: Project = {
+	slug: "whiteboard-rt",
+	title: "Realtime Whiteboard",
+	summary: "다인원 실시간 화이트보드.",
+	date: "2026-03-01",
+	tags: ["b2c"],
+	stack: ["ts", "react"],
+	metrics: [],
+	featured: true,
+	cover: undefined,
+};
+
+const mockPosts: Post[] = [
+	{ slug: "p1", title: "글 1", lede: "lede 1", date: "2026-04-01", tags: [], read: 5 },
+	{ slug: "p2", title: "글 2", lede: "lede 2", date: "2026-03-20", tags: [], read: 8 },
+	{ slug: "p3", title: "글 3", lede: "lede 3", date: "2026-03-05", tags: [], read: 12 },
+];
+
+// ---------------------------------------------------------------------------
+// mock context 팩토리
+// ---------------------------------------------------------------------------
+
+const makeMockContext = (overrides: Partial<{ featured: Project | null; posts: Post[] }> = {}) => {
+	const featured = overrides.featured !== undefined ? overrides.featured : mockFeatured;
+	const posts = overrides.posts ?? mockPosts;
+	const getFeaturedProject = vi.fn().mockResolvedValue(featured);
+	const getRecentPosts = vi.fn().mockResolvedValue(posts);
+	return {
+		context: {
+			container: {
+				getFeaturedProject,
+				getRecentPosts,
+				listProjects: vi.fn(),
+				getProjectDetail: vi.fn(),
+				listPosts: vi.fn(),
+				getPostDetail: vi.fn(),
+			},
+			cloudflare: { env: {}, ctx: {} },
+		},
+		spies: { getFeaturedProject, getRecentPosts },
+	};
+};
+
+// ---------------------------------------------------------------------------
+// Group A — Loader 행동 (loader 직접 호출)
+// ---------------------------------------------------------------------------
+
+describe("Group A — loader 행동", () => {
+	it("getFeaturedProject 1회 호출 + getRecentPosts(3) 호출", async () => {
+		// Arrange
+		const { context, spies } = makeMockContext();
+
+		// Act
+		await loader({ context, request: new Request("http://localhost/") } as never);
+
+		// Assert
+		expect(spies.getFeaturedProject).toHaveBeenCalledTimes(1);
+		expect(spies.getRecentPosts).toHaveBeenCalledTimes(1);
+		expect(spies.getRecentPosts).toHaveBeenCalledWith(3);
+	});
+
+	it("반환 객체에 featured와 posts 키가 존재하고 posts 길이가 3", async () => {
+		// Arrange
+		const { context } = makeMockContext();
+
+		// Act
+		const result = await loader({
+			context,
+			request: new Request("http://localhost/"),
+		} as never);
+
+		// Assert
+		expect(result).toHaveProperty("featured");
+		expect(result).toHaveProperty("posts");
+		expect(result.posts).toHaveLength(3);
+	});
+
+	it("featured가 null인 경우 null이 그대로 전파되고 posts는 유지", async () => {
+		// Arrange
+		const { context } = makeMockContext({ featured: null });
+
+		// Act
+		const result = await loader({
+			context,
+			request: new Request("http://localhost/"),
+		} as never);
+
+		// Assert
+		expect(result.featured).toBeNull();
+		expect(result.posts).toHaveLength(3);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Group B — UI 통합 (createRoutesStub 사용)
+// ---------------------------------------------------------------------------
+
+describe("Group B — UI 통합 렌더", () => {
+	it("HeroWhoami 렌더 — h1에 'ship solo' 텍스트 포함", async () => {
+		// Arrange
+		const Stub = createRoutesStub([
+			{
+				path: "/",
+				Component: IndexRoute,
+				loader: () => ({ featured: mockFeatured, posts: mockPosts }),
+			},
+		]);
+
+		// Act
+		render(<Stub initialEntries={["/"]} />);
+
+		// Assert
+		await screen.findByRole("heading", { level: 1 });
+		expect(screen.getByRole("heading", { level: 1 })).toHaveTextContent(/ship solo/i);
+	});
+
+	it("FeaturedProjectCard 렌더 — mockFeatured.title 노출", async () => {
+		// Arrange
+		const Stub = createRoutesStub([
+			{
+				path: "/",
+				Component: IndexRoute,
+				loader: () => ({ featured: mockFeatured, posts: mockPosts }),
+			},
+		]);
+
+		// Act
+		render(<Stub initialEntries={["/"]} />);
+
+		// Assert
+		await screen.findByText("Realtime Whiteboard");
+		expect(screen.getByText("Realtime Whiteboard")).toBeInTheDocument();
+	});
+
+	it("RecentPostsList 렌더 — post-row 3개 노출", async () => {
+		// Arrange
+		const Stub = createRoutesStub([
+			{
+				path: "/",
+				Component: IndexRoute,
+				loader: () => ({ featured: mockFeatured, posts: mockPosts }),
+			},
+		]);
+
+		// Act
+		render(<Stub initialEntries={["/"]} />);
+
+		// Assert
+		await screen.findByText("글 1");
+		expect(screen.getAllByTestId("post-row")).toHaveLength(3);
+	});
+
+	it("Hero → Featured → Recent 순서로 DOM에 배치", async () => {
+		// Arrange
+		const Stub = createRoutesStub([
+			{
+				path: "/",
+				Component: IndexRoute,
+				loader: () => ({ featured: mockFeatured, posts: mockPosts }),
+			},
+		]);
+
+		// Act
+		render(<Stub initialEntries={["/"]} />);
+		await screen.findByRole("heading", { level: 1 });
+
+		// Assert
+		const hero = screen.getByRole("heading", { level: 1 });
+		const featured = screen.getByText("Realtime Whiteboard");
+		const recent = screen.getAllByTestId("post-row")[0];
+
+		expect(hero.compareDocumentPosition(featured) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+		expect(
+			featured.compareDocumentPosition(recent) & Node.DOCUMENT_POSITION_FOLLOWING,
+		).toBeTruthy();
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Group C — Featured null conditional
+// ---------------------------------------------------------------------------
+
+describe("Group C — featured null conditional", () => {
+	it("featured가 null일 때 FeaturedProjectCard 미렌더, posts는 유지", async () => {
+		// Arrange
+		const StubNullFeatured = createRoutesStub([
+			{
+				path: "/",
+				Component: IndexRoute,
+				loader: () => ({ featured: null, posts: mockPosts }),
+			},
+		]);
+
+		// Act
+		render(<StubNullFeatured initialEntries={["/"]} />);
+		await screen.findByRole("heading", { level: 1 });
+
+		// Assert — FeaturedProjectCard의 타이틀이 렌더되지 않아야 함
+		expect(screen.queryByText("Realtime Whiteboard")).not.toBeInTheDocument();
+		// posts는 여전히 렌더
+		expect(screen.getAllByTestId("post-row")).toHaveLength(3);
+	});
+});

--- a/app/presentation/routes/_index.tsx
+++ b/app/presentation/routes/_index.tsx
@@ -1,14 +1,43 @@
+import FeaturedProjectCard from "../components/home/FeaturedProjectCard";
+import HeroWhoami from "../components/home/HeroWhoami";
+import RecentPostsList from "../components/home/RecentPostsList";
 import type { Route } from "./+types/_index";
 
 export const meta: Route.MetaFunction = () => [
 	{ title: "tkstar.dev" },
-	{ name: "description", content: "tkstar.dev — coming soon" },
+	{ name: "description", content: "1인 개발자 김태곤의 풀스택 작업물 · 글 · 이력." },
 ];
 
-export default function Index() {
+export const loader = async ({ context }: Route.LoaderArgs) => {
+	const [featured, posts] = await Promise.all([
+		context.container.getFeaturedProject(),
+		context.container.getRecentPosts(3),
+	]);
+	return { featured, posts };
+};
+
+const SECTION_HEADER_CLASS =
+	"flex items-center gap-2 mt-6 mb-2 font-mono text-[11px] tracking-[0.12em] uppercase text-faint before:content-['##'] before:text-accent after:content-[''] after:flex-1 after:h-px after:bg-line";
+
+export default function Index({ loaderData }: Route.ComponentProps) {
+	const { featured, posts } = loaderData;
 	return (
-		<main className="container mx-auto p-4">
-			<h1 className="text-2xl font-semibold">tkstar.dev — coming soon</h1>
+		<main className="mx-auto max-w-[var(--container-measure)] px-[var(--spacing-gutter)] py-6">
+			<HeroWhoami />
+
+			<section data-testid="featured-section" aria-labelledby="featured-heading">
+				<h2 id="featured-heading" className={SECTION_HEADER_CLASS}>
+					<span>featured</span>
+				</h2>
+				{featured && <FeaturedProjectCard project={featured} />}
+			</section>
+
+			<section data-testid="recent-section" aria-labelledby="recent-heading">
+				<h2 id="recent-heading" className={SECTION_HEADER_CLASS}>
+					<span>recent posts</span>
+				</h2>
+				<RecentPostsList posts={posts} />
+			</section>
 		</main>
 	);
 }

--- a/app/presentation/routes/_index.tsx
+++ b/app/presentation/routes/_index.tsx
@@ -17,24 +17,40 @@ export const loader = async ({ context }: Route.LoaderArgs) => {
 };
 
 const SECTION_HEADER_CLASS =
-	"flex items-center gap-2 mt-6 mb-2 font-mono text-[11px] tracking-[0.12em] uppercase text-faint before:content-['##'] before:text-accent after:content-[''] after:flex-1 after:h-px after:bg-line";
+	"flex items-center gap-2 m-0 font-mono text-[11px] tracking-[0.12em] uppercase text-muted";
 
 export default function Index({ loaderData }: Route.ComponentProps) {
 	const { featured, posts } = loaderData;
 	return (
-		<main className="mx-auto max-w-[var(--container-measure)] px-[var(--spacing-gutter)] py-6">
+		<main className="mx-auto flex max-w-[var(--container-measure)] flex-col gap-[22px] px-[var(--spacing-gutter)] pt-[22px] pb-20 min-[720px]:gap-7 min-[720px]:px-7 min-[720px]:pt-9 min-[720px]:pb-[120px]">
 			<HeroWhoami />
 
-			<section data-testid="featured-section" aria-labelledby="featured-heading">
+			<section
+				data-testid="featured-section"
+				aria-labelledby="featured-heading"
+				className="flex flex-col gap-1.5"
+			>
 				<h2 id="featured-heading" className={SECTION_HEADER_CLASS}>
+					<span aria-hidden="true" className="text-accent">
+						##
+					</span>
 					<span>featured</span>
+					<span aria-hidden="true" className="h-px flex-1 bg-line" />
 				</h2>
 				{featured && <FeaturedProjectCard project={featured} />}
 			</section>
 
-			<section data-testid="recent-section" aria-labelledby="recent-heading">
+			<section
+				data-testid="recent-section"
+				aria-labelledby="recent-heading"
+				className="flex flex-col gap-1.5"
+			>
 				<h2 id="recent-heading" className={SECTION_HEADER_CLASS}>
+					<span aria-hidden="true" className="text-accent">
+						##
+					</span>
 					<span>recent posts</span>
+					<span aria-hidden="true" className="h-px flex-1 bg-line" />
 				</h2>
 				<RecentPostsList posts={posts} />
 			</section>

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -249,7 +249,7 @@ tkstarDev는 다음 핵심 가치를 단일 도메인에서 달성한다:
 > **진입 조건**: Phase 2 완료 (Repository + DI 가동)
 > **완료 조건 (DoD)**: `wrangler dev`로 7개 콘텐츠 페이지(Home/About/Projects/Project Detail/Blog/Blog Detail/Legal Index)가 seed 데이터로 정상 렌더. Project Detail/Blog Detail 데스크탑 880px+ sticky sidebar 동작. About `[⎙ PDF]` 버튼 → `window.print()` AC-F003-1/2/3 통과.
 
-- [ ] **Task 010: Home Page (F001 Hero + F017 Featured/Recent)**
+- [x] **Task 010: Home Page (F001 Hero + F017 Featured/Recent)** ✅
   - **Must** Read: [tasks/T010-home-page.md](tasks/T010-home-page.md)
   - blockedBy: Task 005, Task 008, Task 009
   - blocks: Task 016

--- a/docs/tasks/T010-home-page.md
+++ b/docs/tasks/T010-home-page.md
@@ -11,7 +11,7 @@
 | **PRD Features** | **F001** (Hero), **F017** (Featured + Recent Posts) |
 | **PRD AC** | — (Page-by-Page Key Features 검증) |
 | **예상 작업 시간** | 1d |
-| **Status** | Not Started |
+| **Status** | Completed |
 
 ## Goal
 Home(`/`) 페이지에 PRD `F001 Hero (whoami + 검색 + 빠른 링크)` + `F017 Featured Project + Recent Posts 3개`를 렌더한다. 검색 트리거 버튼은 Task 016의 Cmd+K Command Palette를 트리거할 placeholder hook을 미리 연결한다.
@@ -126,4 +126,5 @@ Home(`/`) 페이지에 PRD `F001 Hero (whoami + 검색 + 빠른 링크)` + `F017
 ## Change History
 | Date | Changes | Author |
 |------|---------|--------|
-| - | - | - |
+| 2026-04-29 | Phase 2 Green: HeroWhoami / FeaturedProjectCard / RecentPostsList / `_index.tsx` loader 구현. 24/24 test files, 118/118 tests green. (commit `6645a30`) | TaekyungHa |
+| 2026-04-29 | Phase 3 Review fix: design-review 6 Critical(C1-C6) + R1/R3/R4 + code-review R2 일괄 반영. `--color-hatch` / `--duration-120` 토큰 등록, `text-faint`→`text-muted` (WCAG AA), main padding/gap 정본 lockup, 720px breakpoint, btn primary brightness 1.08 + filter transition, row meta `min` 단위 복원. (commit `769bd0c`) | TaekyungHa |


### PR DESCRIPTION
## Summary

- Home(`/`) 페이지 완성 — F001 Hero(whoami + 검색 + 빠른 링크) + F017 Featured Project + Recent Posts(3)
- loader가 DI Container의 `getFeaturedProject` + `getRecentPosts(3)`을 `Promise.all` 호출, featured 미존재 시 카드 conditional 미렌더
- Hero의 [검색해서 이동]은 T016 placeholder hook(`useCommandPalette`)에 연결 — T016에서 본체 채우면 자동 통합
- 디자인 정본(`docs/design-system/proto/pages-1.jsx` + `prototype.css`) 1:1 lockup, WCAG AA contrast 정렬

## 주요 변경

### Components
- `app/presentation/components/home/HeroWhoami.tsx` — whoami prompt + h1(`ship solo. ship fast.`) + 부제 + 3-버튼 클러스터 ([검색해서 이동]/[/about]/[/projects])
- `app/presentation/components/home/FeaturedProjectCard.tsx` — 16:9 cover (URL/hatch placeholder) + stack pills + h2 title + summary, `/projects/:slug` 단일 anchor
- `app/presentation/components/home/RecentPostsList.tsx` — row-link 패턴(date · title · `{read} min`) + "모두 보기 →" ghost 링크 (빈 배열에도 유지)
- `app/presentation/hooks/useCommandPalette.ts` — T016 wiring 전 placeholder (no-op `open`)

### Route
- `app/presentation/routes/_index.tsx` — `loader` (`Promise.all` featured + posts) + Hero/Featured/Recent 3-section 조립 + `aria-labelledby` landmark + `min-[720px]:` breakpoint 정본 lockup

### Design Tokens (`app/app.css`)
- `--color-hatch` 토큰 등록 (dark/light 분기) — cover placeholder 패턴 재사용
- `--duration-120` 토큰 등록 — 정본 transition 120ms 일관 참조

### Phase 3 Review fix (commit `769bd0c`)
design-review 6 Critical(C1-C6) + R1/R3/R4 + code-review R2 일괄 반영:
- C1 PromptLine 단독 mb-3 → hero section flex+gap
- C2 main 컨테이너 padding/gap 정본 lockup + 720px breakpoint
- C3 section h2 ## 의사요소 분리 (aria-hidden span)
- C4 btn primary `transition-[color,bg,border,filter]` + brightness 1.08
- C5 row date/meta `text-faint` → `text-muted` (WCAG AA ~6.5:1)
- C6 `--color-hatch` 토큰 등록, oklab 임시 처리 제거
- R1 RecentPostsList 분기점 `sm:640` → `min-[560px]`
- R3 `rounded-sm` → `rounded-md` (정본 .btn 6px)
- R4 `duration-120` 토큰화
- code-R2 row meta `{p.read}` → `{p.read} min`

## Test plan

### 자동 (CI에서 검증)
- [x] `bun run test` — 24/24 test files, 118/118 tests green (T010 신규 4 test files: HeroWhoami 5 / FeaturedProjectCard 6 / RecentPostsList 5 / `_index` 8 cases)
- [x] `bun run lint` — Biome clean (109 files)
- [x] `bun run typecheck` — 0 errors

### 수동 (리뷰어 확인 권장)
- [ ] `bun run dev` 또는 `bunx wrangler dev` → `/` 진입
  - [ ] Hero 카피(`ship solo. ship fast.` + 부제) 시각 확인
  - [ ] [검색해서 이동] 클릭 → 콘솔 에러 없음 (T016 전까지 no-op)
  - [ ] [/about] / [/projects] 클릭 → 네비게이션 동작
  - [ ] Featured 카드 클릭 → `/projects/:slug` 네비게이션
  - [ ] "모두 보기 →" 클릭 → `/blog` 네비게이션
  - [ ] 다크/라이트 토글 후 색상 회귀 없음
  - [ ] 모바일 / 720px 분기점 / 데스크톱에서 spacing 정본 일치

## ROADMAP / Task

- [x] `docs/ROADMAP.md` Task 010 ✅
- [x] `docs/tasks/T010-home-page.md` Status: Completed + Change History 2건 추가

---
Related: #35