### PR TITLE
✨ feat: T014a Blog Page (F006) + RSS Resource Route (F012)

### DIFF
--- a/app/application/feed/services/__tests__/build-rss-feed.service.test.ts
+++ b/app/application/feed/services/__tests__/build-rss-feed.service.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "vitest";
+import type { Post } from "~/domain/post/post.entity";
+import { buildRssFeed } from "../build-rss-feed.service";
+
+describe("buildRssFeed", () => {
+	const posts: Post[] = [
+		{ slug: "post-a", title: "글 A", lede: "요약 A", date: "2026-04-28", tags: ["solo"], read: 3 },
+		{
+			slug: "post-b",
+			title: "글 B & <C>",
+			lede: "요약 B",
+			date: "2026-04-20",
+			tags: ["ops"],
+			read: 5,
+		},
+		{ slug: "post-c", title: "글 C", lede: "요약 C", date: "2026-04-10", tags: [], read: 2 },
+	];
+
+	it("RSS 2.0 well-formed XML을 반환한다", () => {
+		// Arrange & Act
+		const result = buildRssFeed(posts);
+
+		// Assert
+		expect(result.startsWith('<?xml version="1.0" encoding="UTF-8"?>')).toBe(true);
+		expect(result).toContain('<rss version="2.0"');
+		expect(result).toContain("<channel>");
+		expect(result).toContain("<title>tkstar.dev</title>");
+		expect(result).toContain("<link>https://tkstar.dev/blog</link>");
+		expect(result).toContain("<description>");
+	});
+
+	it("item 개수가 입력한 posts 길이와 동일하다", () => {
+		// Arrange & Act
+		const result = buildRssFeed(posts);
+
+		// Assert
+		const itemMatches = result.match(/<item>/g);
+		expect(itemMatches).not.toBeNull();
+		expect(itemMatches).toHaveLength(3);
+	});
+
+	it("XML 특수문자를 escape 처리한다", () => {
+		// Arrange
+		const specialPost = posts[1];
+
+		// Act
+		const result = buildRssFeed([specialPost]);
+
+		// Assert
+		expect(result).toContain("&amp;");
+		expect(result).toContain("&lt;");
+		expect(result).not.toContain("글 B & <C>");
+	});
+
+	it("pubDate가 RFC 822 형식으로 출력된다", () => {
+		// Arrange
+		const postA = posts[0];
+		const expectedDateFragment = new Date("2026-04-28").toUTCString().slice(0, 16); // "Tue, 28 Apr 2026"
+
+		// Act
+		const result = buildRssFeed([postA]);
+
+		// Assert
+		expect(result).toContain("<pubDate>");
+		expect(result).toContain(expectedDateFragment);
+	});
+
+	it("item link와 guid가 절대 URL로 출력된다", () => {
+		// Arrange
+		const postA = posts[0];
+
+		// Act
+		const result = buildRssFeed([postA]);
+
+		// Assert
+		expect(result).toContain("<link>https://tkstar.dev/blog/post-a</link>");
+		expect(result).toContain("<guid>https://tkstar.dev/blog/post-a</guid>");
+	});
+
+	it("빈 posts 배열 입력 시 item 없이 channel을 반환한다", () => {
+		// Arrange & Act
+		const result = buildRssFeed([]);
+
+		// Assert
+		expect(result).toContain("<channel>");
+		expect(result).not.toContain("<item>");
+	});
+});

