### PR TITLE
✨ feat: T014b — Blog Detail Page (F007)

### DIFF
--- a/app/app.css
+++ b/app/app.css
@@ -89,16 +89,20 @@ html {
 	}
 }
 
-.project-body {
+/* Long-form MDX body — projects (T013) + posts (T014b) 동일 typography */
+.project-body,
+.post-body {
 	font-family: var(--font-mono);
 	font-size: 14px;
 	line-height: 1.7;
 	color: var(--color-fg);
 }
-.project-body > * + * {
+.project-body > * + *,
+.post-body > * + * {
 	margin-top: 1.1em;
 }
-.project-body h2 {
+.project-body h2,
+.post-body h2 {
 	margin-top: 2em;
 	font-size: 18px;
 	font-weight: 600;
@@ -106,38 +110,47 @@ html {
 	color: var(--color-fg);
 	scroll-margin-top: calc(var(--height-topbar) + 12px);
 }
-.project-body h3 {
+.project-body h3,
+.post-body h3 {
 	margin-top: 1.6em;
 	font-size: 15px;
 	font-weight: 600;
 	color: var(--color-fg);
 }
-.project-body p {
+.project-body p,
+.post-body p {
 	color: var(--color-fg);
 }
-.project-body a {
+.project-body a,
+.post-body a {
 	color: var(--color-accent);
 	text-underline-offset: 3px;
 }
-.project-body a:hover {
+.project-body a:hover,
+.post-body a:hover {
 	text-decoration: underline;
 }
 .project-body ul,
-.project-body ol {
+.project-body ol,
+.post-body ul,
+.post-body ol {
 	padding-left: 1.4em;
 	color: var(--color-fg);
 }
-.project-body li + li {
+.project-body li + li,
+.post-body li + li {
 	margin-top: 0.4em;
 }
-.project-body code {
+.project-body code,
+.post-body code {
 	background: var(--color-bg-elev);
 	border: 1px solid var(--color-line);
 	padding: 0 0.35em;
 	border-radius: 3px;
 	font-size: 0.92em;
 }
-.project-body pre {
+.project-body pre,
+.post-body pre {
 	background: var(--color-bg-elev);
 	border: 1px solid var(--color-line);
 	border-radius: 6px;
@@ -146,13 +159,15 @@ html {
 	font-size: 12.5px;
 	line-height: 1.6;
 }
-.project-body pre code {
+.project-body pre code,
+.post-body pre code {
 	background: none;
 	border: none;
 	padding: 0;
 	font-size: inherit;
 }
-.project-body blockquote {
+.project-body blockquote,
+.post-body blockquote {
 	border-left: 2px solid var(--color-line-strong);
 	padding-left: 1em;
 	color: var(--color-muted);
@@ -195,7 +210,7 @@ html {
 		display: none !important;
 	}
 
-	/* biome-ignore lint/style/noDescendingSpecificity: @media print global h2 — .project-body h2 와 다른 스코프(print-only) 이므로 specificity ordering 무관 */
+	/* biome-ignore lint/style/noDescendingSpecificity: @media print global h2 — .project-body / .post-body h2 와 다른 스코프(print-only) 이므로 specificity ordering 무관 */
 	h2 {
 		break-after: avoid-page;
 		page-break-after: avoid;

--- a/app/domain/post/__tests__/post.schema.test.ts
+++ b/app/domain/post/__tests__/post.schema.test.ts
@@ -34,4 +34,51 @@ describe("postSchema", () => {
 		const result = postSchema.safeParse(rest);
 		expect(result.success).toBe(false);
 	});
+
+	// ---------------------------------------------------------------------------
+	// T014b RED — body / toc optional 필드 검증 (아직 schema에 없으므로 실패)
+	// ---------------------------------------------------------------------------
+
+	it("body + toc 포함 시 parse 통과하고 결과에 body 필드가 있다", () => {
+		// Arrange
+		const input = {
+			...validFrontmatter,
+			body: "mdx-fn-body",
+			toc: [{ slug: "intro", text: "Intro" }],
+		};
+
+		// Act
+		const result = postSchema.safeParse(input);
+
+		// Assert
+		expect(result.success).toBe(true);
+		// body 필드가 parsed 결과에 존재해야 한다 (strip 모드라 추가 없이는 undefined)
+		expect((result.data as Record<string, unknown>).body).toBe("mdx-fn-body");
+	});
+
+	it("toc 미제공 시 parse 통과하고 결과의 toc 는 undefined 이다", () => {
+		// Arrange
+		const input = { ...validFrontmatter };
+
+		// Act
+		const result = postSchema.safeParse(input);
+
+		// Assert
+		expect(result.success).toBe(true);
+		expect((result.data as Record<string, unknown>).toc).toBeUndefined();
+	});
+
+	it("toc 항목이 {slug,text} shape 위반이면 reject 한다", () => {
+		// Arrange — text 없이 slug만 있는 toc 항목
+		const input = {
+			...validFrontmatter,
+			toc: [{ slug: "intro" }], // text 누락 → shape 위반
+		};
+
+		// Act
+		const result = postSchema.safeParse(input);
+
+		// Assert
+		expect(result.success).toBe(false);
+	});
 });

--- a/app/domain/post/post.schema.ts
+++ b/app/domain/post/post.schema.ts
@@ -8,4 +8,6 @@ export const postSchema = z.object({
 	date: zIso8601Date(),
 	tags: z.array(z.string()),
 	read: z.number(),
+	body: z.string().optional(),
+	toc: z.array(z.object({ slug: z.string(), text: z.string() })).optional(),
 });

--- a/app/infrastructure/content/mappers/__tests__/post.mapper.test.ts
+++ b/app/infrastructure/content/mappers/__tests__/post.mapper.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import { toPost } from "../post.mapper";
+
+// ---------------------------------------------------------------------------
+// T014b RED — toPost mapper body/toc passthrough 검증
+// 현재 mapper 는 body/toc 를 drop 하므로 이 테스트들은 실패해야 한다
+// ---------------------------------------------------------------------------
+
+describe("toPost mapper", () => {
+	it("raw 에 body + toc 포함 시 entity 도 body 와 toc 를 가진다", () => {
+		// Arrange
+		const raw = {
+			slug: "test-post",
+			title: "Test Post",
+			lede: "A test lede",
+			date: "2026-05-02",
+			tags: ["test"],
+			read: 3,
+			body: "mdx-fn-body-string",
+			toc: [{ slug: "a", text: "A" }],
+		};
+
+		// Act
+		const entity = toPost(raw) as Record<string, unknown>;
+
+		// Assert
+		expect(entity.body).toBe("mdx-fn-body-string");
+		expect((entity.toc as { slug: string; text: string }[])[0].slug).toBe("a");
+	});
+
+	it("raw 에 toc/body 미제공 시 entity 의 toc 와 body 는 undefined 이다", () => {
+		// Arrange
+		const raw = {
+			slug: "no-toc-post",
+			title: "No Toc Post",
+			lede: "A lede without toc",
+			date: "2026-05-02",
+			tags: ["blog"],
+			read: 5,
+		};
+
+		// Act
+		const entity = toPost(raw) as Record<string, unknown>;
+
+		// Assert
+		expect(entity.toc).toBeUndefined();
+		expect(entity.body).toBeUndefined();
+	});
+});

--- a/app/infrastructure/content/mappers/post.mapper.ts
+++ b/app/infrastructure/content/mappers/post.mapper.ts
@@ -8,6 +8,7 @@ type VelitePostInput = {
 	tags: string[];
 	read: number;
 	body?: string;
+	toc?: { slug: string; text: string }[];
 };
 
 export const toPost = (raw: VelitePostInput): Post => ({
@@ -17,4 +18,6 @@ export const toPost = (raw: VelitePostInput): Post => ({
 	date: raw.date,
 	tags: raw.tags,
 	read: raw.read,
+	body: raw.body,
+	toc: raw.toc,
 });

--- a/app/presentation/components/post/PostFooterNav.tsx
+++ b/app/presentation/components/post/PostFooterNav.tsx
@@ -1,0 +1,43 @@
+import { Link } from "react-router";
+
+type Adjacent = { slug: string; title: string } | null;
+type Props = { prev: Adjacent; next: Adjacent };
+
+export default function PostFooterNav({ prev, next }: Props) {
+	return (
+		<nav
+			data-testid="post-footer-nav"
+			aria-label="Post navigation"
+			className="mt-12 grid grid-cols-3 items-center gap-2 border-line border-t pt-6 min-[720px]:gap-3"
+		>
+			{prev ? (
+				<Link
+					to={`/blog/${prev.slug}`}
+					className="inline-flex min-h-11 items-center justify-self-start font-mono text-[12px] text-muted no-underline transition-colors duration-[var(--duration-120)] ease-out hover:text-fg focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent motion-reduce:transition-none"
+				>
+					← prev · {prev.title}
+				</Link>
+			) : (
+				<span />
+			)}
+
+			<Link
+				to="/blog"
+				className="inline-flex min-h-11 items-center justify-center justify-self-center border border-line px-4 py-2 font-mono text-[12px] text-muted no-underline transition-colors duration-[var(--duration-120)] ease-out hover:border-accent hover:text-accent focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent motion-reduce:transition-none"
+			>
+				[모든 글]
+			</Link>
+
+			{next ? (
+				<Link
+					to={`/blog/${next.slug}`}
+					className="inline-flex min-h-11 items-center justify-self-end text-right font-mono text-[12px] text-muted no-underline transition-colors duration-[var(--duration-120)] ease-out hover:text-fg focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent motion-reduce:transition-none"
+				>
+					{next.title} · next →
+				</Link>
+			) : (
+				<span />
+			)}
+		</nav>
+	);
+}

--- a/app/presentation/components/post/ShareTools.tsx
+++ b/app/presentation/components/post/ShareTools.tsx
@@ -12,7 +12,10 @@ export default function ShareTools({ title, canonicalUrl }: Props) {
 	}, [copied]);
 
 	const onCopy = () => {
-		navigator.clipboard.writeText(canonicalUrl).then(() => setCopied(true));
+		navigator.clipboard
+			.writeText(canonicalUrl)
+			.then(() => setCopied(true))
+			.catch(() => {});
 	};
 
 	const xHref = `https://x.com/intent/post?text=${encodeURIComponent(title)}&url=${encodeURIComponent(canonicalUrl)}`;

--- a/app/presentation/components/post/ShareTools.tsx
+++ b/app/presentation/components/post/ShareTools.tsx
@@ -1,0 +1,46 @@
+import { useEffect, useState } from "react";
+
+type Props = { title: string; canonicalUrl: string };
+
+export default function ShareTools({ title, canonicalUrl }: Props) {
+	const [copied, setCopied] = useState(false);
+
+	useEffect(() => {
+		if (!copied) return;
+		const id = setTimeout(() => setCopied(false), 1500);
+		return () => clearTimeout(id);
+	}, [copied]);
+
+	const onCopy = () => {
+		navigator.clipboard.writeText(canonicalUrl).then(() => setCopied(true));
+	};
+
+	const xHref = `https://x.com/intent/post?text=${encodeURIComponent(title)}&url=${encodeURIComponent(canonicalUrl)}`;
+
+	return (
+		<div className="flex flex-col gap-2 border-line border-t pt-4">
+			<h2 className="m-0 font-mono text-[11px] tracking-[0.12em] uppercase text-muted">share</h2>
+			<div className="flex flex-col gap-1">
+				<button
+					type="button"
+					onClick={onCopy}
+					className="inline-flex min-h-9 items-center justify-start font-mono text-[12px] text-muted no-underline transition-colors duration-[var(--duration-120)] ease-out hover:text-fg focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent motion-reduce:transition-none"
+				>
+					copy link
+				</button>
+				<a
+					href={xHref}
+					target="_blank"
+					rel="noopener noreferrer"
+					aria-label="share on x"
+					className="inline-flex min-h-9 items-center justify-start font-mono text-[12px] text-muted no-underline transition-colors duration-[var(--duration-120)] ease-out hover:text-fg focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent motion-reduce:transition-none"
+				>
+					share on X →
+				</a>
+				<span aria-live="polite" className="font-mono text-[11px] text-accent min-h-[1em]">
+					{copied ? "copied" : ""}
+				</span>
+			</div>
+		</div>
+	);
+}

--- a/app/presentation/components/post/__tests__/PostFooterNav.test.tsx
+++ b/app/presentation/components/post/__tests__/PostFooterNav.test.tsx
@@ -1,0 +1,102 @@
+import { render, screen } from "@testing-library/react";
+import { createRoutesStub } from "react-router";
+import { describe, expect, it } from "vitest";
+
+// ---------------------------------------------------------------------------
+// T014b RED — PostFooterNav 컴포넌트 (아직 없으므로 import 자체 실패 → RED)
+// ---------------------------------------------------------------------------
+
+import PostFooterNav from "../PostFooterNav";
+
+// ---------------------------------------------------------------------------
+// 헬퍼 — createRoutesStub으로 <Link> 렌더를 위한 래퍼 생성
+// ---------------------------------------------------------------------------
+
+type Adjacent = { slug: string; title: string } | null;
+
+const renderNav = (prev: Adjacent, next: Adjacent) => {
+	const Stub = createRoutesStub([
+		{
+			path: "/",
+			Component: () => <PostFooterNav prev={prev} next={next} />,
+		},
+	]);
+	render(<Stub initialEntries={["/"]} />);
+};
+
+// ---------------------------------------------------------------------------
+// PostFooterNav
+// ---------------------------------------------------------------------------
+
+describe("PostFooterNav", () => {
+	it("center 셀에 항상 '[모든 글]' 텍스트와 /blog href 링크가 있다 (prev/next 둘 다 있을 때)", async () => {
+		// Arrange
+		const prev = { slug: "a", title: "A" };
+		const next = { slug: "b", title: "B" };
+
+		// Act
+		renderNav(prev, next);
+
+		// Assert
+		const centerLink = await screen.findByRole("link", { name: /모든 글/i });
+		expect(centerLink).toHaveAttribute("href", "/blog");
+		expect(centerLink.textContent).toContain("[모든 글]");
+	});
+
+	it("prev 가 null 이면 좌측 셀에 link 가 없다", async () => {
+		// Arrange
+		const next = { slug: "b", title: "Title B" };
+
+		// Act
+		renderNav(null, next);
+
+		// Assert — /blog 로 시작하는 href 는 next 링크와 center(/blog) 뿐
+		await screen.findByRole("link", { name: /모든 글/i });
+		const blogLinks = screen
+			.getAllByRole("link")
+			.filter((l) => (l.getAttribute("href") ?? "").startsWith("/blog/"));
+		// prev 링크 없으므로 /blog/ 시작 링크는 next 하나뿐
+		expect(blogLinks).toHaveLength(1);
+		expect(blogLinks[0].getAttribute("href")).toBe("/blog/b");
+	});
+
+	it("prev 가 있으면 좌측 셀에 /blog/{slug} href 링크와 title 텍스트가 있다", async () => {
+		// Arrange
+		const prev = { slug: "prev-slug", title: "이전 글 제목" };
+
+		// Act
+		renderNav(prev, null);
+
+		// Assert
+		const prevLink = await screen.findByRole("link", { name: /이전 글 제목/ });
+		expect(prevLink).toHaveAttribute("href", "/blog/prev-slug");
+	});
+
+	it("next 가 null 이면 우측 셀에 link 가 없다", async () => {
+		// Arrange
+		const prev = { slug: "a", title: "Title A" };
+
+		// Act
+		renderNav(prev, null);
+
+		// Assert — /blog/ 로 시작하는 href 는 prev 하나뿐
+		await screen.findByRole("link", { name: /모든 글/i });
+		const blogLinks = screen
+			.getAllByRole("link")
+			.filter((l) => (l.getAttribute("href") ?? "").startsWith("/blog/"));
+		expect(blogLinks).toHaveLength(1);
+		expect(blogLinks[0].getAttribute("href")).toBe("/blog/a");
+	});
+
+	it("next 가 있으면 우측 셀에 /blog/{slug} href 링크와 title 텍스트가 있다", async () => {
+		// Arrange
+		const next = { slug: "next-slug", title: "다음 글 제목" };
+
+		// Act
+		renderNav(null, next);
+
+		// Assert
+		const nextLink = await screen.findByRole("link", { name: /다음 글 제목/ });
+		expect(nextLink).toHaveAttribute("href", "/blog/next-slug");
+	});
+});

--- a/app/presentation/components/post/__tests__/ShareTools.test.tsx
+++ b/app/presentation/components/post/__tests__/ShareTools.test.tsx
@@ -1,0 +1,89 @@
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// ---------------------------------------------------------------------------
+// T014b RED — ShareTools 컴포넌트 (아직 없으므로 import 자체 실패 → RED)
+// ---------------------------------------------------------------------------
+
+import ShareTools from "../ShareTools";
+
+describe("ShareTools", () => {
+	const TITLE = "Test Post Title";
+	const CANONICAL_URL = "https://tkstar.dev/blog/test-post";
+
+	beforeEach(() => {
+		vi.useFakeTimers();
+		// jsdom 환경에서 navigator.clipboard 가 없으므로 직접 주입
+		Object.assign(navigator, {
+			clipboard: {
+				writeText: vi.fn().mockResolvedValue(undefined),
+			},
+		});
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+		vi.restoreAllMocks();
+	});
+
+	it("Copy link 버튼 클릭 시 navigator.clipboard.writeText 가 canonicalUrl 로 호출된다", async () => {
+		// Arrange
+		render(<ShareTools title={TITLE} canonicalUrl={CANONICAL_URL} />);
+
+		// Act
+		const copyButton = screen.getByRole("button", { name: /copy link/i });
+		await act(async () => {
+			fireEvent.click(copyButton);
+		});
+
+		// Assert
+		expect(navigator.clipboard.writeText).toHaveBeenCalledWith(CANONICAL_URL);
+	});
+
+	it("클릭 직후 'copied' 라벨이 노출되고 1500ms 후 사라진다", async () => {
+		// Arrange
+		render(<ShareTools title={TITLE} canonicalUrl={CANONICAL_URL} />);
+		const copyButton = screen.getByRole("button", { name: /copy link/i });
+
+		// Act — 클릭 직후 (clipboard.writeText resolve 까지 microtask 소진)
+		await act(async () => {
+			fireEvent.click(copyButton);
+		});
+
+		// Assert — 'copied' 라벨 표시
+		expect(screen.getByText(/copied/i)).toBeInTheDocument();
+
+		// Act — 1500ms 경과
+		act(() => {
+			vi.advanceTimersByTime(1500);
+		});
+
+		// Assert — 'copied' 라벨 사라짐
+		expect(screen.queryByText(/copied/i)).toBeNull();
+	});
+
+	it("X 공유 링크의 href / target / rel 이 올바르다", () => {
+		// Arrange
+		render(<ShareTools title={TITLE} canonicalUrl={CANONICAL_URL} />);
+
+		// Act
+		const link = screen.getByRole("link", { name: /share on x/i });
+
+		// Assert
+		const expectedHref = `https://x.com/intent/post?text=${encodeURIComponent(TITLE)}&url=${encodeURIComponent(CANONICAL_URL)}`;
+		expect(link.getAttribute("href")).toBe(expectedHref);
+		expect(link.getAttribute("target")).toBe("_blank");
+		expect(link.getAttribute("rel")).toContain("noopener");
+		expect(link.getAttribute("rel")).toContain("noreferrer");
+	});
+
+	it("aria-live='polite' 영역이 존재한다 ('copied' 알림용)", () => {
+		// Arrange
+		render(<ShareTools title={TITLE} canonicalUrl={CANONICAL_URL} />);
+
+		// Act & Assert
+		// aria-live="polite" 는 role="status" 와 동일 ARIA 역할
+		const liveRegion = document.querySelector("[aria-live='polite']");
+		expect(liveRegion).toBeTruthy();
+	});
+});

--- a/app/presentation/routes/__tests__/blog.$slug.test.tsx
+++ b/app/presentation/routes/__tests__/blog.$slug.test.tsx
@@ -1,0 +1,174 @@
+import { render, screen } from "@testing-library/react";
+import { createRoutesStub } from "react-router";
+import { describe, expect, it, vi } from "vitest";
+
+// MdxRenderer를 모킹해 body 함수 평가 불안정성 회피
+vi.mock("../../components/content/MdxRenderer", () => ({
+	default: () => <div data-testid="mdx-content">[mdx body]</div>,
+}));
+
+// ---------------------------------------------------------------------------
+// T014b RED — blog.$slug route (loader + UI)
+// 현재 blog.$slug.tsx 는 placeholder 이므로 loader export 가 없음 → RED
+// ---------------------------------------------------------------------------
+
+import BlogDetail, { loader } from "../blog.$slug";
+
+// ---------------------------------------------------------------------------
+// Mock 데이터
+// ---------------------------------------------------------------------------
+
+type PostWithBody = {
+	slug: string;
+	title: string;
+	lede: string;
+	date: string;
+	tags: string[];
+	read: number;
+	body?: string;
+	toc?: { slug: string; text: string }[];
+};
+
+const POST_WITH_TOC: PostWithBody = {
+	slug: "test-post",
+	title: "Test Blog Post",
+	lede: "A test lede sentence",
+	date: "2026-05-02",
+	tags: ["rr7", "cloudflare"],
+	read: 5,
+	body: "[stub-mdx-body]",
+	toc: [
+		{ slug: "intro", text: "Introduction" },
+		{ slug: "conclusion", text: "Conclusion" },
+	],
+};
+
+const POST_EMPTY_TOC: PostWithBody = {
+	...POST_WITH_TOC,
+	slug: "no-toc-post",
+	toc: [],
+};
+
+// ---------------------------------------------------------------------------
+// Mock context 팩토리
+// ---------------------------------------------------------------------------
+
+const makeMockContext = (
+	detail: { post: PostWithBody; prev: PostWithBody | null; next: PostWithBody | null } = {
+		post: POST_WITH_TOC,
+		prev: null,
+		next: null,
+	},
+) => {
+	const getPostDetail = vi.fn().mockResolvedValue(detail);
+	return {
+		context: {
+			container: {
+				getFeaturedProject: vi.fn(),
+				getRecentPosts: vi.fn(),
+				listProjects: vi.fn(),
+				getProjectDetail: vi.fn(),
+				listPosts: vi.fn(),
+				getPostDetail,
+			},
+			cloudflare: { env: {}, ctx: {} },
+		},
+		spies: { getPostDetail },
+	};
+};
+
+// ---------------------------------------------------------------------------
+// Group A — Loader
+// ---------------------------------------------------------------------------
+
+describe("Group A — blog.$slug loader", () => {
+	it("loader 가 context.container.getPostDetail(params.slug) 를 호출한다", async () => {
+		// Arrange
+		const { context, spies } = makeMockContext();
+
+		// Act
+		const result = await loader({
+			context,
+			params: { slug: "test-post" },
+			request: new Request("https://example.dev/blog/test-post"),
+		} as never);
+
+		// Assert
+		expect(spies.getPostDetail.mock.calls[0][0]).toBe("test-post");
+		// loader 결과에 canonicalUrl 이 포함되어야 한다
+		expect((result as Record<string, unknown>).canonicalUrl).toBe(
+			"https://example.dev/blog/test-post",
+		);
+	});
+
+	it("params.slug 가 undefined 이면 Response 404 를 throw 한다", async () => {
+		// Arrange
+		const { context } = makeMockContext();
+
+		// Act & Assert
+		await expect(
+			loader({
+				context,
+				params: {},
+				request: new Request("https://example.dev/blog/"),
+			} as never),
+		).rejects.toBeInstanceOf(Response);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Group B — UI
+// ---------------------------------------------------------------------------
+
+describe("Group B — blog.$slug UI", () => {
+	it("본문 + ShareTools + PostFooterNav 모두 마운트된다 (toc 비어있지 않을 때)", async () => {
+		// Arrange
+		const CANONICAL = "https://example.dev/blog/test-post";
+		const Stub = createRoutesStub([
+			{
+				path: "/blog/:slug",
+				Component: BlogDetail,
+				loader: () => ({
+					post: POST_WITH_TOC,
+					prev: null,
+					next: null,
+					canonicalUrl: CANONICAL,
+				}),
+			},
+		]);
+
+		// Act
+		render(<Stub initialEntries={["/blog/test-post"]} />);
+
+		// Assert
+		await screen.findByTestId("mdx-content");
+		expect(screen.getByText(POST_WITH_TOC.title)).toBeInTheDocument();
+		// ShareTools — X 공유 링크
+		expect(screen.getByRole("link", { name: /share on x/i })).toBeInTheDocument();
+		// PostFooterNav — '모든 글' 링크
+		expect(screen.getByText("[모든 글]")).toBeInTheDocument();
+	});
+
+	it("toc 가 비어있을 때 OnThisPageToc 가 미렌더된다", async () => {
+		// Arrange
+		const Stub = createRoutesStub([
+			{
+				path: "/blog/:slug",
+				Component: BlogDetail,
+				loader: () => ({
+					post: POST_EMPTY_TOC,
+					prev: null,
+					next: null,
+					canonicalUrl: "https://example.dev/blog/no-toc-post",
+				}),
+			},
+		]);
+
+		// Act
+		render(<Stub initialEntries={["/blog/no-toc-post"]} />);
+
+		// Assert
+		await screen.findByTestId("mdx-content");
+		expect(screen.queryByTestId("on-this-page-toc")).toBeNull();
+	});
+});

--- a/app/presentation/routes/blog.$slug.tsx
+++ b/app/presentation/routes/blog.$slug.tsx
@@ -1,12 +1,51 @@
-import type { MetaFunction } from "react-router";
+import MdxRenderer from "../components/content/MdxRenderer";
+import PostFooterNav from "../components/post/PostFooterNav";
+import ShareTools from "../components/post/ShareTools";
+import OnThisPageToc from "../components/project/OnThisPageToc";
 
-export const meta: MetaFunction = () => [{ title: "Post — tkstar.dev" }];
+import type { Route } from "./+types/blog.$slug";
 
-export default function BlogDetail() {
+export const meta: Route.MetaFunction = () => [{ title: "Post — tkstar.dev" }];
+
+export const loader = async ({ context, params, request }: Route.LoaderArgs) => {
+	if (!params.slug) throw new Response("Not Found", { status: 404 });
+	const detail = await context.container.getPostDetail(params.slug);
+	const url = new URL(request.url);
+	return { ...detail, canonicalUrl: `${url.origin}${url.pathname}` };
+};
+
+export default function BlogDetail({ loaderData }: Route.ComponentProps) {
+	const { post, prev, next, canonicalUrl } = loaderData;
 	return (
-		<main className="container mx-auto p-4">
-			<h1 className="text-2xl font-semibold">Blog Post</h1>
-			<p>placeholder — content lands in T014b.</p>
+		<main className="mx-auto flex max-w-[var(--container-measure)] flex-col gap-[22px] px-[var(--spacing-gutter)] pt-[22px] pb-20 min-[720px]:gap-7 min-[720px]:px-7 min-[720px]:pt-9 min-[720px]:pb-[120px]">
+			<header className="flex flex-col gap-2">
+				<h1 className="flex items-center gap-2 m-0 font-mono text-[11px] tracking-[0.12em] uppercase text-muted">
+					<span aria-hidden="true" className="text-accent">
+						$
+					</span>
+					<span>cat posts/{post.slug}.mdx</span>
+					<span aria-hidden="true" className="h-px flex-1 bg-line" />
+				</h1>
+				<h2 className="m-0 text-[28px] font-semibold tracking-[-0.01em] text-fg min-[720px]:text-[34px]">
+					{post.title}
+				</h2>
+				<p className="font-mono text-[12px] text-faint">{post.lede}</p>
+			</header>
+
+			<div className="flex flex-col gap-8 min-[880px]:grid min-[880px]:grid-cols-[minmax(0,1fr)_280px] min-[880px]:gap-10">
+				<article className="post-body">
+					{post.body ? <MdxRenderer code={post.body} /> : null}
+				</article>
+				<div className="flex flex-col gap-6 min-[880px]:sticky min-[880px]:top-[calc(var(--height-topbar)+36px)] min-[880px]:self-start min-[880px]:max-h-[calc(100dvh-var(--height-topbar)-48px)] min-[880px]:overflow-y-auto">
+					<OnThisPageToc toc={post.toc ?? []} />
+					<ShareTools title={post.title} canonicalUrl={canonicalUrl} />
+				</div>
+			</div>
+
+			<PostFooterNav
+				prev={prev ? { slug: prev.slug, title: prev.title } : null}
+				next={next ? { slug: next.slug, title: next.title } : null}
+			/>
 		</main>
 	);
 }

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -329,7 +329,7 @@ tkstarDev는 다음 핵심 가치를 단일 도메인에서 달성한다:
     - `app/application/feed/services/build-rss-feed.service.ts` + `__tests__/`
   - PR 1개 / 브랜치: `feature/issue-N-blog-list-rss`
 
-- [ ] **Task 014b: Blog Detail Page (F007) — 본문 + sticky sidebar + share**
+- [x] **Task 014b: Blog Detail Page (F007) — 본문 + sticky sidebar + share**
   - **Must** Read: [tasks/T014b-blog-detail.md](tasks/T014b-blog-detail.md)
   - blockedBy: Task 014a
   - blocks: Task 018 (OG)

--- a/docs/tasks/T014b-blog-detail.md
+++ b/docs/tasks/T014b-blog-detail.md
@@ -5,13 +5,13 @@
 | **Task ID** | T014b |
 | **Phase** | Phase 3 — Core Pages UI |
 | **Layer** | Presentation |
-| **Branch** | `feature/issue-N-blog-detail` |
+| **Branch** | `feature/issue-53-blog-detail` |
 | **Depends on** | T014a |
 | **Blocks** | T018 |
 | **PRD Features** | **F007** (Blog 상세) |
 | **PRD AC** | — (UI 표시 위주) |
 | **예상 작업 시간** | 1d |
-| **Status** | Not Started |
+| **Status** | Done |
 
 ## Goal
 `/blog/:slug` 상세 페이지를 MDX 본문 + shiki 코드블록 + 데스크탑 880px+ sticky sidebar(TOC + share)로 구현하고, 하단 3분할 네비(`← prev` / `[모든 글]` / `next →`)을 가동시킨다.
@@ -37,12 +37,12 @@
 - 페이지별 meta export (T019)
 
 ## Acceptance Criteria
-- [ ] `/blog/:slug` 진입 시 본문 + shiki 코드블록 렌더
-- [ ] 데스크탑 880px+에서 sticky sidebar(TOC + share) 노출
-- [ ] copy link 버튼 클릭 시 `navigator.clipboard.writeText` 호출 + 시각 피드백 ("복사됨" toast 또는 inline)
-- [ ] X 공유 링크가 `https://x.com/intent/post?text=<title>&url=<canonical>` 형식
-- [ ] 하단 3분할 (`← prev` / `[모든 글]` / `next →`) — prev/next는 collection 인접 항목, 미존재 시 `<span>`
-- [ ] 미존재 slug 접속 시 splat fallback
+- [x] `/blog/:slug` 진입 시 본문 + shiki 코드블록 렌더
+- [x] 데스크탑 880px+에서 sticky sidebar(TOC + share) 노출
+- [x] copy link 버튼 클릭 시 `navigator.clipboard.writeText` 호출 + 시각 피드백 ("복사됨" toast 또는 inline)
+- [x] X 공유 링크가 `https://x.com/intent/post?text=<title>&url=<canonical>` 형식
+- [x] 하단 3분할 (`← prev` / `[모든 글]` / `next →`) — prev/next는 collection 인접 항목, 미존재 시 `<span>`
+- [x] 미존재 slug 접속 시 splat fallback
 
 ## Implementation Plan (TDD Cycle)
 
@@ -112,4 +112,4 @@
 ## Change History
 | Date | Changes | Author |
 |------|---------|--------|
-| - | - | - |
+| 2026-05-02 | T014b 구현 완료 — `blog.$slug.tsx` + `ShareTools` + `PostFooterNav` 신설, T013 명세 누락이었던 Post `body`/`toc` infra (post.schema/mapper/velite transform) 흡수, `.post-body` typography 통합. PR #(TBD), Issue #53 | TaekyungHa |

--- a/scripts/patch-velite-types.mjs
+++ b/scripts/patch-velite-types.mjs
@@ -8,6 +8,8 @@ const content = `// Patched by scripts/patch-velite-types.mjs after \`velite bui
 // This patch replaces the typegen with explicit minimal types mirroring
 // the schema in velite.config.ts.
 
+export type TocEntry = { slug: string; text: string };
+
 export type Project = {
 \tslug: string;
 \ttitle: string;
@@ -18,7 +20,9 @@ export type Project = {
 \tmetrics: [string, string][];
 \tfeatured?: boolean;
 \tcover?: string;
+\trole?: string;
 \tbody: string;
+\ttoc: TocEntry[];
 };
 export declare const projects: Project[];
 
@@ -30,6 +34,7 @@ export type Post = {
 \ttags: string[];
 \tread: number;
 \tbody: string;
+\ttoc: TocEntry[];
 };
 export declare const posts: Post[];
 

--- a/velite.config.ts
+++ b/velite.config.ts
@@ -29,15 +29,20 @@ const projects = defineCollection({
 const posts = defineCollection({
 	name: "Post",
 	pattern: "posts/**/*.mdx",
-	schema: s.object({
-		slug: s.slug("posts"),
-		title: s.string(),
-		lede: s.string(),
-		date: s.isodate(),
-		tags: s.array(s.string()),
-		read: s.number(),
-		body: s.mdx(),
-	}),
+	schema: s
+		.object({
+			slug: s.slug("posts"),
+			title: s.string(),
+			lede: s.string(),
+			date: s.isodate(),
+			tags: s.array(s.string()),
+			read: s.number(),
+			body: s.mdx(),
+		})
+		.transform((data, { meta }) => ({
+			...data,
+			toc: extractToc(meta.content ?? ""),
+		})),
 });
 
 const legal = defineCollection({


### PR DESCRIPTION
## Summary

`/blog/:slug` 상세 페이지 구현 (Phase 3 콘텐츠 페이지 마무리). MDX 본문 + sticky sidebar(TOC + Share) + 3분할 footer nav. T013 명세 누락이었던 Post `body`/`toc` infra 도 본 PR 에서 함께 흡수.

## Changes

- **Domain**: `post.schema` 에 `body` / `toc` optional 필드 추가
- **Infrastructure**:
  - `velite.config.ts` posts collection 에 `extractToc` transform 추가
  - `post.mapper` body/toc passthrough
  - `scripts/patch-velite-types.mjs` 에 TocEntry / Project.toc / Project.role / Post.toc 타입 보정
- **Presentation**:
  - `app/presentation/routes/blog.$slug.tsx` — placeholder → 실제 페이지 (loader: `getPostDetail` + `canonicalUrl` 합성, 404 throw)
  - `app/presentation/components/post/ShareTools.tsx` — copy link (inline 'copied' 1.5s, aria-live polite, Safari clipboard reject silent catch) + X 공유 anchor
  - `app/presentation/components/post/PostFooterNav.tsx` — 3-cell grid (`prev` / `[모든 글] → /blog` / `next`)
  - `app/app.css` — `.project-body` → `.project-body, .post-body` 그룹 셀렉터 확장 (typography 통합)

## Acceptance Criteria

- [x] `/blog/:slug` 진입 시 본문 + shiki 코드블록 렌더
- [x] 데스크탑 880px+ sticky sidebar (TOC + Share) 노출
- [x] Copy link 버튼 클릭 시 `navigator.clipboard.writeText` 호출 + inline 'copied' 1.5s 피드백
- [x] X 공유 링크가 `https://x.com/intent/post?text=<title>&url=<canonical>` 형식
- [x] 하단 3분할 (`← prev` / `[모든 글]` / `next →`) — prev/next 미존재 시 `<span/>` placeholder
- [x] 미존재 slug 접속 시 splat fallback

## Test plan

- [x] `bun run test` — 207/207 passed (45 files), Coverage threshold 유지
- [x] `bun run typecheck` — exit 0 (wrangler types + RR7 typegen + `tsc -b`)
- [x] `bun run lint` — Biome 148 files clean
- [x] `bun run velite:build` — `.velite/posts.json[0].toc` 비어있지 않음 검증
- [ ] (Reviewer) `wrangler dev` `/blog/2026-04-shipping-solo` 수동 시각 확인 (sticky sidebar, copy link, X 공유, 모바일 inline)

## Architecture / Trade-offs

- **`canonicalUrl` from loader**: `request.url` 에서 origin + pathname 합성 → SSR 시점에 결정, hydration mismatch 회피, staging URL 하드코드 회피.
- **Inline 'copied' 라벨 (Toast 시스템 도입 보류)**: `useState<boolean>` + 1500ms `setTimeout` cleanup, `aria-live='polite'`. Toast 시스템은 별도 task 시점에 일괄 도입.
- **`PostFooterNav` 신설 + `<DetailFooterNav />` 통합 보류**: 현재 `ProjectFooterNav` 와 골격은 동일하나 center 라벨/href 가 다름 — 통합은 Module Depth 원칙상 두 페이지 이상의 공통점이 더 명확해진 시점 (T015/T016) 에 `improve-codebase-architecture` skill 로 일괄 검토.
- **Plan §R1 mitigation**: Safari user-gesture 외 `clipboard.writeText` reject 시 unhandled rejection 방지 — `.catch(() => {})` 한 줄 (silent failure, 'copied' 라벨 미표시 자체가 사용자 피드백).

## Out of Scope (Plan §명시적 보류)

- `<DetailFooterNav />` 통합 (T015/T016 시점)
- Satori OG (T018)
- 페이지별 meta export (T019)
- LinkedIn/Facebook 공유, Toast 시스템

## Reviewer 트리아지 권고 (별도 follow-up)

- **MEDIUM**: 정본 디자인 헤더에 `date · read · tags` pill 클러스터 노출 (현재 prompt + h2 + lede). T019 와 함께 처리 후보.
- **MEDIUM**: sidebar TOC/Share 를 `card`(bg-elev + border + padding) 로 감싸는 정본 패턴 — T013 OnThisPageToc 일괄 재정렬 시 적용.
- **LOW**: ShareTools `min-h-9` (~36px) 모바일 터치 타겟 < 44px (단, sidebar 는 desktop-only sticky 라 회귀는 아님).

Closes #53

---
Related: #53