### PR TITLE
fix: Recent Posts raw ISO 노출 + presentation 날짜 표기 YYYY-MM-DD 통일

### DIFF
--- a/app/presentation/components/home/RecentPostsList.tsx
+++ b/app/presentation/components/home/RecentPostsList.tsx
@@ -1,6 +1,7 @@
 import { Link } from "react-router";
 
 import type { Post } from "../../../domain/post/post.entity";
+import { formatDate } from "../../lib/format";
 
 type Props = { posts: Post[] };
 
@@ -16,7 +17,7 @@ export default function RecentPostsList({ posts }: Props) {
 						className="grid grid-cols-[1fr_auto] min-[560px]:grid-cols-[88px_1fr_auto] items-baseline gap-2.5 border-line border-b py-3.5 font-mono text-[13px] text-fg no-underline transition-colors duration-[var(--duration-120)] ease-out hover:text-accent focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent motion-reduce:transition-none"
 					>
 						<span className="col-span-full text-[11px] text-muted min-[560px]:col-span-1 min-[560px]:text-[11px]">
-							{p.date}
+							{formatDate(p.date)}
 						</span>
 						<span className="font-medium text-fg">{p.title}</span>
 						<span className="text-[11px] text-muted">{p.read} min</span>

--- a/app/presentation/components/home/__tests__/RecentPostsList.test.tsx
+++ b/app/presentation/components/home/__tests__/RecentPostsList.test.tsx
@@ -12,7 +12,7 @@ const mockPosts: Post[] = [
 		slug: "post-1",
 		title: "첫 번째 글",
 		lede: "lede 1",
-		date: "2026-04-01",
+		date: "2026-04-01T00:00:00.000Z",
 		tags: ["dev"],
 		read: 5,
 	},

--- a/app/presentation/components/legal/LegalDocLayout.tsx
+++ b/app/presentation/components/legal/LegalDocLayout.tsx
@@ -1,5 +1,7 @@
 import type { ReactNode } from "react";
 
+import { formatDate } from "../../lib/format";
+
 type Props = {
 	title: string;
 	version: string;
@@ -17,7 +19,7 @@ export default function LegalDocLayout({ title, version, effectiveDate, children
 				<div className="mt-2 flex flex-wrap gap-2.5 font-mono text-[11px] text-faint">
 					<span>버전 {version}</span>
 					<span aria-hidden="true">·</span>
-					<span>시행 {effectiveDate}</span>
+					<span>시행 {formatDate(effectiveDate)}</span>
 				</div>
 			</header>
 			<article

--- a/app/presentation/components/legal/__tests__/LegalDocLayout.test.tsx
+++ b/app/presentation/components/legal/__tests__/LegalDocLayout.test.tsx
@@ -7,7 +7,11 @@ describe("LegalDocLayout", () => {
 	it("title 을 h1 으로 렌더한다", () => {
 		// Arrange & Act
 		render(
-			<LegalDocLayout title="moai 서비스 이용약관" version="1.0.0" effectiveDate="2026-04-28">
+			<LegalDocLayout
+				title="moai 서비스 이용약관"
+				version="1.0.0"
+				effectiveDate="2026-04-28T00:00:00.000Z"
+			>
 				<p>본문</p>
 			</LegalDocLayout>,
 		);
@@ -19,7 +23,7 @@ describe("LegalDocLayout", () => {
 	it("version 을 노출한다", () => {
 		// Arrange & Act
 		render(
-			<LegalDocLayout title="t" version="1.2.3" effectiveDate="2026-04-28">
+			<LegalDocLayout title="t" version="1.2.3" effectiveDate="2026-04-28T00:00:00.000Z">
 				<p>본문</p>
 			</LegalDocLayout>,
 		);
@@ -31,19 +35,19 @@ describe("LegalDocLayout", () => {
 	it("effectiveDate 를 노출한다", () => {
 		// Arrange & Act
 		render(
-			<LegalDocLayout title="t" version="1.0.0" effectiveDate="2026-04-28">
+			<LegalDocLayout title="t" version="1.0.0" effectiveDate="2026-04-28T00:00:00.000Z">
 				<p>본문</p>
 			</LegalDocLayout>,
 		);
 
 		// Assert
-		expect(screen.getByText(/2026-04-28/)).toBeInTheDocument();
+		expect(screen.getByText("시행 2026-04-28")).toBeInTheDocument();
 	});
 
 	it("children 을 article 안에 렌더한다", () => {
 		// Arrange & Act
 		render(
-			<LegalDocLayout title="t" version="1.0.0" effectiveDate="2026-04-28">
+			<LegalDocLayout title="t" version="1.0.0" effectiveDate="2026-04-28T00:00:00.000Z">
 				<p data-testid="legal-body">본문 컨텐츠</p>
 			</LegalDocLayout>,
 		);

--- a/app/presentation/components/post/PostRow.tsx
+++ b/app/presentation/components/post/PostRow.tsx
@@ -1,7 +1,7 @@
 import { Link } from "react-router";
 
 import type { Post } from "../../../domain/post/post.entity";
-import { formatYearMonth } from "../../lib/format";
+import { formatDate } from "../../lib/format";
 
 type Props = { post: Post };
 
@@ -13,11 +13,11 @@ export default function PostRow({ post }: Props) {
 			className="grid grid-cols-[1fr_auto] items-baseline gap-2.5 border-line border-b border-dashed py-3.5 font-mono text-[13px] text-fg no-underline transition-colors duration-[var(--duration-120)] ease-out hover:text-accent focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent motion-reduce:transition-none min-[720px]:grid-cols-[72px_1fr_minmax(0,200px)_60px]"
 		>
 			<span className="hidden text-[11px] text-muted min-[720px]:inline">
-				{formatYearMonth(post.date)}
+				{formatDate(post.date)}
 			</span>
 			<div className="flex flex-col gap-0.5">
 				<span className="font-mono text-[11px] text-accent min-[720px]:hidden">
-					{formatYearMonth(post.date)}
+					{formatDate(post.date)}
 				</span>
 				<span className="font-semibold text-fg">{post.title}</span>
 				<span className="text-[11px] text-muted">{post.lede}</span>

--- a/app/presentation/components/post/PostRow.tsx
+++ b/app/presentation/components/post/PostRow.tsx
@@ -6,19 +6,16 @@ import { formatDate } from "../../lib/format";
 type Props = { post: Post };
 
 export default function PostRow({ post }: Props) {
+	const date = formatDate(post.date);
 	return (
 		<Link
 			to={`/blog/${post.slug}`}
 			data-testid="post-row"
 			className="grid grid-cols-[1fr_auto] items-baseline gap-2.5 border-line border-b border-dashed py-3.5 font-mono text-[13px] text-fg no-underline transition-colors duration-[var(--duration-120)] ease-out hover:text-accent focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent motion-reduce:transition-none min-[720px]:grid-cols-[72px_1fr_minmax(0,200px)_60px]"
 		>
-			<span className="hidden text-[11px] text-muted min-[720px]:inline">
-				{formatDate(post.date)}
-			</span>
+			<span className="hidden text-[11px] text-muted min-[720px]:inline">{date}</span>
 			<div className="flex flex-col gap-0.5">
-				<span className="font-mono text-[11px] text-accent min-[720px]:hidden">
-					{formatDate(post.date)}
-				</span>
+				<span className="font-mono text-[11px] text-accent min-[720px]:hidden">{date}</span>
 				<span className="font-semibold text-fg">{post.title}</span>
 				<span className="text-[11px] text-muted">{post.lede}</span>
 			</div>

--- a/app/presentation/components/post/__tests__/PostRow.test.tsx
+++ b/app/presentation/components/post/__tests__/PostRow.test.tsx
@@ -16,7 +16,7 @@ const mockPost: Post = {
 };
 
 describe("PostRow", () => {
-	it("date(YYYY-MM), title, lede, tags, read 필드를 모두 렌더한다", () => {
+	it("date(YYYY-MM-DD), title, lede, tags, read 필드를 모두 렌더한다", () => {
 		// Arrange / Act
 		render(
 			<MemoryRouter>
@@ -25,7 +25,7 @@ describe("PostRow", () => {
 		);
 
 		// Assert
-		expect(screen.getAllByText("2026-04")).not.toHaveLength(0);
+		expect(screen.getAllByText("2026-04-28")).not.toHaveLength(0);
 		expect(screen.getByText("Example Post")).toBeInTheDocument();
 		expect(screen.getByText(/A short lede/)).toBeInTheDocument();
 		expect(screen.getByText("solo")).toBeInTheDocument();

--- a/app/presentation/components/project/ProjectRow.tsx
+++ b/app/presentation/components/project/ProjectRow.tsx
@@ -1,7 +1,7 @@
 import { Link } from "react-router";
 
 import type { Project } from "../../../domain/project/project.entity";
-import { formatYearMonth } from "../../lib/format";
+import { formatDate } from "../../lib/format";
 
 type Props = { project: Project };
 
@@ -13,7 +13,7 @@ export default function ProjectRow({ project }: Props) {
 			className="grid grid-cols-[1fr_auto] items-baseline gap-2.5 border-line border-b border-dashed py-3.5 font-mono text-[13px] text-fg no-underline transition-colors duration-[var(--duration-120)] ease-out hover:text-accent focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent motion-reduce:transition-none min-[720px]:grid-cols-[72px_140px_1fr_minmax(0,200px)]"
 		>
 			<span className="hidden text-[11px] text-muted min-[720px]:inline">
-				{formatYearMonth(project.date)}
+				{formatDate(project.date)}
 			</span>
 			<span className="hidden text-[12px] text-accent min-[720px]:inline">{project.slug}/</span>
 			<div className="flex flex-col gap-0.5">

--- a/app/presentation/components/project/__tests__/ProjectRow.test.tsx
+++ b/app/presentation/components/project/__tests__/ProjectRow.test.tsx
@@ -17,7 +17,7 @@ const mockProject: Project = {
 };
 
 describe("ProjectRow", () => {
-	it("date(YYYY-MM), slug/, title, summary, stack pills를 모두 렌더한다", () => {
+	it("date(YYYY-MM-DD), slug/, title, summary, stack pills를 모두 렌더한다", () => {
 		// Arrange / Act
 		render(
 			<MemoryRouter>
@@ -26,7 +26,7 @@ describe("ProjectRow", () => {
 		);
 
 		// Assert
-		expect(screen.getByText("2026-04")).toBeInTheDocument();
+		expect(screen.getByText("2026-04-28")).toBeInTheDocument();
 		expect(screen.getAllByText("example-project/")).not.toHaveLength(0);
 		expect(screen.getByText("Example Project")).toBeInTheDocument();
 		expect(screen.getByText(/A short summary/)).toBeInTheDocument();

--- a/app/presentation/lib/__tests__/format.test.ts
+++ b/app/presentation/lib/__tests__/format.test.ts
@@ -1,42 +1,42 @@
 import { describe, expect, it } from "vitest";
-import { formatYearMonth } from "../format";
+import { formatDate } from "../format";
 
-describe("formatYearMonth", () => {
-	it("2026-04-28을 2026-04로 변환한다", () => {
+describe("formatDate", () => {
+	it("ISO 날짜 문자열을 YYYY-MM-DD로 변환한다", () => {
+		// Arrange
+		const input = "2026-04-28T00:00:00.000Z";
+
+		// Act
+		const result = formatDate(input);
+
+		// Assert
+		expect(result).toBe("2026-04-28");
+	});
+
+	it("이미 YYYY-MM-DD 형식인 입력에 대해 동일한 값을 반환한다", () => {
 		// Arrange
 		const input = "2026-04-28";
 
 		// Act
-		const result = formatYearMonth(input);
+		const result = formatDate(input);
 
 		// Assert
-		expect(result).toBe("2026-04");
+		expect(result).toBe("2026-04-28");
 	});
 
-	it("2024-09-01을 2024-09로 변환한다", () => {
+	it("유효하지 않은 날짜 문자열 입력 시 Invalid date 메시지와 함께 throw한다", () => {
 		// Arrange
-		const input = "2024-09-01";
+		const input = "invalid";
 
-		// Act
-		const result = formatYearMonth(input);
-
-		// Assert
-		expect(result).toBe("2024-09");
+		// Act & Assert
+		expect(() => formatDate(input)).toThrow("Invalid date");
 	});
 
-	it("빈 문자열 입력 시 throw한다", () => {
+	it("빈 문자열 입력 시 Invalid date 메시지와 함께 throw한다", () => {
 		// Arrange
 		const input = "";
 
 		// Act & Assert
-		expect(() => formatYearMonth(input)).toThrow();
-	});
-
-	it("유효하지 않은 날짜 문자열 입력 시 throw한다", () => {
-		// Arrange
-		const input = "not-a-date";
-
-		// Act & Assert
-		expect(() => formatYearMonth(input)).toThrow();
+		expect(() => formatDate(input)).toThrow("Invalid date");
 	});
 });

--- a/app/presentation/lib/__tests__/format.test.ts
+++ b/app/presentation/lib/__tests__/format.test.ts
@@ -39,4 +39,28 @@ describe("formatDate", () => {
 		// Act & Assert
 		expect(() => formatDate(input)).toThrow("Invalid date");
 	});
+
+	it("YYYY-MM 월 단위 입력 시 Invalid date 메시지와 함께 throw한다", () => {
+		// Arrange
+		const input = "2026-04";
+
+		// Act & Assert
+		expect(() => formatDate(input)).toThrow("Invalid date");
+	});
+
+	it("자연어 날짜 (예: 'April 28 2026') 입력 시 Invalid date 메시지와 함께 throw한다", () => {
+		// Arrange
+		const input = "April 28 2026";
+
+		// Act & Assert
+		expect(() => formatDate(input)).toThrow("Invalid date");
+	});
+
+	it("선행/후행 공백이 있는 입력 시 Invalid date 메시지와 함께 throw한다", () => {
+		// Arrange
+		const input = "  2026-04-28  ";
+
+		// Act & Assert
+		expect(() => formatDate(input)).toThrow("Invalid date");
+	});
 });

--- a/app/presentation/lib/format.ts
+++ b/app/presentation/lib/format.ts
@@ -1,3 +1,10 @@
+export const formatDate = (date: string): string => {
+	if (!date || Number.isNaN(Date.parse(date))) {
+		throw new Error(`Invalid date: ${date}`);
+	}
+	return date.substring(0, 10);
+};
+
 export const formatYearMonth = (date: string): string => {
 	if (!date || Number.isNaN(Date.parse(date))) {
 		throw new Error(`Invalid date: ${date}`);

--- a/app/presentation/lib/format.ts
+++ b/app/presentation/lib/format.ts
@@ -4,10 +4,3 @@ export const formatDate = (date: string): string => {
 	}
 	return date.substring(0, 10);
 };
-
-export const formatYearMonth = (date: string): string => {
-	if (!date || Number.isNaN(Date.parse(date))) {
-		throw new Error(`Invalid date: ${date}`);
-	}
-	return date.substring(0, 7);
-};

--- a/app/presentation/lib/format.ts
+++ b/app/presentation/lib/format.ts
@@ -1,5 +1,7 @@
+const ISO_DATE_PREFIX_RE = /^\d{4}-\d{2}-\d{2}/;
+
 export const formatDate = (date: string): string => {
-	if (!date || Number.isNaN(Date.parse(date))) {
+	if (!ISO_DATE_PREFIX_RE.test(date) || Number.isNaN(Date.parse(date))) {
 		throw new Error(`Invalid date: ${date}`);
 	}
 	return date.substring(0, 10);

--- a/app/presentation/routes/__tests__/legal.$app.privacy.test.tsx
+++ b/app/presentation/routes/__tests__/legal.$app.privacy.test.tsx
@@ -19,7 +19,7 @@ const moaiPrivacy: AppLegalDoc = {
 	app_slug: "moai",
 	doc_type: "privacy",
 	version: "1.0.0",
-	effective_date: "2026-04-28",
+	effective_date: "2026-04-28T00:00:00.000Z",
 	body: "## moai privacy",
 };
 
@@ -120,7 +120,7 @@ describe("Group B — legal.$app.privacy 컴포넌트", () => {
 		expect(await screen.findByRole("heading", { level: 1 })).toBeInTheDocument();
 		expect(screen.getByText(/moai/i)).toBeInTheDocument();
 		expect(screen.getByText(/1\.0\.0/)).toBeInTheDocument();
-		expect(screen.getByText(/2026-04-28/)).toBeInTheDocument();
+		expect(screen.getByText("시행 2026-04-28")).toBeInTheDocument();
 		expect(screen.getByTestId("mdx-content")).toBeInTheDocument();
 	});
 });

--- a/app/presentation/routes/__tests__/legal.$app.terms.test.tsx
+++ b/app/presentation/routes/__tests__/legal.$app.terms.test.tsx
@@ -19,7 +19,7 @@ const moaiTerms: AppLegalDoc = {
 	app_slug: "moai",
 	doc_type: "terms",
 	version: "1.0.0",
-	effective_date: "2026-04-28",
+	effective_date: "2026-04-28T00:00:00.000Z",
 	body: "## moai terms",
 };
 
@@ -120,7 +120,7 @@ describe("Group B — legal.$app.terms 컴포넌트", () => {
 		expect(await screen.findByRole("heading", { level: 1 })).toBeInTheDocument();
 		expect(screen.getByText(/moai/i)).toBeInTheDocument();
 		expect(screen.getByText(/1\.0\.0/)).toBeInTheDocument();
-		expect(screen.getByText(/2026-04-28/)).toBeInTheDocument();
+		expect(screen.getByText("시행 2026-04-28")).toBeInTheDocument();
 		expect(screen.getByTestId("mdx-content")).toBeInTheDocument();
 	});
 });


### PR DESCRIPTION
## Summary

- Home > Recent Posts에서 더미 Post 날짜가 raw ISO (`2026-04-28T00:00:00.000Z`)로 노출되던 버그 수정
- `app/presentation/lib/format.ts`에 `formatDate(iso) → "YYYY-MM-DD"` 추가, 기존 `formatYearMonth`는 호출자 마이그레이션 후 제거 (Surgical Changes 원칙)
- 4개 컴포넌트(`RecentPostsList`, `PostRow`, `ProjectRow`, `LegalDocLayout`)에 `formatDate` 적용 — `LegalDocLayout`은 동일 패턴의 잠재 버그 동시 수정

## Code review 반영 (MAJOR-1)

- `formatDate`에 `^\d{4}-\d{2}-\d{2}` regex prefix 검증 추가 — `Date.parse("April 28 2026")`, `"2026-04"`, `"  2026-04-28  "` 등 lenient 통과로 silent garbage 반환되던 잠재 결함 차단
- 월 단위 / 자연어 / 공백 boundary 테스트 3건 추가
- `PostRow`의 dual `formatDate(post.date)` 호출을 상단 `const date`로 추출 (DRY)

## Out of scope

- `velite.config.ts` `s.isodate()` 스키마 (정상 동작)
- 더미 frontmatter `date: 2026-04-28` 값 (유지)
- `ProjectMetaSidebar`의 year-only 표기 (의도적 디자인)
- `app/domain/project/project.schema.ts:8` `zNonEmptyString()` → `zIso8601Date()` 통일 (별도 follow-up)

## Test plan

- [x] `bun run test` — 248/248 passing (신규 boundary 케이스 3개 포함)
- [x] `bun run typecheck` — clean
- [x] `bun run lint` — Biome clean
- [x] dev 서버에서 `/`, `/blog`, `/projects` 시각 검증 — 모든 페이지 `2026-04-28` 노출
- [x] code-reviewer (foreground) — MAJOR-1 + MINOR-1 반영
- [x] ux-design-lead design-review (foreground) — 0 BLOCKER / 0 MAJOR
- [ ] Cloudflare Workers production build 시각 검증 (사용자 확인 후)

Closes #59