### PR TITLE
📝 docs: SafeAreaView coding rules (background flicker + app-wide avoidance)

### DIFF
--- a/.claude/rules/glossary-expo.md
+++ b/.claude/rules/glossary-expo.md
@@ -17,7 +17,7 @@ applies_to: expo-sdk-50+ / react-native
 | **EAS Build** | Cloud build service (`eas.json`). Distinct profiles for `development` / `preview` / `production`. Triggered by `eas build`. |
 | **EAS Update** | OTA update channel for JS/asset updates without a store release. Tied to a build's `runtimeVersion`. |
 | **`useNavigation()` / `router`** | Two ways to navigate in Expo Router. Prefer `router.push('/path')` for explicit paths; `useNavigation()` for advanced gestures. |
-| **`SafeAreaView` / `useSafeAreaInsets`** | From `react-native-safe-area-context`. Pad against notch/home-indicator. Mandatory on top-level screens. |
+| **`SafeAreaView` / `useSafeAreaInsets`** | From `react-native-safe-area-context`. Pad against notch/home-indicator. Mandatory on top-level screens. **Coding rules: see design-system skill §3.1 "SafeAreaView background color" / "App-wide SafeAreaView avoidance" and §3.5 review checklist.** |
 | **Reanimated Worklet** | A JS function with `'worklet'` directive that runs on the UI thread. Required for 60fps gesture/scroll animations. |
 | **Hermes** | JS engine on iOS/Android. Already default in modern Expo. Affects stack traces and performance profiling. |
 | **`expo-constants`** | Source of truth for app metadata (`Constants.expoConfig`). Read at runtime instead of hard-coding versions. |

--- a/.claude/skills/design-system/SKILL.md
+++ b/.claude/skills/design-system/SKILL.md
@@ -218,6 +218,70 @@ const styles = StyleSheet.create((theme, rt) => ({
 - **Cross-component sharing** — extract a `variants`-driven reusable component. Do NOT import a shared `StyleSheet` across components; Unistyles optimizes per-instance and shared imports lose that path.
 - **Token access** — theme closure (`(theme, rt) => ...`) or the bridge `tokens` import. Never string-key lookups.
 
+#### SafeAreaView background color (MUST)
+
+`react-native-safe-area-context`'s `SafeAreaView` is a regular View that receives insets from a native shadow view and applies them as Yoga padding/margin. On the first batch layout, insets are undefined; only after `didMoveToWindow` does the second layout pass apply the inseted padding (official docs: *"insets are not updated synchronously"*). Putting a static color like `backgroundColor` directly on SafeAreaView makes the painted box itself depend on inset values, so the colored region expands on the second frame and produces visible flicker.
+
+❌ **Anti-pattern** — SafeAreaView doubles as the painted box:
+
+```tsx
+<SafeAreaView style={styles.screen}>{children}</SafeAreaView>
+
+const styles = StyleSheet.create((theme) => ({
+  screen: { flex: 1, backgroundColor: theme.colors.background },
+}))
+```
+
+✅ **Fix A (preferred)** — parent View paints the color, SafeAreaView only handles insets:
+
+```tsx
+<View style={styles.bg}>
+  <SafeAreaView style={styles.safe}>{children}</SafeAreaView>
+</View>
+
+const styles = StyleSheet.create((theme) => ({
+  bg: { flex: 1, backgroundColor: theme.colors.background },
+  safe: { flex: 1 },
+}))
+```
+
+✅ **Fix B** — inner View paints the color:
+
+```tsx
+<SafeAreaView style={styles.safe}>
+  <View style={styles.bg}>{children}</View>
+</SafeAreaView>
+
+const styles = StyleSheet.create((theme) => ({
+  safe: { flex: 1 },
+  bg: { flex: 1, backgroundColor: theme.colors.background },
+}))
+```
+
+Evidence:
+- Mechanism (strong): official docs `appandflow.github.io/react-native-safe-area-context/api/safe-area-view`, native source `ios/RNCSafeAreaShadowView.m` L98–134 (`updateInsets` sets `super.paddingTop` to inset value).
+- Async behavior (strong): official docs + Issue #226 contributor comment (*"first batch layout ... children get the same size ... second layout the children will get the inseted (proper) size"*).
+- Color causation (medium): Issue #150 — LinearGradient + SafeAreaView backgroundColor combination shows white flash on first frame under 30x slow-motion.
+
+#### App-wide SafeAreaView avoidance (SHOULD)
+
+React Navigation official recommendation: do NOT wrap the entire screen root in `<SafeAreaView>`; apply `useSafeAreaInsets` padding only on children that need specific edges.
+
+> Note: the stated rationale for this recommendation is **layout stability** (`reactnavigation.org/docs/handling-safe-area`: *"containing safe area is animating, it causes jumpy behavior"*), NOT color flicker. This is a separate guideline from Rule 1 (SafeAreaView background color above).
+
+✅ **Recommended**:
+
+```tsx
+const insets = useSafeAreaInsets()
+return (
+  <View style={[styles.bg, { paddingTop: insets.top }]}>
+    {/* only children that need an edge receive insets */}
+  </View>
+)
+```
+
+⚠️ **Do NOT mix** — using the `<SafeAreaView>` component and the `useSafeAreaInsets` hook in the same tree causes flicker because the two sources update at different times (RN Nav official warning). Use only one approach within a single screen.
+
 ### 3.2 Vanilla React Native (no Unistyles)
 
 Same rule — `StyleSheet.create` at module top-level, token imports only, no inline objects except for runtime-computed values.
@@ -247,6 +311,8 @@ When running REVIEW mode's **Visual Consistency** and **Component Composition** 
 **Stack-specific:**
 - [ ] (Expo+RN + Unistyles) Theme value pulled via a string key instead of the typed theme closure argument.
 - [ ] (Expo+RN + Unistyles) Conditional style solved by object merging instead of `variants(...)` call syntax.
+- [ ] (Expo+RN) `backgroundColor` or any dynamic color style applied directly on `<SafeAreaView>` — padding is applied on the second layout pass, so the colored region expands late and causes flicker. Move color to a parent or child View (see §3.1 SafeAreaView background color).
+- [ ] (Expo+RN) Entire screen root wrapped in `<SafeAreaView>` — prefer per-edge application via `useSafeAreaInsets` (see §3.1 App-wide SafeAreaView avoidance). Do NOT mix the `SafeAreaView` component and the `useSafeAreaInsets` hook in the same screen.
 - [ ] (NativeWind) `style={{}}` used where className could express the value (tokens bypassed).
 - [ ] (Web + Tailwind) Utility classes built via string concatenation in render instead of a `cva` / `clsx` recipe at module scope.
 - [ ] (CSS Modules) Shared style imported across components instead of `composes` or a variant-driven component.


### PR DESCRIPTION
## Summary
- design-system skill §3.1에 SafeAreaView 관련 두 rule 추가
  - **Background color (MUST)**: SafeAreaView는 두번째 layout pass에서 inset padding이 적용 → 자체에 `backgroundColor` 두면 colored region 늦게 확장돼 flicker. 부모/자식 View로 색상 분리해야 함.
  - **App-wide avoidance (SHOULD)**: React Navigation 권장 — screen root 전체 wrap 대신 `useSafeAreaInsets`로 필요한 edge에만 적용. component/hook 같은 tree에서 혼용 금지.
- §3.5 review checklist에 두 rule 검증 항목 추가
- `glossary-expo.md` SafeAreaView 항목에서 §3.1/§3.5로 cross-link

## Test plan
- [ ] design-system SKILL.md REVIEW mode에서 새 checklist 항목이 노출되는지 확인
- [ ] glossary-expo.md SafeAreaView 항목 link가 의도대로 §3.1/§3.5를 지칭하는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)