--- a/app/application/feed/services/build-rss-feed.service.ts
+++ b/app/application/feed/services/build-rss-feed.service.ts
@@ -1,0 +1,42 @@
+import type { Post } from "~/domain/post/post.entity";
+
+const SITE_URL = "https://tkstar.dev";
+const SITE_TITLE = "tkstar.dev";
+const SITE_DESC = "1인 기업(개발자) 개인 브랜드 사이트";
+
+const escapeXml = (s: string): string =>
+	s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+
+const toRfc822 = (iso: string): string => new Date(iso).toUTCString();
+
+export const buildRssFeed = (posts: Post[]): string => {
+	const items = posts
+		.map((p) => {
+			const url = `${SITE_URL}/blog/${p.slug}`;
+			return [
+				"    <item>",
+				`      <title>${escapeXml(p.title)}</title>`,
+				`      <link>${url}</link>`,
+				`      <description>${escapeXml(p.lede)}</description>`,
+				`      <pubDate>${toRfc822(p.date)}</pubDate>`,
+				`      <guid>${url}</guid>`,
+				"    </item>",
+			].join("\n");
+		})
+		.join("\n");
+
+	return [
+		'<?xml version="1.0" encoding="UTF-8"?>',
+		'<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">',
+		"  <channel>",
+		`    <title>${SITE_TITLE}</title>`,
+		`    <link>${SITE_URL}/blog</link>`,
+		`    <description>${SITE_DESC}</description>`,
+		`    <atom:link href="${SITE_URL}/rss.xml" rel="self" type="application/rss+xml"/>`,
+		items,
+		"  </channel>",
+		"</rss>",
+	]
+		.filter(Boolean)
+		.join("\n");
+};

--- a/app/infrastructure/config/__tests__/container.test.ts
+++ b/app/infrastructure/config/__tests__/container.test.ts
@@ -32,8 +32,10 @@ vi.mock("#content", () => ({
 			slug: "post-1",
 			title: "Post 1",
 			summary: "Post 1 요약",
+			lede: "Post 1 lede",
 			date: "2026-04-20T00:00:00.000Z",
 			tags: ["x"],
+			read: 3,
 			cover: undefined,
 			body: "",
 		},
@@ -41,8 +43,10 @@ vi.mock("#content", () => ({
 			slug: "post-2",
 			title: "Post 2",
 			summary: "Post 2 요약",
+			lede: "Post 2 lede",
 			date: "2026-04-21T00:00:00.000Z",
 			tags: ["y"],
+			read: 5,
 			cover: undefined,
 			body: "",
 		},
@@ -56,7 +60,7 @@ import { buildContainer, type Container } from "../container";
 describe("buildContainer", () => {
 	const env = {} as Env;
 
-	it("Container에 6개 service 함수가 모두 노출된다", () => {
+	it("Container에 7개 service 함수가 모두 노출된다", () => {
 		const c = buildContainer(env);
 		const keys: (keyof Container)[] = [
 			"listProjects",
@@ -65,6 +69,7 @@ describe("buildContainer", () => {
 			"listPosts",
 			"getPostDetail",
 			"getRecentPosts",
+			"buildRssFeed",
 		];
 		for (const k of keys) {
 			expect(typeof c[k]).toBe("function");
@@ -127,6 +132,19 @@ describe("buildContainer", () => {
 			expect(result.post.slug).toBe("post-2");
 			expect(result.prev).toBeNull();
 			expect(result.next?.slug).toBe("post-1");
+		});
+	});
+
+	describe("feed services delegation", () => {
+		it("buildRssFeed는 모든 post를 포함한 RSS 2.0 XML을 반환한다", async () => {
+			const c = buildContainer(env);
+			const xml = await c.buildRssFeed();
+			expect(xml.startsWith('<?xml version="1.0" encoding="UTF-8"?>')).toBe(true);
+			expect(xml).toContain('<rss version="2.0"');
+			const itemMatches = xml.match(/<item>/g);
+			expect(itemMatches).toHaveLength(2);
+			expect(xml).toContain("<link>https://tkstar.dev/blog/post-1</link>");
+			expect(xml).toContain("<link>https://tkstar.dev/blog/post-2</link>");
 		});
 	});
 });

--- a/app/infrastructure/config/container.ts
+++ b/app/infrastructure/config/container.ts
@@ -6,6 +6,7 @@ import { getProjectDetail } from "~/application/content/services/get-project-det
 import { getRecentPosts } from "~/application/content/services/get-recent-posts.service";
 import { listPosts } from "~/application/content/services/list-posts.service";
 import { listProjects } from "~/application/content/services/list-projects.service";
+import { buildRssFeed } from "~/application/feed/services/build-rss-feed.service";
 import type { Post } from "~/domain/post/post.entity";
 import type { Project } from "~/domain/project/project.entity";
 import { velitePostRepository } from "~/infrastructure/content/velite-post.repository";
@@ -20,6 +21,7 @@ export type Container = {
 	listPosts: (opts?: { tag?: string }) => Promise<Post[]>;
 	getPostDetail: (slug: string) => Promise<{ post: Post; prev: Post | null; next: Post | null }>;
 	getRecentPosts: (n: number) => Promise<Post[]>;
+	buildRssFeed: () => Promise<string>;
 };
 
 export const buildContainer = (_env: Env): Container => {
@@ -32,5 +34,6 @@ export const buildContainer = (_env: Env): Container => {
 		listPosts: (opts) => listPosts(postRepo, opts),
 		getPostDetail: (slug) => getPostDetail(postRepo, slug),
 		getRecentPosts: (n) => getRecentPosts(postRepo, n),
+		buildRssFeed: async () => buildRssFeed(await postRepo.findAll()),
 	};
 };

--- a/app/presentation/components/post/PostRow.tsx
+++ b/app/presentation/components/post/PostRow.tsx
@@ -1,0 +1,40 @@
+import { Link } from "react-router";
+
+import type { Post } from "../../../domain/post/post.entity";
+import { formatYearMonth } from "../../lib/format";
+
+type Props = { post: Post };
+
+export default function PostRow({ post }: Props) {
+	return (
+		<Link
+			to={`/blog/${post.slug}`}
+			data-testid="post-row"
+			className="grid grid-cols-[1fr_auto] items-baseline gap-2.5 border-line border-b border-dashed py-3.5 font-mono text-[13px] text-fg no-underline transition-colors duration-[var(--duration-120)] ease-out hover:text-accent focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent motion-reduce:transition-none min-[720px]:grid-cols-[72px_1fr_minmax(0,200px)_60px]"
+		>
+			<span className="hidden text-[11px] text-muted min-[720px]:inline">
+				{formatYearMonth(post.date)}
+			</span>
+			<div className="flex flex-col gap-0.5">
+				<span className="font-mono text-[11px] text-accent min-[720px]:hidden">
+					{formatYearMonth(post.date)}
+				</span>
+				<span className="font-semibold text-fg">{post.title}</span>
+				<span className="text-[11px] text-muted">{post.lede}</span>
+			</div>
+			<div className="flex flex-wrap justify-end gap-1.5">
+				{post.tags.map((t) => (
+					<span
+						key={t}
+						className="inline-block rounded-full border border-line-strong px-2 py-0.5 font-mono text-[11px] text-muted tracking-[0.02em]"
+					>
+						{t}
+					</span>
+				))}
+			</div>
+			<span className="hidden text-right text-[11px] text-muted min-[720px]:inline">
+				{post.read} min
+			</span>
+		</Link>
+	);
+}

--- a/app/presentation/components/post/__tests__/PostRow.test.tsx
+++ b/app/presentation/components/post/__tests__/PostRow.test.tsx
@@ -1,0 +1,49 @@
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
+import { describe, expect, it } from "vitest";
+
+import type { Post } from "../../../../domain/post/post.entity";
+
+import PostRow from "../PostRow";
+
+const mockPost: Post = {
+	slug: "example-post",
+	title: "Example Post",
+	lede: "A short lede of the post.",
+	date: "2026-04-28",
+	tags: ["solo", "ops"],
+	read: 3,
+};
+
+describe("PostRow", () => {
+	it("date(YYYY-MM), title, lede, tags, read 필드를 모두 렌더한다", () => {
+		// Arrange / Act
+		render(
+			<MemoryRouter>
+				<PostRow post={mockPost} />
+			</MemoryRouter>,
+		);
+
+		// Assert
+		expect(screen.getAllByText("2026-04")).not.toHaveLength(0);
+		expect(screen.getByText("Example Post")).toBeInTheDocument();
+		expect(screen.getByText(/A short lede/)).toBeInTheDocument();
+		expect(screen.getByText("solo")).toBeInTheDocument();
+		expect(screen.getByText("ops")).toBeInTheDocument();
+		expect(screen.getByText(/3\s*min/)).toBeInTheDocument();
+	});
+
+	it("행 컨테이너가 /blog/{slug}로 향하는 Link이다", () => {
+		// Arrange / Act
+		render(
+			<MemoryRouter>
+				<PostRow post={mockPost} />
+			</MemoryRouter>,
+		);
+
+		// Assert
+		const row = screen.getByTestId("post-row");
+		expect(row.tagName).toBe("A");
+		expect(row).toHaveAttribute("href", "/blog/example-post");
+	});
+});

--- a/app/presentation/lib/chrome-links.ts
+++ b/app/presentation/lib/chrome-links.ts
@@ -10,10 +10,10 @@ export const TOPBAR_LINKS: ChromeLink[] = [
 	{ label: "blog", href: "/blog" },
 ];
 
-// TODO: X / RSS placeholder — T0xx에서 실 URL 확정 시 교체. external: true로 두어 SPA navigation 회피.
+// TODO: X placeholder — T0xx에서 실 URL 확정 시 교체. external: true로 두어 SPA navigation 회피.
 export const FOOTER_LINKS: ChromeLink[] = [
 	{ label: "GitHub", href: "https://github.com/onepunch-tk", external: true },
 	{ label: "X", href: "#", external: true },
-	{ label: "RSS", href: "#", external: true },
+	{ label: "RSS", href: "/rss.xml", external: true },
 	{ label: "Contact", href: "/contact" },
 ];

--- a/app/presentation/routes/__tests__/blog._index.test.tsx
+++ b/app/presentation/routes/__tests__/blog._index.test.tsx
@@ -1,0 +1,172 @@
+import { render, screen } from "@testing-library/react";
+import { createRoutesStub } from "react-router";
+import { describe, expect, it, vi } from "vitest";
+
+import type { Post } from "../../../domain/post/post.entity";
+
+import BlogIndex, { loader } from "../blog._index";
+
+const mockPosts: Post[] = [
+	{
+		slug: "alpha",
+		title: "Alpha Post",
+		lede: "alpha lede",
+		date: "2026-04-28",
+		tags: ["solo", "ops"],
+		read: 3,
+	},
+	{
+		slug: "beta",
+		title: "Beta Post",
+		lede: "beta lede",
+		date: "2026-04-20",
+		tags: ["solo"],
+		read: 5,
+	},
+	{
+		slug: "gamma",
+		title: "Gamma Post",
+		lede: "gamma lede",
+		date: "2026-04-10",
+		tags: ["ops"],
+		read: 2,
+	},
+];
+
+const makeMockContext = (filtered: Post[] = mockPosts, all: Post[] = mockPosts) => {
+	const listPosts = vi
+		.fn()
+		.mockImplementation((opts?: { tag?: string }) =>
+			Promise.resolve(opts?.tag !== undefined ? filtered : all),
+		);
+	return {
+		context: {
+			container: {
+				listProjects: vi.fn(),
+				getProjectDetail: vi.fn(),
+				getFeaturedProject: vi.fn(),
+				listPosts,
+				getPostDetail: vi.fn(),
+				getRecentPosts: vi.fn(),
+				buildRssFeed: vi.fn(),
+			},
+			cloudflare: { env: {}, ctx: {} },
+		},
+		spies: { listPosts },
+	};
+};
+
+// ---------------------------------------------------------------------------
+// Group A — Loader
+// ---------------------------------------------------------------------------
+
+describe("Group A — blog._index loader", () => {
+	it("?tag=foo → listPosts가 두 번 호출, 첫 호출 {tag:'foo'}, 두 번째 인자 없음", async () => {
+		// Arrange
+		const { context, spies } = makeMockContext([mockPosts[0]], mockPosts);
+
+		// Act
+		await loader({
+			context,
+			request: new Request("http://localhost/blog?tag=foo"),
+		} as never);
+
+		// Assert
+		expect(spies.listPosts).toHaveBeenCalledTimes(2);
+		expect(spies.listPosts).toHaveBeenNthCalledWith(1, { tag: "foo" });
+		expect(spies.listPosts).toHaveBeenNthCalledWith(2);
+	});
+
+	it("반환 객체는 {posts, allTags(unique sorted), activeTag}", async () => {
+		// Arrange
+		const { context } = makeMockContext();
+
+		// Act
+		const result = await loader({
+			context,
+			request: new Request("http://localhost/blog?tag=solo"),
+		} as never);
+
+		// Assert
+		expect(result.activeTag).toBe("solo");
+		expect(result.allTags).toEqual(["ops", "solo"]);
+		expect(result.posts).toHaveLength(3);
+	});
+
+	it("tag 파라미터 없으면 activeTag는 null", async () => {
+		// Arrange
+		const { context } = makeMockContext();
+
+		// Act
+		const result = await loader({
+			context,
+			request: new Request("http://localhost/blog"),
+		} as never);
+
+		// Assert
+		expect(result.activeTag).toBeNull();
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Group B — UI
+// ---------------------------------------------------------------------------
+
+describe("Group B — blog._index UI", () => {
+	it("post-row가 mockPosts 길이만큼 렌더된다", async () => {
+		// Arrange
+		const Stub = createRoutesStub([
+			{
+				path: "/blog",
+				Component: BlogIndex,
+				loader: () => ({ posts: mockPosts, allTags: ["a", "b"], activeTag: null }),
+			},
+		]);
+
+		// Act
+		render(<Stub initialEntries={["/blog"]} />);
+
+		// Assert
+		await screen.findByText("Alpha Post");
+		expect(screen.getAllByTestId("post-row")).toHaveLength(3);
+	});
+
+	it("빈 결과 + activeTag 'x' → empty-state + 'No matches.' 텍스트", async () => {
+		// Arrange
+		const Stub = createRoutesStub([
+			{
+				path: "/blog",
+				Component: BlogIndex,
+				loader: () => ({ posts: [], allTags: ["a"], activeTag: "x" }),
+			},
+		]);
+
+		// Act
+		render(<Stub initialEntries={["/blog?tag=x"]} />);
+
+		// Assert
+		await screen.findByTestId("empty-state");
+		expect(screen.getByText(/No matches\./)).toBeInTheDocument();
+	});
+
+	it("페이지 헤더에 '$ ls -la blog/' 라인이 1번 노출", async () => {
+		// Arrange
+		const Stub = createRoutesStub([
+			{
+				path: "/blog",
+				Component: BlogIndex,
+				loader: () => ({ posts: mockPosts, allTags: [], activeTag: null }),
+			},
+		]);
+
+		// Act
+		render(<Stub initialEntries={["/blog"]} />);
+
+		// Assert
+		await screen.findByText("Alpha Post");
+		const headers = screen
+			.getAllByRole("heading", { level: 1 })
+			.filter((el) => /\$\s*ls -la blog\//.test(el.textContent ?? ""));
+		expect(headers).toHaveLength(1);
+	});
+});

--- a/app/presentation/routes/__tests__/rss.test.ts
+++ b/app/presentation/routes/__tests__/rss.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { loader } from "../rss[.xml]";
+
+const makeContext = (xml: string) => {
+	const buildRssFeed = vi.fn().mockResolvedValue(xml);
+	return {
+		context: {
+			container: {
+				listProjects: vi.fn(),
+				getProjectDetail: vi.fn(),
+				getFeaturedProject: vi.fn(),
+				listPosts: vi.fn(),
+				getPostDetail: vi.fn(),
+				getRecentPosts: vi.fn(),
+				buildRssFeed,
+			},
+			cloudflare: { env: {}, ctx: {} },
+		},
+		spies: { buildRssFeed },
+	};
+};
+
+describe("rss[.xml] loader", () => {
+	it("Content-Type 헤더가 application/xml로 설정된다", async () => {
+		const { context } = makeContext('<?xml version="1.0"?><rss></rss>');
+
+		const res = await loader({ context } as never);
+
+		expect(res.headers.get("Content-Type")).toMatch(/^application\/xml/);
+	});
+
+	it("응답 body가 <?xml로 시작한다", async () => {
+		const { context } = makeContext('<?xml version="1.0"?><rss></rss>');
+
+		const res = await loader({ context } as never);
+		const body = await res.text();
+
+		expect(body.startsWith("<?xml")).toBe(true);
+	});
+
+	it("container.buildRssFeed()에 위임한다", async () => {
+		const { context, spies } = makeContext('<?xml version="1.0"?><rss></rss>');
+
+		await loader({ context } as never);
+
+		expect(spies.buildRssFeed).toHaveBeenCalledOnce();
+	});
+});

--- a/app/presentation/routes/blog._index.tsx
+++ b/app/presentation/routes/blog._index.tsx
@@ -1,12 +1,61 @@
-import type { MetaFunction } from "react-router";
+import PostRow from "../components/post/PostRow";
+import TagFilterChips from "../components/project/TagFilterChips";
 
-export const meta: MetaFunction = () => [{ title: "Blog — tkstar.dev" }];
+import type { Route } from "./+types/blog._index";
 
-export default function BlogIndex() {
+export const meta: Route.MetaFunction = () => [{ title: "Blog — tkstar.dev" }];
+
+export const loader = async ({ context, request }: Route.LoaderArgs) => {
+	const url = new URL(request.url);
+	const tag = url.searchParams.get("tag") ?? undefined;
+	const [posts, all] = await Promise.all([
+		context.container.listPosts({ tag }),
+		context.container.listPosts(),
+	]);
+	const allTags = Array.from(new Set(all.flatMap((p) => p.tags))).sort();
+	return { posts, allTags, activeTag: tag ?? null };
+};
+
+export default function BlogIndex({ loaderData }: Route.ComponentProps) {
+	const { posts, allTags, activeTag } = loaderData;
 	return (
-		<main className="container mx-auto p-4">
-			<h1 className="text-2xl font-semibold">Blog</h1>
-			<p>placeholder — list lands in T014a.</p>
+		<main className="mx-auto flex max-w-[var(--container-measure)] flex-col gap-[22px] px-[var(--spacing-gutter)] pt-[22px] pb-20 min-[720px]:gap-7 min-[720px]:px-7 min-[720px]:pt-9 min-[720px]:pb-[120px]">
+			<header className="flex flex-col gap-2">
+				<h1 className="flex items-center gap-2 m-0 font-mono text-[11px] tracking-[0.12em] uppercase text-muted">
+					<span aria-hidden="true" className="text-accent">
+						$
+					</span>
+					<span>ls -la blog/</span>
+					<span aria-hidden="true" className="h-px flex-1 bg-line" />
+				</h1>
+				<p className="font-mono text-[12px] text-faint">
+					total {posts.length} · velite collection · sorted by date desc
+				</p>
+			</header>
+
+			<TagFilterChips tags={allTags} activeTag={activeTag} />
+
+			{posts.length === 0 ? (
+				<div data-testid="empty-state" className="flex flex-col gap-1 font-mono text-[12px]">
+					<div className="text-muted">$ grep -l 'tag:{activeTag ?? "*"}' posts/*.mdx</div>
+					<div className="text-faint">No matches.</div>
+				</div>
+			) : (
+				<div className="flex flex-col">
+					<div
+						aria-hidden="true"
+						className="hidden border-line-strong border-b-[1.5px] py-1 font-mono text-[11px] text-faint tracking-[0.08em] uppercase min-[720px]:grid min-[720px]:grid-cols-[72px_1fr_minmax(0,200px)_60px] min-[720px]:gap-2.5"
+					>
+						<span>date</span>
+						<span>title · lede</span>
+						<span className="text-right">tags</span>
+						<span className="text-right">read</span>
+					</div>
+					{posts.map((p) => (
+						<PostRow key={p.slug} post={p} />
+					))}
+				</div>
+			)}
 		</main>
 	);
 }

--- a/app/presentation/routes/rss[.xml].tsx
+++ b/app/presentation/routes/rss[.xml].tsx
@@ -1,7 +1,8 @@
-export const loader = () => {
-	const body = `<?xml version="1.0" encoding="UTF-8"?>
-<rss version="2.0"><channel><title>tkstar.dev</title></channel></rss>`;
-	return new Response(body, {
+import type { Route } from "./+types/rss[.xml]";
+
+export const loader = async ({ context }: Route.LoaderArgs) => {
+	const xml = await context.container.buildRssFeed();
+	return new Response(xml, {
 		headers: { "Content-Type": "application/xml; charset=utf-8" },
 	});
 };

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -313,7 +313,7 @@ tkstarDev는 다음 핵심 가치를 단일 도메인에서 달성한다:
   - 가정 해소: A002 완료
   - PR 1개 / 브랜치: `feature/issue-N-project-detail`
 
-- [ ] **Task 014a: Blog Page (F006) — 목록 + 태그 필터 + RSS Resource Route (F012)**
+- [x] **Task 014a: Blog Page (F006) — 목록 + 태그 필터 + RSS Resource Route (F012)** — 완료 (2026-04-30, PR #48)
   - **Must** Read: [tasks/T014a-blog-list-rss.md](tasks/T014a-blog-list-rss.md)
   - blockedBy: Task 005, Task 007, Task 008, Task 009
   - blocks: Task 014b, Task 018 (OG)

--- a/docs/tasks/T014a-blog-list-rss.md
+++ b/docs/tasks/T014a-blog-list-rss.md
@@ -5,13 +5,13 @@
 | **Task ID** | T014a |
 | **Phase** | Phase 3 — Core Pages UI |
 | **Layer** | Presentation + Application(`build-rss-feed.service`) + Resource Route |
-| **Branch** | `feature/issue-N-blog-list-rss` |
+| **Branch** | `feature/issue-48-blog-list-rss` |
 | **Depends on** | T005, T007, T008, T009 |
 | **Blocks** | T014b, T018 |
 | **PRD Features** | **F006** (Blog 목록), **F012** (RSS) |
 | **PRD AC** | — (UI 표시 + RSS XML well-formed) |
 | **예상 작업 시간** | 1d |
-| **Status** | Not Started |
+| **Status** | Completed |
 
 ## Goal
 `/blog` 목록 페이지를 발행일 역순 + 태그 필터 + 행 형태로 구현하고, `/rss.xml` 리소스 라우트가 RSS 2.0 well-formed XML을 반환하게 한다. T014b(Blog Detail)의 사전 단계.
@@ -36,12 +36,12 @@
 - 페이지별 meta export (T019)
 
 ## Acceptance Criteria
-- [ ] `/blog` 진입 시 모든 post가 발행일 역순으로 행 형태로 렌더
-- [ ] 각 행에 제목, date, lede, tags, read 표시
-- [ ] 태그 칩 클릭 시 URL `?tag=<tag>` 변경 + 필터링 결과
-- [ ] `/rss.xml` 응답이 RSS 2.0 well-formed XML, `<rss version="2.0">`, `<channel>`, `<title>`, `<link>`, `<description>`, `<item>{title,link,description,pubDate,guid}` 포함
-- [ ] item 수 = 모든 post 수
-- [ ] `Content-Type: application/xml` 헤더
+- [x] `/blog` 진입 시 모든 post가 발행일 역순으로 행 형태로 렌더
+- [x] 각 행에 제목, date, lede, tags, read 표시
+- [x] 태그 칩 클릭 시 URL `?tag=<tag>` 변경 + 필터링 결과
+- [x] `/rss.xml` 응답이 RSS 2.0 well-formed XML, `<rss version="2.0">`, `<channel>`, `<title>`, `<link>`, `<description>`, `<item>{title,link,description,pubDate,guid}` 포함
+- [x] item 수 = 모든 post 수
+- [x] `Content-Type: application/xml` 헤더
 
 ## Implementation Plan (TDD Cycle)
 
@@ -127,4 +127,4 @@
 ## Change History
 | Date | Changes | Author |
 |------|---------|--------|
-| - | - | - |
+| 2026-04-30 | T014a 완료 — 5 TDD cycles (build-rss-feed service / Container / rss route / PostRow / blog._index) + 17 tests Green. Phase 3 code-review/design-review 0 blocking issues. PR #48 squash merge 대기. | TaekyungHa |


### PR DESCRIPTION
## Summary

T014a 완료 — `/blog` 목록 페이지 + `/rss.xml` resource route. T014b(Blog Detail)의 사전 단계.

- **F006 Blog 목록**: 발행일 역순 행 리스트(date | title+lede | tags | read 4-column) + 태그 필터 (`TagFilterChips` 재사용)
- **F012 RSS**: RSS 2.0 well-formed XML, `Content-Type: application/xml`, `<item>` per post, RFC 822 pubDate, XML escape (`&`, `<`, `>`)
- **Footer RSS link fix**: 기존 `href="#"` placeholder → `/rss.xml` 실 경로 연결 (T011 잔여 TODO 해소)

Closes #48

## 구현 노트

- **CA layering**: `build-rss-feed.service.ts` (Application/feed) — pure function, Domain Post entity만 의존. Container가 `postRepo.findAll()` 결과를 Application service에 주입.
- **Surgical Changes**: `TagFilterChips`는 T012에서 이미 generic — `project/`에서 직접 import 재사용. PostRow는 ProjectRow 스타일 1:1 시각 미러.
- **velite cache 활용**: `velitePostRepository.findAll()`가 module-import 시점에 `Object.freeze(sortByDateDesc(posts.map(toPost)))` 캐시. RSS 매 요청 sort/map 재실행 없음.
- **Site URL**: `https://tkstar.dev` 모듈 상수 하드코딩 (env 분리는 미래 task로 deferral).

## Test plan

- [x] `bun run test` — 41 files / 189 tests Green (신규 17 tests: build-rss-feed 6, container 1, rss 3, PostRow 2, blog._index 6)
- [x] `bun run typecheck` — exit 0
- [x] `bun run lint` — exit 0, 0 warnings
- [x] Phase 3 code-reviewer — 0 blocking (CA / OWASP A03 / Surgical Changes 모두 통과)
- [x] Phase 3 ux-design-lead — 0 blocking (ProjectRow ↔ PostRow 1:1 시각 미러 + 다크모드 토큰 100% 일관)
- [x] 수동 검증: `bun run dev` `/blog` 행 리스트 + `/rss.xml` XML 트리 + footer RSS 링크 정상 동작

## 후속 (out-of-scope)

- T014b — Blog Detail Page (F007, 본 PR이 unblock)
- 모바일에서 `read min` 노출 여부 (design-review S1, advisory)
- `?tag=` 빈값 normalize (code-review A1, projects._index와 통합 chore)
- Footer X 링크 (별도 task에서 SNS 핸들 확정 시 교체)

🤖 Generated with [Claude Code](https://claude.com/claude-code)