### PR TITLE
chore: presentation components code review followup

### DIFF
--- a/app/presentation/components/chrome/Footer.tsx
+++ b/app/presentation/components/chrome/Footer.tsx
@@ -1,8 +1,6 @@
 import { Link } from "react-router";
 import { FOOTER_LINKS } from "../../lib/chrome-links";
 
-const CURRENT_YEAR = new Date().getFullYear();
-
 const linkClass =
 	"rounded-sm hover:text-fg focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent";
 
@@ -10,7 +8,7 @@ export default function Footer() {
 	return (
 		<footer className="border-t border-line text-muted text-xs">
 			<div className="mx-auto flex max-w-5xl flex-col gap-3 px-4 py-6 sm:flex-row sm:items-center sm:justify-between">
-				<p>© {CURRENT_YEAR} tkstar.dev</p>
+				<p>© {new Date().getFullYear()} tkstar.dev</p>
 				<ul className="flex flex-wrap gap-4">
 					{FOOTER_LINKS.map((link) => (
 						<li key={link.label}>

--- a/app/presentation/components/chrome/Topbar.tsx
+++ b/app/presentation/components/chrome/Topbar.tsx
@@ -36,9 +36,9 @@ export default function Topbar() {
 					))}
 					<button
 						type="button"
-						disabled
 						aria-disabled="true"
-						aria-label="검색 (T016에서 활성화)"
+						aria-label="검색 (준비 중)"
+						onClick={(e) => e.preventDefault()}
 						className="cursor-not-allowed rounded-sm border border-line px-2 py-1 text-muted text-xs opacity-60 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent"
 					>
 						{kbd}

--- a/app/presentation/components/content/MdxRenderer.tsx
+++ b/app/presentation/components/content/MdxRenderer.tsx
@@ -1,6 +1,11 @@
 import { Fragment } from "react";
 import { jsx, jsxs } from "react/jsx-runtime";
 
+/**
+ * @internal SECURITY-CRITICAL — `code` MUST be a build-time velite mdx output (function-body source).
+ * Trusted source: `#content/{projects,posts,legal}` JSON `body` field.
+ * Do NOT pass user-supplied or runtime-fetched strings — adding such a call site is RCE-equivalent.
+ */
 const evaluateMdxBody = (code: string) => {
 	const fn = new Function(code);
 	return fn({ Fragment, jsx, jsxs }).default;

--- a/app/presentation/components/home/FeaturedProjectCard.tsx
+++ b/app/presentation/components/home/FeaturedProjectCard.tsx
@@ -4,9 +4,6 @@ import type { Project } from "../../../domain/project/project.entity";
 
 type Props = { project: Project };
 
-const COVER_HATCH_CLASS =
-	"bg-bg-elev bg-[image:repeating-linear-gradient(45deg,var(--color-hatch)_0_8px,transparent_8px_16px)]";
-
 export default function FeaturedProjectCard({ project }: Props) {
 	return (
 		<Link
@@ -23,12 +20,11 @@ export default function FeaturedProjectCard({ project }: Props) {
 						alt=""
 						loading="eager"
 						decoding="async"
+						fetchPriority="high"
 						className="h-full w-full object-cover"
 					/>
 				) : (
-					<div
-						className={`flex h-full w-full items-center justify-center font-mono text-[11px] text-faint tracking-[0.06em] ${COVER_HATCH_CLASS}`}
-					>
+					<div className="flex h-full w-full items-center justify-center bg-bg-elev bg-[image:repeating-linear-gradient(45deg,var(--color-hatch)_0_8px,transparent_8px_16px)] font-mono text-[11px] text-faint tracking-[0.06em]">
 						cover · 16:9
 					</div>
 				)}
@@ -45,9 +41,9 @@ export default function FeaturedProjectCard({ project }: Props) {
 				))}
 			</div>
 
-			<h2 className="m-0 font-mono font-semibold text-[clamp(1.25rem,3.4vw,1.5rem)] leading-[1.2] tracking-[-0.01em]">
+			<h3 className="m-0 font-mono font-semibold text-[clamp(1.25rem,3.4vw,1.5rem)] leading-[1.2] tracking-[-0.01em]">
 				{project.title}
-			</h2>
+			</h3>
 
 			<p className="m-0 mt-1.5 text-muted text-sm leading-[1.7]">{project.summary}</p>
 		</Link>

--- a/app/presentation/components/home/HeroWhoami.tsx
+++ b/app/presentation/components/home/HeroWhoami.tsx
@@ -4,12 +4,6 @@ import { useCommandPalette } from "../../hooks/useCommandPalette";
 const BTN_BASE =
 	"inline-flex items-center gap-2 rounded-md border px-4 py-2.5 font-mono text-[13px] font-medium duration-[var(--duration-120)] ease-out motion-reduce:transition-none focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent";
 
-const BTN_DEFAULT = `${BTN_BASE} transition-colors border-line-strong bg-transparent text-fg hover:border-accent hover:text-accent`;
-
-const BTN_PRIMARY = `${BTN_BASE} transition-[color,background-color,border-color,filter] border-accent bg-accent text-bg hover:brightness-[1.08]`;
-
-const BTN_GHOST = `${BTN_BASE} transition-colors border-line bg-transparent text-muted hover:border-accent hover:text-accent`;
-
 export default function HeroWhoami() {
 	const { open } = useCommandPalette();
 
@@ -37,13 +31,23 @@ export default function HeroWhoami() {
 			</p>
 
 			<div className="mt-2 flex flex-wrap items-center gap-2">
-				<button type="button" onClick={open} className={BTN_PRIMARY}>
+				<button
+					type="button"
+					onClick={open}
+					className={`${BTN_BASE} border-accent bg-accent text-bg transition-[color,background-color,border-color,filter] hover:brightness-[1.08]`}
+				>
 					›&nbsp;&nbsp;검색해서 이동
 				</button>
-				<Link to="/about" className={BTN_DEFAULT}>
+				<Link
+					to="/about"
+					className={`${BTN_BASE} border-line-strong bg-transparent text-fg transition-colors hover:border-accent hover:text-accent`}
+				>
 					/about
 				</Link>
-				<Link to="/projects" className={BTN_GHOST}>
+				<Link
+					to="/projects"
+					className={`${BTN_BASE} border-line bg-transparent text-muted transition-colors hover:border-accent hover:text-accent`}
+				>
 					/projects
 				</Link>
 			</div>

--- a/app/presentation/components/home/RecentPostsList.tsx
+++ b/app/presentation/components/home/RecentPostsList.tsx
@@ -2,19 +2,6 @@ import { Link } from "react-router";
 
 import type { Post } from "../../../domain/post/post.entity";
 
-const ROW_LINK_CLASS =
-	"grid grid-cols-[1fr_auto] min-[560px]:grid-cols-[88px_1fr_auto] gap-2.5 py-3.5 border-b border-line font-mono text-[13px] items-baseline no-underline text-fg transition-colors duration-[var(--duration-120)] ease-out hover:text-accent focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent motion-reduce:transition-none";
-
-const ROW_DATE_CLASS =
-	"text-muted text-[11px] min-[560px]:text-[11px] col-span-full min-[560px]:col-span-1";
-
-const ROW_TITLE_CLASS = "text-fg font-medium";
-
-const ROW_META_CLASS = "text-muted text-[11px]";
-
-const GHOST_BTN_CLASS =
-	"inline-flex items-center gap-2 rounded-md border border-line bg-transparent px-4 py-2.5 font-mono text-[13px] font-medium text-muted transition-colors duration-[var(--duration-120)] ease-out hover:border-accent hover:text-accent focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent motion-reduce:transition-none";
-
 type Props = { posts: Post[] };
 
 export default function RecentPostsList({ posts }: Props) {
@@ -26,17 +13,22 @@ export default function RecentPostsList({ posts }: Props) {
 						key={p.slug}
 						to={`/blog/${p.slug}`}
 						data-testid="post-row"
-						className={ROW_LINK_CLASS}
+						className="grid grid-cols-[1fr_auto] min-[560px]:grid-cols-[88px_1fr_auto] items-baseline gap-2.5 border-line border-b py-3.5 font-mono text-[13px] text-fg no-underline transition-colors duration-[var(--duration-120)] ease-out hover:text-accent focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent motion-reduce:transition-none"
 					>
-						<span className={ROW_DATE_CLASS}>{p.date}</span>
-						<span className={ROW_TITLE_CLASS}>{p.title}</span>
-						<span className={ROW_META_CLASS}>{p.read} min</span>
+						<span className="col-span-full text-[11px] text-muted min-[560px]:col-span-1 min-[560px]:text-[11px]">
+							{p.date}
+						</span>
+						<span className="font-medium text-fg">{p.title}</span>
+						<span className="text-[11px] text-muted">{p.read} min</span>
 					</Link>
 				))}
 			</div>
 
 			<div className="mt-4">
-				<Link to="/blog" className={GHOST_BTN_CLASS}>
+				<Link
+					to="/blog"
+					className="inline-flex items-center gap-2 rounded-md border border-line bg-transparent px-4 py-2.5 font-medium font-mono text-[13px] text-muted transition-colors duration-[var(--duration-120)] ease-out hover:border-accent hover:text-accent focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent motion-reduce:transition-none"
+				>
 					모두 보기 →
 				</Link>
 			</div>

--- a/app/presentation/components/home/__tests__/FeaturedProjectCard.test.tsx
+++ b/app/presentation/components/home/__tests__/FeaturedProjectCard.test.tsx
@@ -37,7 +37,7 @@ describe("FeaturedProjectCard", () => {
 		expect(links[0]).toHaveAttribute("href", "/projects/whiteboard-rt");
 	});
 
-	it("h2 heading으로 프로젝트 제목이 렌더된다", () => {
+	it("h3 heading으로 프로젝트 제목이 렌더된다", () => {
 		// Arrange
 		render(
 			<MemoryRouter>
@@ -46,7 +46,7 @@ describe("FeaturedProjectCard", () => {
 		);
 
 		// Act & Assert
-		expect(screen.getByRole("heading", { level: 2 })).toHaveTextContent("Realtime Whiteboard");
+		expect(screen.getByRole("heading", { level: 3 })).toHaveTextContent("Realtime Whiteboard");
 	});
 
 	it("프로젝트 summary가 렌더된다", () => {

--- a/app/presentation/lib/chrome-links.ts
+++ b/app/presentation/lib/chrome-links.ts
@@ -8,7 +8,6 @@ export const TOPBAR_LINKS: ChromeLink[] = [
 	{ label: "about", href: "/about" },
 	{ label: "projects", href: "/projects" },
 	{ label: "blog", href: "/blog" },
-	{ label: "now", href: "/now" },
 ];
 
 // TODO: X / RSS placeholder — T0xx에서 실 URL 확정 시 교체. external: true로 두어 SPA navigation 회피.


### PR DESCRIPTION
## Summary

`code-reviewer` 서브에이전트 ad-hoc 리뷰(P1 4 / P2 9) 후속 surgical fix. 사용자 승인 항목 일괄 적용 — 동작 변화 없음 (heading level 1건은 테스트 동기화).

## Applied

### P1
- **chrome-links.ts**: `/now` dead route 제거 (라우트 파일 부재 → 클릭 시 404)
- **MdxRenderer.tsx**: `evaluateMdxBody` 위에 `@internal SECURITY-CRITICAL` JSDoc 추가 — build-time velite 산출물 외 입력 금지를 컴포넌트 측에 명시 (defense-in-depth)

### P2
- **FeaturedProjectCard.tsx**:
  - `COVER_HATCH_CLASS` 단일 사용 const inline (`code-style.md` §Single-Use Extraction Rules)
  - cover `<img>`에 `fetchPriority="high"` 추가 (LCP 우선순위 명시)
  - project title `<h2>` → `<h3>` (`_index.tsx` 섹션 `<h2 id="featured-heading">`와의 heading 계층 정합)
- **FeaturedProjectCard.test.tsx**: `getByRole("heading", { level: 2 })` → `level: 3` 동기화
- **RecentPostsList.tsx**: 5개 className const inline (`ROW_LINK/DATE/TITLE/META_CLASS`, `GHOST_BTN_CLASS`)
- **HeroWhoami.tsx**: `BTN_DEFAULT/PRIMARY/GHOST` 3개 inline (`BTN_BASE`는 3 use이므로 유지)
- **Footer.tsx**: `CURRENT_YEAR` 상수 inline
- **Topbar.tsx**: 비활성화 검색 버튼 a11y 개선
  - `disabled` HTML 속성 제거 (focus 가능, screen reader 인지 가능)
  - `onClick={(e) => e.preventDefault()}` 추가
  - `aria-label "검색 (T016에서 활성화)"` → `"검색 (준비 중)"` (사용자에게 task ID 노출 제거)
  - `aria-disabled="true"` 유지

## Skipped (사용자 승인)

- **P1-2** `MdxRenderer` `Map<string, Component>` 캐시 — measured cost 없음 (React 19 Compiler 정책 부합), 현 상태 유지 valid
- **P1-4** X/RSS `href="#"` placeholder — F018 SEO task에서 RSS 활성화 시 함께 처리

## Out of Scope

- `_index.tsx` 이중 `<main>` 중첩
- `MdxRenderer` 호출처 (loader) 보안 검증
- `useTheme.ts` SSR fallback inconsistency

## Test plan

- [x] `bun run lint` — pass (Biome, 109 files)
- [x] `bun run typecheck` — pass (wrangler types + RR typegen + tsc -b)
- [x] `bun run test` — 24 files / 118 tests pass
- [x] code-reviewer 후속 delta-review — No P0/P1 findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #40