### PR TITLE
✨ feat: T016 — F016 Cmd+K Command Palette

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,9 @@
 # Velite
 /.velite/
 
+# Velite-derived search index (generated at build time)
+/public/search-index.json
+
 # Cloudflare Workers
 /.wrangler/
 /worker-configuration.d.ts

--- a/app/app.css
+++ b/app/app.css
@@ -89,6 +89,34 @@ html {
 	}
 }
 
+/* CommandPalette (T016 F016) — 120ms fade-in for backdrop + panel.
+   prototype.css 정본의 "transition: 120ms ease" 와 동일 duration. */
+@keyframes palette-backdrop-in {
+	from {
+		opacity: 0;
+	}
+	to {
+		opacity: 1;
+	}
+}
+@keyframes palette-panel-in {
+	from {
+		opacity: 0;
+		transform: translateY(-4px) scale(0.985);
+	}
+	to {
+		opacity: 1;
+		transform: translateY(0) scale(1);
+	}
+}
+@media (prefers-reduced-motion: reduce) {
+	[data-palette-backdrop],
+	[data-palette-panel] {
+		/* biome-ignore lint/complexity/noImportantStyles: Tailwind arbitrary [animation:...] 유틸리티가 동일 specificity로 출력되므로, prefers-reduced-motion 환경에서 animation 을 확실히 끄려면 !important 가 필요. */
+		animation: none !important;
+	}
+}
+
 /* Long-form MDX body — projects (T013) + posts (T014b) 동일 typography */
 .project-body,
 .post-body {

--- a/app/application/search/lib/__tests__/token-search.test.ts
+++ b/app/application/search/lib/__tests__/token-search.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from "vitest";
+import { tokenSearch, type SearchableItem } from "../token-search";
+
+describe("tokenSearch", () => {
+	it("빈 items 배열 입력 시 빈 배열을 반환한다", () => {
+		// Arrange
+		const items: SearchableItem[] = [];
+
+		// Act
+		const result = tokenSearch(items, "rou");
+
+		// Assert
+		expect(result).toEqual([]);
+	});
+
+	it("빈 쿼리 입력 시 모든 items를 원래 순서 그대로 반환한다", () => {
+		// Arrange
+		const items: SearchableItem[] = [
+			{ slug: "a", title: "router navigation" },
+			{ slug: "b", title: "component design" },
+			{ slug: "c", title: "typescript guide" },
+		];
+
+		// Act (빈 문자열)
+		const resultEmpty = tokenSearch(items, "");
+
+		// Assert
+		expect(resultEmpty).toEqual(items);
+	});
+
+	it("공백만 있는 쿼리 입력 시 모든 items를 원래 순서 그대로 반환한다", () => {
+		// Arrange
+		const items: SearchableItem[] = [
+			{ slug: "a", title: "router navigation" },
+			{ slug: "b", title: "component design" },
+			{ slug: "c", title: "typescript guide" },
+		];
+
+		// Act (공백만 있는 쿼리)
+		const resultWhitespace = tokenSearch(items, "   ");
+
+		// Assert
+		expect(resultWhitespace).toEqual(items);
+	});
+
+	it("AND 토큰 필터링: 모든 토큰이 매칭된 item만 반환한다", () => {
+		// Arrange
+		const items: SearchableItem[] = [
+			{ slug: "a", title: "router navigation" },
+			{ slug: "b", title: "router only" },
+			{ slug: "c", title: "unrelated" },
+		];
+
+		// Act
+		const result = tokenSearch(items, "rou nav");
+
+		// Assert
+		expect(result).toHaveLength(1);
+		expect(result[0].slug).toBe("a");
+	});
+
+	it("토큰은 title, tags, summary 필드를 대소문자 구분 없이 검색하고 ANY 매칭으로 AND 조건을 충족한다", () => {
+		// Arrange
+		const items: SearchableItem[] = [
+			{
+				slug: "a",
+				title: "intro post",
+				tags: ["TYPESCRIPT"],
+				summary: "cloudflare workers deploy guide",
+			},
+		];
+
+		// Act — "typescript"는 tags에만, "cloudflare"는 summary에만 있음
+		const result = tokenSearch(items, "typescript cloudflare");
+
+		// Assert
+		expect(result).toHaveLength(1);
+		expect(result[0].slug).toBe("a");
+	});
+
+	it("가중치 점수 내림차순으로 정렬한다 (title +3 / tag +2 / summary +1)", () => {
+		// Arrange
+		const token = "vitest";
+		const itemX: SearchableItem = {
+			slug: "x",
+			title: "testing guide",
+			tags: ["testing"],
+			summary: `learn vitest basics`,
+		};
+		const itemY: SearchableItem = {
+			slug: "y",
+			title: "testing guide",
+			tags: [token],
+			summary: "how to write tests",
+		};
+		const itemZ: SearchableItem = {
+			slug: "z",
+			title: `${token} deep dive`,
+			tags: ["testing"],
+			summary: "how to write tests",
+		};
+
+		// Act
+		const result = tokenSearch([itemX, itemY, itemZ], token);
+
+		// Assert — 점수: Z(title +3) > Y(tag +2) > X(summary +1)
+		expect(result.map((i: SearchableItem) => i.slug)).toEqual(["z", "y", "x"]);
+	});
+
+	it("점수가 같은 items는 입력 배열 원래 순서를 유지한다 (stable tie-break)", () => {
+		// Arrange — 두 items 모두 title에만 토큰이 있어 동점(+3)
+		const token = "react";
+		const first: SearchableItem = { slug: "first", title: `${token} patterns` };
+		const second: SearchableItem = { slug: "second", title: `intro to ${token}` };
+
+		// Act
+		const result = tokenSearch([first, second], token);
+
+		// Assert
+		expect(result.map((i: SearchableItem) => i.slug)).toEqual(["first", "second"]);
+	});
+
+	it("제네릭 타입: 반환값이 T[]이므로 확장 타입의 추가 필드가 보존된다", () => {
+		// Arrange
+		type ProjectLike = SearchableItem & { kind: "project" };
+		const items: ProjectLike[] = [
+			{ slug: "proj-a", title: "router architecture", kind: "project" },
+			{ slug: "proj-b", title: "unrelated content", kind: "project" },
+		];
+
+		// Act
+		const result = tokenSearch(items, "router");
+
+		// Assert — 캐스트 없이 kind 필드에 접근 가능
+		expect(result).toHaveLength(1);
+		expect(result[0].kind).toBe("project");
+	});
+});

--- a/app/application/search/lib/token-search.ts
+++ b/app/application/search/lib/token-search.ts
@@ -1,0 +1,42 @@
+export type SearchableItem = {
+	slug: string;
+	title: string;
+	tags?: string[];
+	summary?: string;
+};
+
+const TITLE_WEIGHT = 3;
+const TAG_WEIGHT = 2;
+const SUMMARY_WEIGHT = 1;
+
+export const tokenSearch = <T extends SearchableItem>(items: T[], query: string): T[] => {
+	const tokens = query.toLowerCase().trim().split(/\s+/).filter(Boolean);
+	if (tokens.length === 0) return [...items];
+
+	const scored: { item: T; score: number; index: number }[] = [];
+	for (let index = 0; index < items.length; index++) {
+		const item = items[index];
+		const title = item.title.toLowerCase();
+		const tagsText = (item.tags ?? []).join(" ").toLowerCase();
+		const summary = (item.summary ?? "").toLowerCase();
+
+		let score = 0;
+		let allMatched = true;
+		for (const token of tokens) {
+			let tokenScore = 0;
+			if (title.includes(token)) tokenScore += TITLE_WEIGHT;
+			if (tagsText.includes(token)) tokenScore += TAG_WEIGHT;
+			if (summary.includes(token)) tokenScore += SUMMARY_WEIGHT;
+			if (tokenScore === 0) {
+				allMatched = false;
+				break;
+			}
+			score += tokenScore;
+		}
+
+		if (allMatched) scored.push({ item, score, index });
+	}
+
+	scored.sort((a, b) => b.score - a.score || a.index - b.index);
+	return scored.map((s) => s.item);
+};

--- a/app/application/search/services/__tests__/build-search-index.service.test.ts
+++ b/app/application/search/services/__tests__/build-search-index.service.test.ts
@@ -19,6 +19,8 @@ describe("buildSearchIndex", () => {
 		slug: "2026-04-shipping-solo",
 		title: "1인 기업으로 출발하기",
 		lede: "tkstar.dev 첫 글",
+		date: "2026-04-28",
+		read: 3,
 		tags: ["solo", "ops"],
 		body: "function _createMdxContent() { /* huge mdx body */ }",
 	};
@@ -107,6 +109,8 @@ describe("buildSearchIndex", () => {
 			slug: `post-${i}`,
 			title: `Post ${i}`,
 			lede: "포스트 한 줄 요약 ~ 두 줄 정도 길이.",
+			date: "2026-04-20",
+			read: 6,
 			tags: ["ops"],
 			body: "should not appear",
 		}));
@@ -119,17 +123,33 @@ describe("buildSearchIndex", () => {
 		expect(json.length).toBeLessThanOrEqual(150 * 1024);
 	});
 
-	it("결과의 모든 그룹은 SearchableItem 형태({slug,title,summary,tags?})만 노출한다", () => {
+	it("결과의 pages/projects 는 SearchableItem 형태({slug,title,summary,tags?})만, posts 는 추가로 date/read 만 노출한다", () => {
 		// Arrange & Act
 		const result = buildSearchIndex({ projects: [project], posts: [post] });
-		const all = [...result.pages, ...result.projects, ...result.posts];
 
-		// Assert — allowed key set
-		const allowed = new Set(["slug", "title", "summary", "tags"]);
-		for (const item of all) {
+		// Assert — pages / projects 는 SearchableItem 키 셋
+		const baseAllowed = new Set(["slug", "title", "summary", "tags"]);
+		for (const item of [...result.pages, ...result.projects]) {
 			for (const key of Object.keys(item)) {
-				expect(allowed.has(key)).toBe(true);
+				expect(baseAllowed.has(key)).toBe(true);
 			}
 		}
+
+		// posts 는 base + date/read 만 허용
+		const postAllowed = new Set(["slug", "title", "summary", "tags", "date", "read"]);
+		for (const item of result.posts) {
+			for (const key of Object.keys(item)) {
+				expect(postAllowed.has(key)).toBe(true);
+			}
+		}
+	});
+
+	it("posts 출력에 date 와 read 필드가 보존된다", () => {
+		// Arrange & Act
+		const result = buildSearchIndex({ projects: [], posts: [post] });
+
+		// Assert
+		expect(result.posts[0].date).toBe("2026-04-28");
+		expect(result.posts[0].read).toBe(3);
 	});
 });

--- a/app/application/search/services/__tests__/build-search-index.service.test.ts
+++ b/app/application/search/services/__tests__/build-search-index.service.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from "vitest";
+import {
+	buildSearchIndex,
+	type ProjectIndexInput,
+	type PostIndexInput,
+} from "../build-search-index.service";
+
+describe("buildSearchIndex", () => {
+	const project: ProjectIndexInput = {
+		slug: "example-project",
+		title: "Example Project",
+		summary: "Phase 2 검증용 시드 프로젝트",
+		tags: ["seed", "infra"],
+		// body는 입력 시에는 들어올 수 있어도 출력에서는 제외되어야 함
+		body: "function _createMdxContent() { /* huge mdx body */ }",
+	};
+
+	const post: PostIndexInput = {
+		slug: "2026-04-shipping-solo",
+		title: "1인 기업으로 출발하기",
+		lede: "tkstar.dev 첫 글",
+		tags: ["solo", "ops"],
+		body: "function _createMdxContent() { /* huge mdx body */ }",
+	};
+
+	it("정적 라우트 6개를 pages 그룹에 정해진 순서로 포함한다", () => {
+		// Arrange & Act
+		const result = buildSearchIndex({ projects: [], posts: [] });
+
+		// Assert
+		expect(result.pages.map((p: { slug: string }) => p.slug)).toEqual([
+			"/",
+			"/about",
+			"/projects",
+			"/blog",
+			"/contact",
+			"/legal",
+		]);
+	});
+
+	it("pages 항목은 title 과 summary 가 비어있지 않다", () => {
+		// Arrange & Act
+		const result = buildSearchIndex({ projects: [], posts: [] });
+
+		// Assert
+		for (const page of result.pages) {
+			expect(page.title.length).toBeGreaterThan(0);
+			expect(page.summary?.length ?? 0).toBeGreaterThan(0);
+		}
+	});
+
+	it("projects 입력을 SearchableItem 형태로 매핑하고 입력 순서를 유지한다", () => {
+		// Arrange
+		const second: ProjectIndexInput = {
+			slug: "second-project",
+			title: "Second",
+			summary: "두 번째",
+			tags: [],
+			body: "body content",
+		};
+
+		// Act
+		const result = buildSearchIndex({ projects: [project, second], posts: [] });
+
+		// Assert
+		expect(result.projects).toHaveLength(2);
+		expect(result.projects[0].slug).toBe("example-project");
+		expect(result.projects[1].slug).toBe("second-project");
+		expect(result.projects[0].title).toBe("Example Project");
+		expect(result.projects[0].summary).toBe("Phase 2 검증용 시드 프로젝트");
+		expect(result.projects[0].tags).toEqual(["seed", "infra"]);
+	});
+
+	it("posts 입력의 lede 를 summary 로 정규화하고 lede 키는 출력에 남기지 않는다", () => {
+		// Arrange & Act
+		const result = buildSearchIndex({ projects: [], posts: [post] });
+
+		// Assert
+		expect(result.posts).toHaveLength(1);
+		expect(result.posts[0].slug).toBe("2026-04-shipping-solo");
+		expect(result.posts[0].title).toBe("1인 기업으로 출발하기");
+		expect(result.posts[0].summary).toBe("tkstar.dev 첫 글");
+		expect("lede" in result.posts[0]).toBe(false);
+	});
+
+	it("출력 항목 어디에도 body 키가 포함되지 않는다", () => {
+		// Arrange & Act
+		const result = buildSearchIndex({ projects: [project], posts: [post] });
+
+		// Assert — pages / projects / posts 모든 그룹에 body 부재
+		const all = [...result.pages, ...result.projects, ...result.posts];
+		for (const item of all) {
+			expect("body" in item).toBe(false);
+		}
+	});
+
+	it("JSON 직렬화 size 가 150KB 이하다 (gzip ~100KB 환산)", () => {
+		// Arrange — 100개 프로젝트 + 200개 포스트로 양산
+		const projects: ProjectIndexInput[] = Array.from({ length: 100 }, (_, i) => ({
+			slug: `project-${i}`,
+			title: `Project Title ${i} — long enough name for realism`,
+			summary: "프로젝트 요약 한 두 문장 정도 길이로 작성됩니다.",
+			tags: ["solo", "infra", "ts"],
+			body: "this body should not appear in the output",
+		}));
+		const posts: PostIndexInput[] = Array.from({ length: 200 }, (_, i) => ({
+			slug: `post-${i}`,
+			title: `Post ${i}`,
+			lede: "포스트 한 줄 요약 ~ 두 줄 정도 길이.",
+			tags: ["ops"],
+			body: "should not appear",
+		}));
+
+		// Act
+		const result = buildSearchIndex({ projects, posts });
+		const json = JSON.stringify(result);
+
+		// Assert
+		expect(json.length).toBeLessThanOrEqual(150 * 1024);
+	});
+
+	it("결과의 모든 그룹은 SearchableItem 형태({slug,title,summary,tags?})만 노출한다", () => {
+		// Arrange & Act
+		const result = buildSearchIndex({ projects: [project], posts: [post] });
+		const all = [...result.pages, ...result.projects, ...result.posts];
+
+		// Assert — allowed key set
+		const allowed = new Set(["slug", "title", "summary", "tags"]);
+		for (const item of all) {
+			for (const key of Object.keys(item)) {
+				expect(allowed.has(key)).toBe(true);
+			}
+		}
+	});
+});

--- a/app/application/search/services/build-search-index.service.ts
+++ b/app/application/search/services/build-search-index.service.ts
@@ -12,17 +12,23 @@ export type PostIndexInput = {
 	slug: string;
 	title: string;
 	lede: string;
+	date: string;
+	read: number;
 	tags?: string[];
 	[key: string]: unknown;
 };
 
+export type IndexedPage = SearchableItem;
+export type IndexedProject = SearchableItem;
+export type IndexedPost = SearchableItem & { date: string; read: number };
+
 export type SearchIndex = {
-	pages: SearchableItem[];
-	projects: SearchableItem[];
-	posts: SearchableItem[];
+	pages: IndexedPage[];
+	projects: IndexedProject[];
+	posts: IndexedPost[];
 };
 
-const STATIC_PAGES: SearchableItem[] = [
+const STATIC_PAGES: IndexedPage[] = [
 	{ slug: "/", title: "Home", summary: "tkstar.dev — 1인 기업 개인 브랜드" },
 	{ slug: "/about", title: "About", summary: "B2B 채용·협업 검토를 위한 이력 페이지" },
 	{ slug: "/projects", title: "Projects", summary: "B2C 의뢰 검토용 프로젝트 케이스 스터디 모음" },
@@ -31,30 +37,37 @@ const STATIC_PAGES: SearchableItem[] = [
 	{ slug: "/legal", title: "Legal", summary: "출시한 앱별 이용약관 / 개인정보처리방침 색인" },
 ];
 
-const toSearchable = (input: {
-	slug: string;
-	title: string;
-	summary: string;
-	tags?: string[];
-}): SearchableItem => {
-	const item: SearchableItem = {
-		slug: input.slug,
-		title: input.title,
-		summary: input.summary,
-	};
-	if (input.tags && input.tags.length > 0) item.tags = input.tags;
+const withTags = <T extends { tags?: string[] }>(item: T): T => {
+	if (item.tags && item.tags.length === 0) {
+		const { tags: _omit, ...rest } = item;
+		return rest as T;
+	}
 	return item;
 };
+
+const toIndexedProject = (p: ProjectIndexInput): IndexedProject =>
+	withTags({
+		slug: p.slug,
+		title: p.title,
+		summary: p.summary,
+		...(p.tags && p.tags.length > 0 ? { tags: p.tags } : {}),
+	});
+
+const toIndexedPost = (p: PostIndexInput): IndexedPost =>
+	withTags({
+		slug: p.slug,
+		title: p.title,
+		summary: p.lede,
+		date: p.date.slice(0, 10),
+		read: p.read,
+		...(p.tags && p.tags.length > 0 ? { tags: p.tags } : {}),
+	});
 
 export const buildSearchIndex = (input: {
 	projects: ProjectIndexInput[];
 	posts: PostIndexInput[];
-}): SearchIndex => {
-	const projects = input.projects.map((p) =>
-		toSearchable({ slug: p.slug, title: p.title, summary: p.summary, tags: p.tags }),
-	);
-	const posts = input.posts.map((p) =>
-		toSearchable({ slug: p.slug, title: p.title, summary: p.lede, tags: p.tags }),
-	);
-	return { pages: STATIC_PAGES.map((page) => ({ ...page })), projects, posts };
-};
+}): SearchIndex => ({
+	pages: STATIC_PAGES.map((page) => ({ ...page })),
+	projects: input.projects.map(toIndexedProject),
+	posts: input.posts.map(toIndexedPost),
+});

--- a/app/application/search/services/build-search-index.service.ts
+++ b/app/application/search/services/build-search-index.service.ts
@@ -1,0 +1,60 @@
+import type { SearchableItem } from "../lib/token-search";
+
+export type ProjectIndexInput = {
+	slug: string;
+	title: string;
+	summary: string;
+	tags?: string[];
+	[key: string]: unknown;
+};
+
+export type PostIndexInput = {
+	slug: string;
+	title: string;
+	lede: string;
+	tags?: string[];
+	[key: string]: unknown;
+};
+
+export type SearchIndex = {
+	pages: SearchableItem[];
+	projects: SearchableItem[];
+	posts: SearchableItem[];
+};
+
+const STATIC_PAGES: SearchableItem[] = [
+	{ slug: "/", title: "Home", summary: "tkstar.dev — 1인 기업 개인 브랜드" },
+	{ slug: "/about", title: "About", summary: "B2B 채용·협업 검토를 위한 이력 페이지" },
+	{ slug: "/projects", title: "Projects", summary: "B2C 의뢰 검토용 프로젝트 케이스 스터디 모음" },
+	{ slug: "/blog", title: "Blog", summary: "월 1편 운영 원칙의 기술 블로그" },
+	{ slug: "/contact", title: "Contact", summary: "B2B / B2C 의뢰 문의 폼" },
+	{ slug: "/legal", title: "Legal", summary: "출시한 앱별 이용약관 / 개인정보처리방침 색인" },
+];
+
+const toSearchable = (input: {
+	slug: string;
+	title: string;
+	summary: string;
+	tags?: string[];
+}): SearchableItem => {
+	const item: SearchableItem = {
+		slug: input.slug,
+		title: input.title,
+		summary: input.summary,
+	};
+	if (input.tags && input.tags.length > 0) item.tags = input.tags;
+	return item;
+};
+
+export const buildSearchIndex = (input: {
+	projects: ProjectIndexInput[];
+	posts: PostIndexInput[];
+}): SearchIndex => {
+	const projects = input.projects.map((p) =>
+		toSearchable({ slug: p.slug, title: p.title, summary: p.summary, tags: p.tags }),
+	);
+	const posts = input.posts.map((p) =>
+		toSearchable({ slug: p.slug, title: p.title, summary: p.lede, tags: p.tags }),
+	);
+	return { pages: STATIC_PAGES.map((page) => ({ ...page })), projects, posts };
+};

--- a/app/presentation/components/chrome/Topbar.tsx
+++ b/app/presentation/components/chrome/Topbar.tsx
@@ -1,5 +1,6 @@
 import { Link, useLocation } from "react-router";
 import { useKbdHint } from "../../hooks/useKbdHint";
+import { openCommandPalette } from "../../hooks/useCommandPalette";
 import ThemeToggle from "./ThemeToggle";
 
 export default function Topbar() {
@@ -27,10 +28,9 @@ export default function Topbar() {
 					<button
 						type="button"
 						data-chrome="search-trigger"
-						aria-disabled="true"
-						aria-label="검색 (준비 중)"
-						onClick={(e) => e.preventDefault()}
-						className="inline-flex w-full max-w-[360px] cursor-not-allowed items-center gap-2 rounded-md border border-line bg-bg-elev px-2.5 py-1.5 text-muted text-xs opacity-80 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent"
+						aria-label="검색 — Command Palette 열기"
+						onClick={openCommandPalette}
+						className="inline-flex w-full max-w-[360px] cursor-pointer items-center gap-2 rounded-md border border-line bg-bg-elev px-2.5 py-1.5 text-muted text-xs transition-colors duration-[var(--duration-120)] ease-out hover:border-line-strong hover:text-fg motion-reduce:transition-none focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent"
 					>
 						<span aria-hidden="true">›</span>
 						<span className="flex-1 truncate text-left">go to ─ /about, post...</span>

--- a/app/presentation/components/home/HeroWhoami.tsx
+++ b/app/presentation/components/home/HeroWhoami.tsx
@@ -1,12 +1,10 @@
 import { Link } from "react-router";
-import { useCommandPalette } from "../../hooks/useCommandPalette";
+import { openCommandPalette } from "../../hooks/useCommandPalette";
 
 const BTN_BASE =
 	"inline-flex items-center gap-2 rounded-md border px-4 py-2.5 font-mono text-[13px] font-medium duration-[var(--duration-120)] ease-out motion-reduce:transition-none focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent";
 
 export default function HeroWhoami() {
-	const { open } = useCommandPalette();
-
 	return (
 		<section aria-labelledby="hero-heading" className="flex flex-col gap-3 sm:gap-[22px]">
 			<div className="flex items-baseline gap-0 font-mono text-faint text-xs">
@@ -33,7 +31,7 @@ export default function HeroWhoami() {
 			<div className="mt-2 flex flex-wrap items-center gap-2">
 				<button
 					type="button"
-					onClick={open}
+					onClick={openCommandPalette}
 					className={`${BTN_BASE} border-accent bg-accent text-bg transition-[color,background-color,border-color,filter] hover:brightness-[1.08]`}
 				>
 					›&nbsp;&nbsp;검색해서 이동

--- a/app/presentation/components/home/__tests__/HeroWhoami.test.tsx
+++ b/app/presentation/components/home/__tests__/HeroWhoami.test.tsx
@@ -4,7 +4,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const openSpy = vi.fn();
 vi.mock("../../../hooks/useCommandPalette", () => ({
-	useCommandPalette: () => ({ open: openSpy }),
+	openCommandPalette: () => openSpy(),
 }));
 
 import HeroWhoami from "../HeroWhoami";

--- a/app/presentation/components/palette/CommandPalette.tsx
+++ b/app/presentation/components/palette/CommandPalette.tsx
@@ -80,6 +80,10 @@ export default function CommandPalette() {
 						data-testid="palette-input"
 						value={api.query}
 						onChange={(e) => api.setQuery(e.target.value)}
+						onKeyDown={(e) => {
+							// open trigger '/' 가 input 에 echo 되는 race 차단 (빈 query 일 때만)
+							if (e.key === "/" && api.query === "") e.preventDefault();
+						}}
 						placeholder="go to ─ /about, project slug, post..."
 						className="flex-1 bg-transparent py-3 font-mono text-fg text-sm outline-none placeholder:text-faint"
 					/>

--- a/app/presentation/components/palette/CommandPalette.tsx
+++ b/app/presentation/components/palette/CommandPalette.tsx
@@ -14,7 +14,23 @@ const GROUP_LABELS: Record<PaletteGroup | "recents", string> = {
 	posts: "Posts",
 };
 
+const TYPE_BADGE: Record<PaletteGroup, string> = {
+	pages: "page",
+	projects: "project",
+	posts: "post",
+};
+
 type GroupKey = PaletteGroup | "recents";
+
+const itemMeta = (item: PaletteEntry): string => {
+	if (item.group === "posts") {
+		const date = item.date ?? "";
+		const read = item.read != null ? `${item.read} min` : "";
+		return [date, read].filter(Boolean).join(" · ");
+	}
+	if (item.group === "projects") return item.summary ?? item.href;
+	return item.href;
+};
 
 const collectGroups = (api: CommandPaletteApi): { key: GroupKey; items: PaletteEntry[] }[] => {
 	const out: { key: GroupKey; items: PaletteEntry[] }[] = [];
@@ -125,13 +141,18 @@ export default function CommandPalette() {
 												<div className="flex items-baseline gap-2">
 													<span
 														aria-hidden="true"
-														className="w-3 font-mono text-accent text-xs opacity-0 data-[active=true]:opacity-100"
+														className="w-3 shrink-0 font-mono text-accent text-xs opacity-0 data-[active=true]:opacity-100"
 														data-active={isActive ? "true" : "false"}
 													>
 														▸
 													</span>
-													<span className="font-mono text-fg text-sm">{item.title}</span>
-													<span className="truncate font-mono text-faint text-xs">{item.href}</span>
+													<span className="shrink-0 font-mono text-fg text-sm">{item.title}</span>
+													<span className="min-w-0 flex-1 truncate font-mono text-faint text-xs">
+														{itemMeta(item)}
+													</span>
+													<span className="shrink-0 rounded-sm border border-line px-1.5 py-0.5 font-mono text-[10px] text-muted">
+														{TYPE_BADGE[item.group]}
+													</span>
 												</div>
 											</li>
 										);

--- a/app/presentation/components/palette/CommandPalette.tsx
+++ b/app/presentation/components/palette/CommandPalette.tsx
@@ -116,9 +116,16 @@ export default function CommandPalette() {
 													api.setActiveIndex(itemIndex);
 													api.selectActive();
 												}}
-												className="cursor-pointer border-l-2 border-l-transparent px-4 py-2 transition-colors duration-[var(--duration-120)] ease-out motion-reduce:transition-none data-[active=true]:border-l-accent data-[active=true]:bg-accent/10"
+												className="cursor-pointer border-l-2 border-l-transparent px-4 py-2 transition-colors duration-[var(--duration-120)] ease-out motion-reduce:transition-none data-[active=true]:border-l-accent data-[active=true]:bg-bg-card"
 											>
 												<div className="flex items-baseline gap-2">
+													<span
+														aria-hidden="true"
+														className="w-3 font-mono text-accent text-xs opacity-0 data-[active=true]:opacity-100"
+														data-active={isActive ? "true" : "false"}
+													>
+														▸
+													</span>
 													<span className="font-mono text-fg text-sm">{item.title}</span>
 													<span className="truncate font-mono text-faint text-xs">{item.href}</span>
 												</div>

--- a/app/presentation/components/palette/CommandPalette.tsx
+++ b/app/presentation/components/palette/CommandPalette.tsx
@@ -1,0 +1,103 @@
+import { useEffect, useRef, useState } from "react";
+import {
+	type CommandPaletteApi,
+	type PaletteEntry,
+	type PaletteGroup,
+	useCommandPalette,
+} from "~/presentation/hooks/useCommandPalette";
+
+const GROUP_LABELS: Record<PaletteGroup | "recents", string> = {
+	recents: "Recent",
+	pages: "Pages",
+	projects: "Projects",
+	posts: "Posts",
+};
+
+type GroupKey = PaletteGroup | "recents";
+
+const collectGroups = (api: CommandPaletteApi): { key: GroupKey; items: PaletteEntry[] }[] => {
+	const out: { key: GroupKey; items: PaletteEntry[] }[] = [];
+	if (api.recents.length > 0) out.push({ key: "recents", items: api.recents });
+	if (api.groups.pages.length > 0) out.push({ key: "pages", items: api.groups.pages });
+	if (api.groups.projects.length > 0) out.push({ key: "projects", items: api.groups.projects });
+	if (api.groups.posts.length > 0) out.push({ key: "posts", items: api.groups.posts });
+	return out;
+};
+
+export default function CommandPalette() {
+	const api = useCommandPalette();
+	const inputRef = useRef<HTMLInputElement | null>(null);
+	const [listEl, setListEl] = useState<HTMLUListElement | null>(null);
+
+	useEffect(() => {
+		if (api.isOpen) inputRef.current?.focus();
+	}, [api.isOpen]);
+
+	useEffect(() => {
+		if (!listEl) return;
+		const onEnter = (e: Event) => {
+			const target = e.target as HTMLElement | null;
+			const item = target?.closest<HTMLElement>("[data-palette-index]");
+			if (!item) return;
+			const idx = Number(item.dataset.paletteIndex);
+			if (Number.isFinite(idx)) api.setActiveIndex(idx);
+		};
+		listEl.addEventListener("pointerenter", onEnter, true);
+		return () => listEl.removeEventListener("pointerenter", onEnter, true);
+	}, [listEl, api.setActiveIndex]);
+
+	if (!api.isOpen) return null;
+
+	const visible = collectGroups(api);
+	let runningIndex = 0;
+
+	return (
+		<div
+			data-testid="palette-modal"
+			role="dialog"
+			aria-modal="true"
+			aria-label="Command palette"
+			className="fixed inset-0 z-50 flex items-start justify-center bg-black/40 pt-24"
+		>
+			<div className="w-full max-w-xl rounded-md border border-border bg-bg-elev shadow-lg">
+				<input
+					ref={inputRef}
+					data-testid="palette-input"
+					value={api.query}
+					onChange={(e) => api.setQuery(e.target.value)}
+					placeholder="Search pages, projects, posts..."
+					className="w-full bg-transparent px-4 py-3 outline-none"
+				/>
+				<ul ref={setListEl} className="max-h-96 overflow-y-auto py-2">
+					{visible.map(({ key, items }) => (
+						<li key={key} data-testid={`palette-group-${key}`}>
+							<div className="px-4 py-1 text-xs uppercase text-muted">{GROUP_LABELS[key]}</div>
+							<ul>
+								{items.map((item) => {
+									const itemIndex = runningIndex++;
+									const isActive = itemIndex === api.activeIndex;
+									return (
+										<li
+											key={`${key}-${item.slug}`}
+											data-testid={`palette-item-${key === "recents" ? item.group : key}-${item.slug}`}
+											data-active={isActive ? "true" : "false"}
+											data-palette-index={itemIndex}
+											onClick={() => {
+												api.setActiveIndex(itemIndex);
+												api.selectActive();
+											}}
+											className={`cursor-pointer px-4 py-2 ${isActive ? "bg-accent/10" : ""}`}
+										>
+											<div className="text-sm">{item.title}</div>
+											<div className="text-xs text-muted">{item.href}</div>
+										</li>
+									);
+								})}
+							</ul>
+						</li>
+					))}
+				</ul>
+			</div>
+		</div>
+	);
+}

--- a/app/presentation/components/palette/CommandPalette.tsx
+++ b/app/presentation/components/palette/CommandPalette.tsx
@@ -5,7 +5,6 @@ import {
 	type PaletteGroup,
 	useCommandPalette,
 } from "~/presentation/hooks/useCommandPalette";
-import { useKbdHint } from "~/presentation/hooks/useKbdHint";
 
 const GROUP_LABELS: Record<PaletteGroup | "recents", string> = {
 	recents: "Recent",
@@ -43,7 +42,6 @@ const collectGroups = (api: CommandPaletteApi): { key: GroupKey; items: PaletteE
 
 export default function CommandPalette() {
 	const api = useCommandPalette();
-	const kbd = useKbdHint();
 	const inputRef = useRef<HTMLInputElement | null>(null);
 	const [listEl, setListEl] = useState<HTMLUListElement | null>(null);
 
@@ -103,12 +101,6 @@ export default function CommandPalette() {
 						placeholder="go to ─ /about, project slug, post..."
 						className="flex-1 bg-transparent py-3 font-mono text-fg text-sm outline-none placeholder:text-faint"
 					/>
-					<kbd className="hidden rounded-sm border border-line px-1.5 py-0.5 font-mono text-[10px] text-muted sm:inline-block">
-						{kbd}
-					</kbd>
-					<kbd className="hidden rounded-sm border border-line px-1.5 py-0.5 font-mono text-[10px] text-muted sm:inline-block">
-						esc
-					</kbd>
 				</div>
 
 				{isEmpty ? (

--- a/app/presentation/components/palette/CommandPalette.tsx
+++ b/app/presentation/components/palette/CommandPalette.tsx
@@ -5,6 +5,7 @@ import {
 	type PaletteGroup,
 	useCommandPalette,
 } from "~/presentation/hooks/useCommandPalette";
+import { useKbdHint } from "~/presentation/hooks/useKbdHint";
 
 const GROUP_LABELS: Record<PaletteGroup | "recents", string> = {
 	recents: "Recent",
@@ -26,6 +27,7 @@ const collectGroups = (api: CommandPaletteApi): { key: GroupKey; items: PaletteE
 
 export default function CommandPalette() {
 	const api = useCommandPalette();
+	const kbd = useKbdHint();
 	const inputRef = useRef<HTMLInputElement | null>(null);
 	const [listEl, setListEl] = useState<HTMLUListElement | null>(null);
 
@@ -49,54 +51,100 @@ export default function CommandPalette() {
 	if (!api.isOpen) return null;
 
 	const visible = collectGroups(api);
+	const isEmpty = visible.length === 0;
 	let runningIndex = 0;
 
 	return (
 		<div
 			data-testid="palette-modal"
+			data-palette-backdrop
 			role="dialog"
 			aria-modal="true"
 			aria-label="Command palette"
-			className="fixed inset-0 z-50 flex items-start justify-center bg-black/40 pt-24"
+			onClick={(e) => {
+				// 패널 자체 클릭은 무시 — backdrop(자기 자신)만 close 트리거
+				if (e.target === e.currentTarget) api.close();
+			}}
+			className="fixed inset-0 z-50 flex items-start justify-center bg-black/50 px-4 pt-[14vh] backdrop-blur-sm motion-reduce:bg-black/60 motion-reduce:backdrop-blur-none [animation:palette-backdrop-in_var(--duration-120)_ease-out]"
 		>
-			<div className="w-full max-w-xl rounded-md border border-border bg-bg-elev shadow-lg">
-				<input
-					ref={inputRef}
-					data-testid="palette-input"
-					value={api.query}
-					onChange={(e) => api.setQuery(e.target.value)}
-					placeholder="Search pages, projects, posts..."
-					className="w-full bg-transparent px-4 py-3 outline-none"
-				/>
-				<ul ref={setListEl} className="max-h-96 overflow-y-auto py-2">
-					{visible.map(({ key, items }) => (
-						<li key={key} data-testid={`palette-group-${key}`}>
-							<div className="px-4 py-1 text-xs uppercase text-muted">{GROUP_LABELS[key]}</div>
-							<ul>
-								{items.map((item) => {
-									const itemIndex = runningIndex++;
-									const isActive = itemIndex === api.activeIndex;
-									return (
-										<li
-											key={`${key}-${item.slug}`}
-											data-testid={`palette-item-${key === "recents" ? item.group : key}-${item.slug}`}
-											data-active={isActive ? "true" : "false"}
-											data-palette-index={itemIndex}
-											onClick={() => {
-												api.setActiveIndex(itemIndex);
-												api.selectActive();
-											}}
-											className={`cursor-pointer px-4 py-2 ${isActive ? "bg-accent/10" : ""}`}
-										>
-											<div className="text-sm">{item.title}</div>
-											<div className="text-xs text-muted">{item.href}</div>
-										</li>
-									);
-								})}
-							</ul>
-						</li>
-					))}
-				</ul>
+			<div
+				data-palette-panel
+				className="w-full max-w-xl overflow-hidden rounded-md border border-line-strong bg-bg-elev font-mono shadow-2xl shadow-black/40 [animation:palette-panel-in_var(--duration-120)_ease-out]"
+			>
+				<div className="flex items-center gap-2 border-line border-b px-4">
+					<span aria-hidden="true" className="text-accent text-sm">
+						›
+					</span>
+					<input
+						ref={inputRef}
+						data-testid="palette-input"
+						value={api.query}
+						onChange={(e) => api.setQuery(e.target.value)}
+						placeholder="go to ─ /about, project slug, post..."
+						className="flex-1 bg-transparent py-3 font-mono text-fg text-sm outline-none placeholder:text-faint"
+					/>
+					<kbd className="hidden rounded-sm border border-line px-1.5 py-0.5 font-mono text-[10px] text-muted sm:inline-block">
+						{kbd}
+					</kbd>
+					<kbd className="hidden rounded-sm border border-line px-1.5 py-0.5 font-mono text-[10px] text-muted sm:inline-block">
+						esc
+					</kbd>
+				</div>
+
+				{isEmpty ? (
+					<div className="px-4 py-8 text-center font-mono text-muted text-xs">
+						{api.query ? "검색 결과 없음" : "검색어를 입력하세요"}
+					</div>
+				) : (
+					<ul ref={setListEl} className="max-h-[60vh] overflow-y-auto py-2">
+						{visible.map(({ key, items }) => (
+							<li key={key} data-testid={`palette-group-${key}`}>
+								<div className="px-4 pt-2 pb-1 font-mono text-[10px] text-faint uppercase tracking-[0.12em]">
+									{GROUP_LABELS[key]}
+								</div>
+								<ul>
+									{items.map((item) => {
+										const itemIndex = runningIndex++;
+										const isActive = itemIndex === api.activeIndex;
+										return (
+											<li
+												key={`${key}-${item.slug}`}
+												data-testid={`palette-item-${key === "recents" ? item.group : key}-${item.slug}`}
+												data-active={isActive ? "true" : "false"}
+												data-palette-index={itemIndex}
+												onClick={() => {
+													api.setActiveIndex(itemIndex);
+													api.selectActive();
+												}}
+												className="cursor-pointer border-l-2 border-l-transparent px-4 py-2 transition-colors duration-[var(--duration-120)] ease-out motion-reduce:transition-none data-[active=true]:border-l-accent data-[active=true]:bg-accent/10"
+											>
+												<div className="flex items-baseline gap-2">
+													<span className="font-mono text-fg text-sm">{item.title}</span>
+													<span className="truncate font-mono text-faint text-xs">{item.href}</span>
+												</div>
+											</li>
+										);
+									})}
+								</ul>
+							</li>
+						))}
+					</ul>
+				)}
+
+				<div className="flex items-center justify-end gap-3 border-line border-t bg-bg/40 px-4 py-2 font-mono text-[10px] text-faint">
+					<span className="flex items-center gap-1">
+						<kbd className="rounded-sm border border-line px-1 py-0.5 text-muted">↑↓</kbd>
+						이동
+					</span>
+					<span className="flex items-center gap-1">
+						<kbd className="rounded-sm border border-line px-1 py-0.5 text-muted">↵</kbd>
+						선택
+					</span>
+					<span className="flex items-center gap-1">
+						<kbd className="rounded-sm border border-line px-1 py-0.5 text-muted">esc</kbd>
+						닫기
+					</span>
+				</div>
 			</div>
 		</div>
 	);

--- a/app/presentation/components/palette/__tests__/CommandPalette.test.tsx
+++ b/app/presentation/components/palette/__tests__/CommandPalette.test.tsx
@@ -1,0 +1,217 @@
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { SearchableItem } from "~/application/search/lib/token-search";
+import CommandPalette from "../CommandPalette";
+
+// react-router의 useNavigate를 모킹한다
+const navigate = vi.fn();
+vi.mock("react-router", async (orig) => {
+	const actual = await orig<typeof import("react-router")>();
+	return { ...actual, useNavigate: () => navigate };
+});
+
+// 검색 인덱스 페이로드 헬퍼
+const makeIndexPayload = (overrides?: {
+	pages?: SearchableItem[];
+	projects?: SearchableItem[];
+	posts?: SearchableItem[];
+}) => ({
+	pages: overrides?.pages ?? [],
+	projects: overrides?.projects ?? [],
+	posts: overrides?.posts ?? [],
+});
+
+// fetch 모킹 헬퍼
+const mockFetch = (payload: ReturnType<typeof makeIndexPayload>) => {
+	globalThis.fetch = vi.fn(async () => new Response(JSON.stringify(payload), { status: 200 }));
+};
+
+// Cmd+K 단축키 디스패치 헬퍼
+const openWithCmdK = async () => {
+	await act(async () => {
+		window.dispatchEvent(new KeyboardEvent("keydown", { key: "k", metaKey: true, bubbles: true }));
+	});
+};
+
+const renderPalette = () =>
+	render(
+		<MemoryRouter>
+			<CommandPalette />
+		</MemoryRouter>,
+	);
+
+describe("CommandPalette", () => {
+	beforeEach(() => {
+		sessionStorage.clear();
+		vi.restoreAllMocks();
+		navigate.mockReset();
+	});
+
+	it("기본 상태: palette-modal이 DOM에 없다", () => {
+		// Arrange
+		mockFetch(makeIndexPayload());
+
+		// Act
+		renderPalette();
+
+		// Assert
+		expect(screen.queryByTestId("palette-modal")).toBeNull();
+	});
+
+	it("Cmd+K 단축키로 팔레트가 열리고 palette-modal이 DOM에 나타난다", async () => {
+		// Arrange
+		mockFetch(makeIndexPayload());
+		renderPalette();
+
+		// Act
+		await openWithCmdK();
+
+		// Assert
+		expect(screen.getByTestId("palette-modal")).toBeInTheDocument();
+	});
+
+	it("열렸을 때 모달에 role=dialog와 aria-modal=true 속성이 있다", async () => {
+		// Arrange
+		mockFetch(makeIndexPayload());
+		renderPalette();
+
+		// Act
+		await openWithCmdK();
+
+		// Assert
+		const modal = screen.getByTestId("palette-modal");
+		expect(modal).toHaveAttribute("role", "dialog");
+		expect(modal).toHaveAttribute("aria-modal", "true");
+	});
+
+	it("열렸을 때 palette-input이 존재하고 자동 포커스된다", async () => {
+		// Arrange
+		mockFetch(makeIndexPayload());
+		renderPalette();
+
+		// Act
+		await openWithCmdK();
+
+		// Assert
+		const input = screen.getByTestId("palette-input");
+		expect(input).toBeInTheDocument();
+		await waitFor(() => {
+			expect(document.activeElement).toBe(input);
+		});
+	});
+
+	it("항목이 있는 그룹 헤더는 모두 렌더된다", async () => {
+		// Arrange
+		const payload = makeIndexPayload({
+			pages: [{ slug: "/about", title: "About" }],
+			projects: [{ slug: "my-project", title: "My Project" }],
+			posts: [{ slug: "hello", title: "Hello" }],
+		});
+		mockFetch(payload);
+		renderPalette();
+
+		// Act
+		await openWithCmdK();
+
+		// Assert
+		expect(screen.getByTestId("palette-group-pages")).toBeInTheDocument();
+		expect(screen.getByTestId("palette-group-projects")).toBeInTheDocument();
+		expect(screen.getByTestId("palette-group-posts")).toBeInTheDocument();
+	});
+
+	it("항목이 없는 그룹은 DOM에 렌더되지 않는다", async () => {
+		// Arrange
+		const payload = makeIndexPayload({
+			pages: [{ slug: "/about", title: "About" }],
+			projects: [],
+			posts: [],
+		});
+		mockFetch(payload);
+		renderPalette();
+
+		// Act
+		await openWithCmdK();
+
+		// Assert
+		expect(screen.getByTestId("palette-group-pages")).toBeInTheDocument();
+		expect(screen.queryByTestId("palette-group-projects")).toBeNull();
+		expect(screen.queryByTestId("palette-group-posts")).toBeNull();
+	});
+
+	it("sessionStorage에 recents가 있고 query가 비어 있으면 recents 그룹이 표시된다", async () => {
+		// Arrange
+		sessionStorage.setItem(
+			"tkstar-palette-recent",
+			JSON.stringify([{ slug: "/", title: "Home", group: "pages" }]),
+		);
+		mockFetch(makeIndexPayload());
+		renderPalette();
+
+		// Act
+		await openWithCmdK();
+
+		// Assert
+		expect(screen.getByTestId("palette-group-recents")).toBeInTheDocument();
+	});
+
+	it("recents가 있어도 텍스트를 입력하면 recents 그룹이 숨겨진다", async () => {
+		// Arrange
+		sessionStorage.setItem(
+			"tkstar-palette-recent",
+			JSON.stringify([{ slug: "/", title: "Home", group: "pages" }]),
+		);
+		mockFetch(makeIndexPayload());
+		renderPalette();
+		await openWithCmdK();
+		const input = screen.getByTestId("palette-input");
+
+		// Act
+		await act(async () => {
+			fireEvent.change(input, { target: { value: "x" } });
+		});
+
+		// Assert
+		expect(screen.queryByTestId("palette-group-recents")).toBeNull();
+	});
+
+	it("두 번째 항목에 포인터 진입 시 해당 항목의 data-active가 true, 첫 번째는 false다", async () => {
+		// Arrange
+		const payload = makeIndexPayload({
+			pages: [
+				{ slug: "/about", title: "About" },
+				{ slug: "/projects", title: "Projects" },
+			],
+		});
+		mockFetch(payload);
+		renderPalette();
+		await openWithCmdK();
+
+		// Act
+		const secondItem = screen.getByTestId("palette-item-pages-/projects");
+		await act(async () => {
+			secondItem.dispatchEvent(new PointerEvent("pointerenter", { bubbles: true }));
+		});
+
+		// Assert
+		expect(secondItem).toHaveAttribute("data-active", "true");
+		expect(screen.getByTestId("palette-item-pages-/about")).toHaveAttribute("data-active", "false");
+	});
+
+	it("Escape 키로 열려 있는 팔레트가 닫힌다", async () => {
+		// Arrange
+		mockFetch(makeIndexPayload());
+		renderPalette();
+		await openWithCmdK();
+		expect(screen.getByTestId("palette-modal")).toBeInTheDocument();
+
+		// Act
+		await act(async () => {
+			window.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+		});
+
+		// Assert
+		expect(screen.queryByTestId("palette-modal")).toBeNull();
+	});
+});

--- a/app/presentation/hooks/__tests__/useCommandPalette.test.ts
+++ b/app/presentation/hooks/__tests__/useCommandPalette.test.ts
@@ -1,0 +1,361 @@
+import { act, renderHook } from "@testing-library/react";
+import { createElement } from "react";
+import { MemoryRouter } from "react-router";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { SearchableItem } from "~/application/search/lib/token-search";
+import { useCommandPalette } from "../useCommandPalette";
+
+// react-router의 useNavigate를 모킹한다
+const navigate = vi.fn();
+vi.mock("react-router", async (orig) => {
+	const actual = await orig<typeof import("react-router")>();
+	return { ...actual, useNavigate: () => navigate };
+});
+
+// 검색 인덱스 페이로드 헬퍼
+const makeIndexPayload = (overrides?: {
+	pages?: SearchableItem[];
+	projects?: SearchableItem[];
+	posts?: SearchableItem[];
+}) => ({
+	pages: overrides?.pages ?? [],
+	projects: overrides?.projects ?? [],
+	posts: overrides?.posts ?? [],
+});
+
+// fetch 모킹 헬퍼
+const mockFetch = (payload: ReturnType<typeof makeIndexPayload>) => {
+	globalThis.fetch = vi.fn(async () => new Response(JSON.stringify(payload), { status: 200 }));
+};
+
+// renderHook을 MemoryRouter로 감싸는 래퍼
+const wrapper = ({ children }: { children: React.ReactNode }) =>
+	createElement(MemoryRouter, null, children);
+
+// 키다운 이벤트 디스패치 헬퍼
+const fireKey = (key: string, opts: { metaKey?: boolean; ctrlKey?: boolean } = {}) => {
+	window.dispatchEvent(new KeyboardEvent("keydown", { key, bubbles: true, ...opts }));
+};
+
+describe("useCommandPalette", () => {
+	beforeEach(() => {
+		sessionStorage.clear();
+		vi.restoreAllMocks();
+		navigate.mockReset();
+	});
+
+	describe("초기 상태", () => {
+		it("초기 상태: isOpen=false, query='', activeIndex=0이다", () => {
+			// Arrange
+			mockFetch(makeIndexPayload());
+
+			// Act
+			const { result } = renderHook(() => useCommandPalette(), { wrapper });
+
+			// Assert
+			expect(result.current.isOpen).toBe(false);
+			expect(result.current.query).toBe("");
+			expect(result.current.activeIndex).toBe(0);
+		});
+	});
+
+	describe("키보드 단축키", () => {
+		it("macOS 단축키(metaKey+k)로 팔레트가 열린다", async () => {
+			// Arrange
+			mockFetch(makeIndexPayload());
+			const { result } = renderHook(() => useCommandPalette(), { wrapper });
+
+			// Act
+			await act(async () => {
+				fireKey("k", { metaKey: true });
+			});
+
+			// Assert
+			expect(result.current.isOpen).toBe(true);
+		});
+
+		it("Win/Linux 단축키(ctrlKey+k)로 팔레트가 열린다", async () => {
+			// Arrange
+			mockFetch(makeIndexPayload());
+			const { result } = renderHook(() => useCommandPalette(), { wrapper });
+
+			// Act
+			await act(async () => {
+				fireKey("k", { ctrlKey: true });
+			});
+
+			// Assert
+			expect(result.current.isOpen).toBe(true);
+		});
+
+		it("슬래시('/') 단축키로 팔레트가 열린다", async () => {
+			// Arrange
+			mockFetch(makeIndexPayload());
+			const { result } = renderHook(() => useCommandPalette(), { wrapper });
+
+			// Act
+			await act(async () => {
+				fireKey("/");
+			});
+
+			// Assert
+			expect(result.current.isOpen).toBe(true);
+		});
+
+		it("Escape 키로 열린 팔레트가 닫힌다", async () => {
+			// Arrange
+			mockFetch(makeIndexPayload());
+			const { result } = renderHook(() => useCommandPalette(), { wrapper });
+			await act(async () => {
+				result.current.open();
+			});
+			expect(result.current.isOpen).toBe(true);
+
+			// Act
+			await act(async () => {
+				fireKey("Escape");
+			});
+
+			// Assert
+			expect(result.current.isOpen).toBe(false);
+		});
+	});
+
+	describe("포커스 가드", () => {
+		it("<input>에 포커스가 있으면 단축키로 팔레트가 열리지 않는다", async () => {
+			// Arrange
+			mockFetch(makeIndexPayload());
+			const input = document.createElement("input");
+			document.body.appendChild(input);
+			input.focus();
+			const { result } = renderHook(() => useCommandPalette(), { wrapper });
+
+			// Act
+			await act(async () => {
+				fireKey("k", { metaKey: true });
+				fireKey("k", { ctrlKey: true });
+				fireKey("/");
+			});
+
+			// Assert
+			expect(result.current.isOpen).toBe(false);
+			document.body.removeChild(input);
+		});
+
+		it("<textarea>에 포커스가 있으면 단축키로 팔레트가 열리지 않는다", async () => {
+			// Arrange
+			mockFetch(makeIndexPayload());
+			const textarea = document.createElement("textarea");
+			document.body.appendChild(textarea);
+			textarea.focus();
+			const { result } = renderHook(() => useCommandPalette(), { wrapper });
+
+			// Act
+			await act(async () => {
+				fireKey("k", { metaKey: true });
+				fireKey("k", { ctrlKey: true });
+				fireKey("/");
+			});
+
+			// Assert
+			expect(result.current.isOpen).toBe(false);
+			document.body.removeChild(textarea);
+		});
+
+		it("[contenteditable]에 포커스가 있으면 단축키로 팔레트가 열리지 않는다", async () => {
+			// Arrange
+			mockFetch(makeIndexPayload());
+			const div = document.createElement("div");
+			div.setAttribute("contenteditable", "true");
+			document.body.appendChild(div);
+			div.focus();
+			const { result } = renderHook(() => useCommandPalette(), { wrapper });
+
+			// Act
+			await act(async () => {
+				fireKey("k", { metaKey: true });
+				fireKey("k", { ctrlKey: true });
+				fireKey("/");
+			});
+
+			// Assert
+			expect(result.current.isOpen).toBe(false);
+			document.body.removeChild(div);
+		});
+	});
+
+	describe("lazy fetch", () => {
+		it("팔레트를 열고 닫고 다시 열어도 fetch('/search-index.json')는 정확히 1회만 호출된다", async () => {
+			// Arrange
+			const pages: SearchableItem[] = [{ slug: "/about", title: "About" }];
+			mockFetch(makeIndexPayload({ pages }));
+			const { result } = renderHook(() => useCommandPalette(), { wrapper });
+
+			// Act
+			await act(async () => {
+				result.current.open();
+			});
+			await act(async () => {
+				result.current.close();
+			});
+			await act(async () => {
+				result.current.open();
+			});
+
+			// Assert
+			expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+			expect(globalThis.fetch).toHaveBeenCalledWith("/search-index.json");
+			expect(result.current.groups.pages.length).toBe(1);
+		});
+	});
+
+	describe("키보드 네비게이션", () => {
+		it("ArrowDown으로 activeIndex가 증가하고 마지막 항목에서 클램핑된다", async () => {
+			// Arrange
+			const pages: SearchableItem[] = [
+				{ slug: "/", title: "Home" },
+				{ slug: "/about", title: "About" },
+			];
+			mockFetch(makeIndexPayload({ pages }));
+			const { result } = renderHook(() => useCommandPalette(), { wrapper });
+			await act(async () => {
+				result.current.open();
+			});
+			expect(result.current.flatItems.length).toBeGreaterThan(1);
+
+			// Act & Assert — 아래로 이동
+			await act(async () => {
+				fireKey("ArrowDown");
+			});
+			expect(result.current.activeIndex).toBe(1);
+
+			// 마지막 항목에서 클램핑
+			await act(async () => {
+				fireKey("ArrowDown");
+			});
+			expect(result.current.activeIndex).toBe(result.current.flatItems.length - 1);
+		});
+
+		it("ArrowUp으로 activeIndex가 감소하고 0에서 클램핑된다", async () => {
+			// Arrange
+			const pages: SearchableItem[] = [
+				{ slug: "/", title: "Home" },
+				{ slug: "/about", title: "About" },
+			];
+			mockFetch(makeIndexPayload({ pages }));
+			const { result } = renderHook(() => useCommandPalette(), { wrapper });
+			await act(async () => {
+				result.current.open();
+			});
+
+			// Act & Assert — 위로 이동 시 0에서 클램핑
+			await act(async () => {
+				fireKey("ArrowUp");
+			});
+			expect(result.current.activeIndex).toBe(0);
+		});
+	});
+
+	describe("선택 동작", () => {
+		it("Enter 키로 active 항목을 선택하면 navigate 호출, recent 저장, isOpen=false가 된다", async () => {
+			// Arrange
+			const pages: SearchableItem[] = [
+				{ slug: "/about", title: "About" },
+				{ slug: "/projects", title: "Projects" },
+			];
+			mockFetch(makeIndexPayload({ pages }));
+			const { result } = renderHook(() => useCommandPalette(), { wrapper });
+			await act(async () => {
+				result.current.open();
+			});
+			expect(result.current.flatItems.length).toBeGreaterThan(0);
+
+			// Act
+			await act(async () => {
+				fireKey("Enter");
+			});
+
+			// Assert
+			const firstItem = result.current.flatItems[0] ?? {
+				href: "/about",
+				slug: "/about",
+				title: "About",
+				group: "pages",
+			};
+			expect(navigate).toHaveBeenCalledTimes(1);
+			expect(navigate).toHaveBeenCalledWith(firstItem.href);
+			const storedRaw = sessionStorage.getItem("tkstar-palette-recent");
+			expect(storedRaw).not.toBeNull();
+			const stored = JSON.parse(storedRaw as string) as Array<{
+				slug: string;
+				title: string;
+				group: string;
+			}>;
+			expect(stored.length).toBeGreaterThanOrEqual(1);
+			expect(result.current.isOpen).toBe(false);
+		});
+
+		it("query가 비어 있고 recents가 있으면 recents가 flatItems에 노출된다", async () => {
+			// Arrange
+			sessionStorage.setItem(
+				"tkstar-palette-recent",
+				JSON.stringify([{ slug: "/", title: "Home", group: "pages" }]),
+			);
+			mockFetch(makeIndexPayload());
+			const { result } = renderHook(() => useCommandPalette(), { wrapper });
+
+			// Act
+			await act(async () => {
+				result.current.open();
+			});
+
+			// Assert
+			expect(result.current.recents.length).toBe(1);
+			expect(result.current.flatItems[0]?.slug).toBe("/");
+		});
+
+		it("query가 비어 있지 않으면 recents가 숨겨진다", async () => {
+			// Arrange
+			sessionStorage.setItem(
+				"tkstar-palette-recent",
+				JSON.stringify([{ slug: "/", title: "Home", group: "pages" }]),
+			);
+			mockFetch(makeIndexPayload());
+			const { result } = renderHook(() => useCommandPalette(), { wrapper });
+			await act(async () => {
+				result.current.open();
+			});
+
+			// Act
+			await act(async () => {
+				result.current.setQuery("about");
+			});
+
+			// Assert
+			expect(result.current.recents.length).toBe(0);
+		});
+
+		it("query 입력 시 tokenSearch로 groups가 필터링된다", async () => {
+			// Arrange
+			const pages: SearchableItem[] = [
+				{ slug: "/about", title: "About" },
+				{ slug: "/blog", title: "Blog" },
+			];
+			mockFetch(makeIndexPayload({ pages }));
+			const { result } = renderHook(() => useCommandPalette(), { wrapper });
+			await act(async () => {
+				result.current.open();
+			});
+
+			// Act
+			await act(async () => {
+				result.current.setQuery("about");
+			});
+
+			// Assert
+			expect(result.current.groups.pages.length).toBe(1);
+			expect(result.current.groups.pages[0]?.slug).toBe("/about");
+		});
+	});
+});

--- a/app/presentation/hooks/useCommandPalette.ts
+++ b/app/presentation/hooks/useCommandPalette.ts
@@ -8,6 +8,8 @@ export type PaletteGroup = "pages" | "projects" | "posts";
 export type PaletteEntry = SearchableItem & {
 	group: PaletteGroup;
 	href: string;
+	date?: string;
+	read?: number;
 };
 
 export type CommandPaletteApi = {
@@ -24,10 +26,12 @@ export type CommandPaletteApi = {
 	selectActive: () => void;
 };
 
+type IndexedPost = SearchableItem & { date?: string; read?: number };
+
 type SearchIndexPayload = {
 	pages: SearchableItem[];
 	projects: SearchableItem[];
-	posts: SearchableItem[];
+	posts: IndexedPost[];
 };
 
 type PaletteCommand = "open" | "close";
@@ -49,7 +53,10 @@ export const closeCommandPalette = (): void => {
 const hrefFor = (group: PaletteGroup, slug: string): string =>
 	group === "pages" ? slug : group === "projects" ? `/projects/${slug}` : `/blog/${slug}`;
 
-const toEntry = (item: SearchableItem, group: PaletteGroup): PaletteEntry => ({
+const toEntry = (
+	item: SearchableItem & { date?: string; read?: number },
+	group: PaletteGroup,
+): PaletteEntry => ({
 	...item,
 	group,
 	href: hrefFor(group, item.slug),

--- a/app/presentation/hooks/useCommandPalette.ts
+++ b/app/presentation/hooks/useCommandPalette.ts
@@ -1,8 +1,41 @@
-// T010 placeholder. T016에서 실제 Command Palette open 로직으로 교체.
-export const useCommandPalette = (): { open: () => void } => {
+import type { SearchableItem } from "~/application/search/lib/token-search";
+
+export type PaletteGroup = "pages" | "projects" | "posts";
+
+export type PaletteEntry = SearchableItem & {
+	group: PaletteGroup;
+	href: string;
+};
+
+export type CommandPaletteApi = {
+	isOpen: boolean;
+	open: () => void;
+	close: () => void;
+	query: string;
+	setQuery: (q: string) => void;
+	groups: { pages: PaletteEntry[]; projects: PaletteEntry[]; posts: PaletteEntry[] };
+	recents: PaletteEntry[];
+	flatItems: PaletteEntry[];
+	activeIndex: number;
+	setActiveIndex: (i: number) => void;
+	selectActive: () => void;
+};
+
+const noop = (): void => {};
+
+// T010 placeholder. Cycle 4 Green 에서 실제 구현으로 교체.
+export const useCommandPalette = (): CommandPaletteApi => {
 	return {
-		open: () => {
-			/* T016 wires real palette */
-		},
+		isOpen: false,
+		open: noop,
+		close: noop,
+		query: "",
+		setQuery: noop,
+		groups: { pages: [], projects: [], posts: [] },
+		recents: [],
+		flatItems: [],
+		activeIndex: 0,
+		setActiveIndex: noop,
+		selectActive: noop,
 	};
 };

--- a/app/presentation/hooks/useCommandPalette.ts
+++ b/app/presentation/hooks/useCommandPalette.ts
@@ -120,10 +120,7 @@ export const useCommandPalette = (): CommandPaletteApi => {
 
 	const visibleRecents = trimmed ? [] : recents;
 	const flatItems = useMemo(
-		() =>
-			visibleRecents.length > 0
-				? visibleRecents
-				: [...groups.pages, ...groups.projects, ...groups.posts],
+		() => [...visibleRecents, ...groups.pages, ...groups.projects, ...groups.posts],
 		[visibleRecents, groups],
 	);
 

--- a/app/presentation/hooks/useCommandPalette.ts
+++ b/app/presentation/hooks/useCommandPalette.ts
@@ -30,7 +30,21 @@ type SearchIndexPayload = {
 	posts: SearchableItem[];
 };
 
+type PaletteCommand = "open" | "close";
+
 const SEARCH_INDEX_URL = "/search-index.json";
+
+// Module-level command channel — Topbar/HeroWhoami fire commands without
+// owning their own palette state. Single ChromeLayout instance subscribes.
+const commandSubscribers = new Set<(cmd: PaletteCommand) => void>();
+
+export const openCommandPalette = (): void => {
+	for (const fn of commandSubscribers) fn("open");
+};
+
+export const closeCommandPalette = (): void => {
+	for (const fn of commandSubscribers) fn("close");
+};
 
 const hrefFor = (group: PaletteGroup, slug: string): string =>
 	group === "pages" ? slug : group === "projects" ? `/projects/${slug}` : `/blog/${slug}`;
@@ -113,8 +127,19 @@ export const useCommandPalette = (): CommandPaletteApi => {
 		[visibleRecents, groups],
 	);
 
+	// Keep latest values reachable from the keydown handler without
+	// re-registering the window listener on every render.
+	const flatItemsRef = useRef(flatItems);
+	const activeIndexRef = useRef(activeIndex);
+	useEffect(() => {
+		flatItemsRef.current = flatItems;
+	}, [flatItems]);
+	useEffect(() => {
+		activeIndexRef.current = activeIndex;
+	}, [activeIndex]);
+
 	const selectActive = useCallback(() => {
-		const item = flatItems[activeIndex];
+		const item = flatItemsRef.current[activeIndexRef.current];
 		if (!item) {
 			setIsOpen(false);
 			return;
@@ -122,7 +147,7 @@ export const useCommandPalette = (): CommandPaletteApi => {
 		pushRecent({ slug: item.slug, title: item.title, group: item.group });
 		navigate(item.href);
 		setIsOpen(false);
-	}, [activeIndex, flatItems, navigate]);
+	}, [navigate]);
 
 	useEffect(() => {
 		const handler = (e: KeyboardEvent) => {
@@ -140,7 +165,8 @@ export const useCommandPalette = (): CommandPaletteApi => {
 			if (!isOpen) return;
 			if (e.key === "ArrowDown") {
 				e.preventDefault();
-				setActiveIndex((i) => Math.min(i + 1, Math.max(0, flatItems.length - 1)));
+				const max = Math.max(0, flatItemsRef.current.length - 1);
+				setActiveIndex((i) => Math.min(i + 1, max));
 			} else if (e.key === "ArrowUp") {
 				e.preventDefault();
 				setActiveIndex((i) => Math.max(0, i - 1));
@@ -151,7 +177,18 @@ export const useCommandPalette = (): CommandPaletteApi => {
 		};
 		window.addEventListener("keydown", handler);
 		return () => window.removeEventListener("keydown", handler);
-	}, [isOpen, flatItems.length, open, selectActive]);
+	}, [isOpen, open, selectActive]);
+
+	useEffect(() => {
+		const sub = (cmd: PaletteCommand) => {
+			if (cmd === "open") open();
+			else setIsOpen(false);
+		};
+		commandSubscribers.add(sub);
+		return () => {
+			commandSubscribers.delete(sub);
+		};
+	}, [open]);
 
 	return {
 		isOpen,

--- a/app/presentation/hooks/useCommandPalette.ts
+++ b/app/presentation/hooks/useCommandPalette.ts
@@ -1,4 +1,7 @@
-import type { SearchableItem } from "~/application/search/lib/token-search";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useNavigate } from "react-router";
+import { tokenSearch, type SearchableItem } from "~/application/search/lib/token-search";
+import { getRecent, pushRecent, type RecentItem } from "~/presentation/lib/recent-visits";
 
 export type PaletteGroup = "pages" | "projects" | "posts";
 
@@ -21,21 +24,146 @@ export type CommandPaletteApi = {
 	selectActive: () => void;
 };
 
-const noop = (): void => {};
+type SearchIndexPayload = {
+	pages: SearchableItem[];
+	projects: SearchableItem[];
+	posts: SearchableItem[];
+};
 
-// T010 placeholder. Cycle 4 Green 에서 실제 구현으로 교체.
+const SEARCH_INDEX_URL = "/search-index.json";
+
+const hrefFor = (group: PaletteGroup, slug: string): string =>
+	group === "pages" ? slug : group === "projects" ? `/projects/${slug}` : `/blog/${slug}`;
+
+const toEntry = (item: SearchableItem, group: PaletteGroup): PaletteEntry => ({
+	...item,
+	group,
+	href: hrefFor(group, item.slug),
+});
+
+const recentToEntry = (r: RecentItem): PaletteEntry => ({
+	slug: r.slug,
+	title: r.title,
+	group: r.group,
+	href: hrefFor(r.group, r.slug),
+});
+
+const isInputFocused = (el: Element | null): boolean => {
+	if (!el) return false;
+	const tag = el.tagName;
+	if (tag === "INPUT" || tag === "TEXTAREA") return true;
+	if ((el as HTMLElement).isContentEditable === true) return true;
+	const ce = el.getAttribute("contenteditable");
+	return ce === "" || ce === "true";
+};
+
 export const useCommandPalette = (): CommandPaletteApi => {
+	const navigate = useNavigate();
+	const [isOpen, setIsOpen] = useState(false);
+	const [query, setQuery] = useState("");
+	const [activeIndex, setActiveIndex] = useState(0);
+	const [index, setIndex] = useState<SearchIndexPayload>({
+		pages: [],
+		projects: [],
+		posts: [],
+	});
+	const [recents, setRecents] = useState<PaletteEntry[]>([]);
+	const fetchRef = useRef<Promise<SearchIndexPayload> | null>(null);
+
+	const ensureIndex = useCallback(() => {
+		if (!fetchRef.current) {
+			fetchRef.current = (async () => {
+				const res = await fetch(SEARCH_INDEX_URL);
+				const payload = (await res.json()) as SearchIndexPayload;
+				setIndex(payload);
+				return payload;
+			})();
+		}
+		return fetchRef.current;
+	}, []);
+
+	const open = useCallback(() => {
+		setRecents(getRecent().map(recentToEntry));
+		setActiveIndex(0);
+		setIsOpen(true);
+		void ensureIndex();
+	}, [ensureIndex]);
+
+	const close = useCallback(() => {
+		setIsOpen(false);
+	}, []);
+
+	const trimmed = query.trim();
+	const groups = useMemo(() => {
+		const filterGroup = (items: SearchableItem[], group: PaletteGroup) =>
+			(trimmed ? tokenSearch(items, trimmed) : items).map((it) => toEntry(it, group));
+		return {
+			pages: filterGroup(index.pages, "pages"),
+			projects: filterGroup(index.projects, "projects"),
+			posts: filterGroup(index.posts, "posts"),
+		};
+	}, [index, trimmed]);
+
+	const visibleRecents = trimmed ? [] : recents;
+	const flatItems = useMemo(
+		() =>
+			visibleRecents.length > 0
+				? visibleRecents
+				: [...groups.pages, ...groups.projects, ...groups.posts],
+		[visibleRecents, groups],
+	);
+
+	const selectActive = useCallback(() => {
+		const item = flatItems[activeIndex];
+		if (!item) {
+			setIsOpen(false);
+			return;
+		}
+		pushRecent({ slug: item.slug, title: item.title, group: item.group });
+		navigate(item.href);
+		setIsOpen(false);
+	}, [activeIndex, flatItems, navigate]);
+
+	useEffect(() => {
+		const handler = (e: KeyboardEvent) => {
+			if (e.key === "Escape") {
+				setIsOpen(false);
+				return;
+			}
+			const isShortcut = ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "k") || e.key === "/";
+			if (isShortcut) {
+				if (isInputFocused(document.activeElement)) return;
+				e.preventDefault();
+				open();
+				return;
+			}
+			if (!isOpen) return;
+			if (e.key === "ArrowDown") {
+				e.preventDefault();
+				setActiveIndex((i) => Math.min(i + 1, Math.max(0, flatItems.length - 1)));
+			} else if (e.key === "ArrowUp") {
+				e.preventDefault();
+				setActiveIndex((i) => Math.max(0, i - 1));
+			} else if (e.key === "Enter") {
+				e.preventDefault();
+				selectActive();
+			}
+		};
+		window.addEventListener("keydown", handler);
+		return () => window.removeEventListener("keydown", handler);
+	}, [isOpen, flatItems.length, open, selectActive]);
+
 	return {
-		isOpen: false,
-		open: noop,
-		close: noop,
-		query: "",
-		setQuery: noop,
-		groups: { pages: [], projects: [], posts: [] },
-		recents: [],
-		flatItems: [],
-		activeIndex: 0,
-		setActiveIndex: noop,
-		selectActive: noop,
+		isOpen,
+		open,
+		close,
+		query,
+		setQuery,
+		groups,
+		recents: visibleRecents,
+		flatItems,
+		activeIndex,
+		setActiveIndex,
+		selectActive,
 	};
 };

--- a/app/presentation/layouts/ChromeLayout.tsx
+++ b/app/presentation/layouts/ChromeLayout.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from "react";
 import Footer from "../components/chrome/Footer";
 import Topbar from "../components/chrome/Topbar";
+import CommandPalette from "../components/palette/CommandPalette";
 
 export default function ChromeLayout({ children }: { children: ReactNode }) {
 	return (
@@ -10,6 +11,7 @@ export default function ChromeLayout({ children }: { children: ReactNode }) {
 				{children}
 			</main>
 			<Footer />
+			<CommandPalette />
 		</>
 	);
 }

--- a/app/presentation/layouts/__tests__/ChromeLayout.test.tsx
+++ b/app/presentation/layouts/__tests__/ChromeLayout.test.tsx
@@ -7,6 +7,9 @@ vi.mock("../../components/chrome/Topbar", () => ({
 vi.mock("../../components/chrome/Footer", () => ({
 	default: () => <footer data-testid="footer-mock" />,
 }));
+vi.mock("../../components/palette/CommandPalette", () => ({
+	default: () => null,
+}));
 
 import ChromeLayout from "../ChromeLayout";
 

--- a/app/presentation/lib/__tests__/recent-visits.test.ts
+++ b/app/presentation/lib/__tests__/recent-visits.test.ts
@@ -1,0 +1,126 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { getRecent, pushRecent, type RecentItem } from "../recent-visits";
+
+describe("recent-visits", () => {
+	beforeEach(() => {
+		sessionStorage.clear();
+	});
+
+	it("스토리지가 비어 있을 때 getRecent()는 빈 배열을 반환한다", () => {
+		// Act
+		const result = getRecent();
+
+		// Assert
+		expect(result).toEqual([]);
+	});
+
+	it("pushRecent 후 getRecent()는 해당 아이템을 반환한다", () => {
+		// Arrange
+		const item: RecentItem = { slug: "home", title: "홈", group: "pages" };
+
+		// Act
+		pushRecent(item);
+		const result = getRecent();
+
+		// Assert
+		expect(result).toEqual([item]);
+	});
+
+	it("가장 최근에 push한 아이템이 앞에 위치한다 (most-recent-first)", () => {
+		// Arrange
+		const a: RecentItem = { slug: "a", title: "A", group: "pages" };
+		const b: RecentItem = { slug: "b", title: "B", group: "projects" };
+		const c: RecentItem = { slug: "c", title: "C", group: "posts" };
+
+		// Act
+		pushRecent(a);
+		pushRecent(b);
+		pushRecent(c);
+		const result = getRecent();
+
+		// Assert
+		expect(result).toEqual([c, b, a]);
+	});
+
+	it("6번째 아이템 push 시 최대 5개로 제한되고 가장 오래된 항목이 제거된다", () => {
+		// Arrange
+		const items: RecentItem[] = [
+			{ slug: "first", title: "First", group: "pages" },
+			{ slug: "second", title: "Second", group: "pages" },
+			{ slug: "third", title: "Third", group: "pages" },
+			{ slug: "fourth", title: "Fourth", group: "pages" },
+			{ slug: "fifth", title: "Fifth", group: "pages" },
+			{ slug: "sixth", title: "Sixth", group: "pages" },
+		];
+
+		// Act
+		for (const item of items) {
+			pushRecent(item);
+		}
+		const result = getRecent();
+
+		// Assert
+		expect(result).toHaveLength(5);
+		expect(result.map((i: RecentItem) => i.slug)).not.toContain("first");
+	});
+
+	it("동일 slug push 시 기존 항목을 제거하고 새 메타데이터로 앞에 위치시킨다 (LRU move-to-front)", () => {
+		// Arrange
+		const aOriginal: RecentItem = { slug: "a", title: "A", group: "pages" };
+		const b: RecentItem = { slug: "b", title: "B", group: "projects" };
+		const aUpdated: RecentItem = { slug: "a", title: "updated A", group: "projects" };
+
+		// Act
+		pushRecent(aOriginal);
+		pushRecent(b);
+		pushRecent(aUpdated);
+		const result = getRecent();
+
+		// Assert
+		expect(result).toHaveLength(2);
+		expect(result[0]).toEqual(aUpdated);
+		expect(result[1]).toEqual(b);
+	});
+
+	it("pushRecent 후 getRecent()를 두 번 호출해도 동일한 결과를 반환한다 (sessionStorage 영속)", () => {
+		// Arrange
+		const item: RecentItem = { slug: "about", title: "About", group: "pages" };
+
+		// Act
+		pushRecent(item);
+		const first = getRecent();
+		const second = getRecent();
+
+		// Assert
+		expect(first).toEqual(second);
+	});
+
+	it("sessionStorage에 깨진 JSON이 있을 때 getRecent()는 빈 배열을 반환한다 (에러 미전파)", () => {
+		// Arrange
+		sessionStorage.setItem("tkstar-palette-recent", "not-json{{{");
+
+		// Act
+		const result = getRecent();
+
+		// Assert
+		expect(result).toEqual([]);
+	});
+
+	it("다양한 group 값이 sessionStorage를 통해 그대로 보존된다", () => {
+		// Arrange
+		const page: RecentItem = { slug: "home", title: "홈", group: "pages" };
+		const project: RecentItem = { slug: "proj-a", title: "프로젝트 A", group: "projects" };
+		const post: RecentItem = { slug: "post-1", title: "포스트 1", group: "posts" };
+
+		// Act
+		pushRecent(page);
+		pushRecent(project);
+		pushRecent(post);
+		const result = getRecent();
+
+		// Assert
+		expect(result[0].group).toBe("posts");
+		expect(result[1].group).toBe("projects");
+		expect(result[2].group).toBe("pages");
+	});
+});

--- a/app/presentation/lib/recent-visits.ts
+++ b/app/presentation/lib/recent-visits.ts
@@ -1,0 +1,38 @@
+export type RecentItem = {
+	slug: string;
+	title: string;
+	group: "pages" | "projects" | "posts";
+};
+
+const KEY = "tkstar-palette-recent";
+const MAX = 5;
+
+const isRecentItem = (value: unknown): value is RecentItem => {
+	if (typeof value !== "object" || value === null) return false;
+	const v = value as Record<string, unknown>;
+	return (
+		typeof v.slug === "string" &&
+		typeof v.title === "string" &&
+		(v.group === "pages" || v.group === "projects" || v.group === "posts")
+	);
+};
+
+export const getRecent = (): RecentItem[] => {
+	if (typeof sessionStorage === "undefined") return [];
+	const raw = sessionStorage.getItem(KEY);
+	if (raw === null) return [];
+	try {
+		const parsed = JSON.parse(raw);
+		if (!Array.isArray(parsed)) return [];
+		return parsed.filter(isRecentItem);
+	} catch {
+		return [];
+	}
+};
+
+export const pushRecent = (item: RecentItem): void => {
+	if (typeof sessionStorage === "undefined") return;
+	const current = getRecent().filter((existing) => existing.slug !== item.slug);
+	const next = [item, ...current].slice(0, MAX);
+	sessionStorage.setItem(KEY, JSON.stringify(next));
+};

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -368,7 +368,7 @@ tkstarDev는 다음 핵심 가치를 단일 도메인에서 달성한다:
 > **진입 조건**: Phase 3 완료 (DI 가동, 라우트 동작 확인)
 > **완료 조건 (DoD)**: AC-F008-1/2/3/4, AC-F009-1/2/3 모두 자동 테스트 통과. 실제 hello@tkstar.dev → 본인 메일 + 제출자 자동응답이 staging에서 발송 확인.
 
-- [ ] **Task 016: F016 Cmd+K Command Palette (글로벌 검색 네비)**
+- [x] **Task 016: F016 Cmd+K Command Palette (글로벌 검색 네비)**
   - **Must** Read: [tasks/T016-command-palette.md](tasks/T016-command-palette.md)
   - blockedBy: Task 003, Task 008, Task 009, Task 010 (Home에서 트리거)
   - Layer: Application(`build-search-index.service.ts`) + Presentation(palette UI/hook)

--- a/docs/tasks/T016-command-palette.md
+++ b/docs/tasks/T016-command-palette.md
@@ -35,14 +35,14 @@
 - FlexSearch/Fuse 도입 (콘텐츠 100+ 시 재검토)
 
 ## Acceptance Criteria (PRD AC 인용)
-- [ ] **AC-F016-1**: 페이지에 입력 포커스가 없다 → ⌘K(macOS) 또는 Ctrl+K(Win/Linux) 또는 `/` 입력 → palette가 열리고 검색 input에 자동 포커스
-- [ ] **AC-F016-2**: input/textarea/contenteditable에 포커스가 있다 → 위 단축키 입력 → palette가 열리지 않고 기본 입력 동작 유지
-- [ ] **AC-F016-3**: palette 열림 + 검색어 "rou nav" → 토큰 기반 필터 → "rou"와 "nav"를 모두 포함하는 항목만 그룹 헤더(pages/projects/posts) 별로 표시
-- [ ] **AC-F016-4**: 결과 리스트 → ↓ ↑로 네비 + ↵로 진입 + Esc로 닫기 → 키보드만으로 모든 동작 + 마우스 호버 시 선택 인덱스 동기화
-- [ ] **AC-F016-5**: 사이트가 처음 로드 → 검색 인덱스 fetch → JSON gzip 100KB 이하 + 본문(body) 미포함 + 세션당 1회만 fetch
+- [x] **AC-F016-1**: 페이지에 입력 포커스가 없다 → ⌘K(macOS) 또는 Ctrl+K(Win/Linux) 또는 `/` 입력 → palette가 열리고 검색 input에 자동 포커스
+- [x] **AC-F016-2**: input/textarea/contenteditable에 포커스가 있다 → 위 단축키 입력 → palette가 열리지 않고 기본 입력 동작 유지
+- [x] **AC-F016-3**: palette 열림 + 검색어 "rou nav" → 토큰 기반 필터 → "rou"와 "nav"를 모두 포함하는 항목만 그룹 헤더(pages/projects/posts) 별로 표시
+- [x] **AC-F016-4**: 결과 리스트 → ↓ ↑로 네비 + ↵로 진입 + Esc로 닫기 → 키보드만으로 모든 동작 + 마우스 호버 시 선택 인덱스 동기화
+- [x] **AC-F016-5**: 사이트가 처음 로드 → 검색 인덱스 fetch → JSON gzip 100KB 이하 + 본문(body) 미포함 + 세션당 1회만 fetch
 
 ### Task 추가 AC (Issue #7 보강)
-- [ ] cross-platform 단축키 분기 명시: macOS는 `event.metaKey === true`, Windows·Linux는 `event.ctrlKey === true`, `/`는 공통 — RTL `userEvent.keyboard('{Meta>}k{/Meta}')` / `'{Control>}k{/Control}'` / `'/'` 3 케이스 모두 통과
+- [x] cross-platform 단축키 분기 명시: macOS는 `event.metaKey === true`, Windows·Linux는 `event.ctrlKey === true`, `/`는 공통 — RTL `userEvent.keyboard('{Meta>}k{/Meta}')` / `'{Control>}k{/Control}'` / `'/'` 3 케이스 모두 통과
 
 ## Implementation Plan (TDD Cycle)
 

--- a/docs/tasks/T016-command-palette.md
+++ b/docs/tasks/T016-command-palette.md
@@ -11,7 +11,7 @@
 | **PRD Features** | **F016** (Cmd+K Command Palette) |
 | **PRD AC** | **AC-F016-1**, **AC-F016-2**, **AC-F016-3**, **AC-F016-4**, **AC-F016-5** |
 | **예상 작업 시간** | 1.5d |
-| **Status** | Not Started |
+| **Status** | Done |
 
 ## Goal
 사이트의 주 네비게이션 패러다임인 Cmd+K Command Palette를 가동시킨다. ⌘K(macOS) / Ctrl+K(Windows·Linux) / `/` 단축키로 오픈, 토큰 기반 다중 키워드 필터, 키보드/마우스 네비, 빌드 타임 검색 인덱스 lazy fetch까지 모두 AC 통과.

--- a/velite.config.ts
+++ b/velite.config.ts
@@ -1,6 +1,9 @@
+import { mkdirSync, writeFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
 import rehypeShiki from "@shikijs/rehype";
 import rehypeSlug from "rehype-slug";
 import { defineCollection, defineConfig, s } from "velite";
+import { buildSearchIndex } from "./app/application/search/services/build-search-index.service";
 import { extractToc } from "./velite/transforms/extract-toc";
 
 const projects = defineCollection({
@@ -57,6 +60,8 @@ const legal = defineCollection({
 	}),
 });
 
+const SEARCH_INDEX_PATH = resolve(process.cwd(), "public/search-index.json");
+
 export default defineConfig({
 	root: "content",
 	output: { data: ".velite", clean: true },
@@ -67,5 +72,13 @@ export default defineConfig({
 			// biome-ignore lint/suspicious/noExplicitAny: shiki rehype 플러그인 타입 incompat
 			[rehypeShiki as any, { theme: "github-dark" }],
 		],
+	},
+	complete: async (data) => {
+		const index = buildSearchIndex({
+			projects: data.projects ?? [],
+			posts: data.posts ?? [],
+		});
+		mkdirSync(dirname(SEARCH_INDEX_PATH), { recursive: true });
+		writeFileSync(SEARCH_INDEX_PATH, JSON.stringify(index));
 	},
 });


### PR DESCRIPTION
## Summary

T016 (F016) 구현 완료. 사이트 주 네비게이션 패러다임인 ⌘K Command Palette 가동.

- ⌘K (macOS) / Ctrl+K (Win·Linux) / `/` 단축키로 글로벌 오픈
- input/textarea/contenteditable 포커스 가드
- 토큰 기반 AND 필터 + 가중 스코어링 (title +3 / tag +2 / summary +1, 안정 정렬)
- 키보드 네비 (↑↓/Enter/Esc) + 마우스 hover 동기화
- 검색 인덱스 lazy fetch — hook 인스턴스당 1회 (모듈 ref 캐시), gzip 552B (현재 본문 2건 기준; 100KB 한참 여유)
- sessionStorage 최근 5개 LRU empty-state
- Topbar / HeroWhoami trigger 도 active 화 (모바일·마우스 접근성 회복)
- `[data-theme]` 다크모드 parity, 120ms ease motion + reduced-motion 대체

## Changes

**Application (Clean Architecture)**:
- `app/application/search/lib/token-search.ts` — pure tokenSearch 함수 (8 tests)
- `app/application/search/services/build-search-index.service.ts` — buildSearchIndex use case + STATIC_PAGES (7 tests)
- `velite.config.ts` — `complete` 훅에서 `public/search-index.json` 자동 생성

**Presentation**:
- `app/presentation/lib/recent-visits.ts` — sessionStorage LRU (8 tests)
- `app/presentation/hooks/useCommandPalette.ts` — T010 placeholder 교체. ref 기반 stale-closure 방지. module-level command channel (`openCommandPalette` / `closeCommandPalette`) 로 다중 trigger 지원 (15 tests)
- `app/presentation/components/palette/CommandPalette.tsx` — modal/그룹/active row/Korean empty state (10 tests)
- `app/presentation/layouts/ChromeLayout.tsx` — palette 마운트
- `app/presentation/components/chrome/Topbar.tsx` — search trigger 활성화 → openCommandPalette
- `app/presentation/components/home/HeroWhoami.tsx` — onClick={openCommandPalette}
- `app/app.css` — @keyframes palette-backdrop-in / palette-panel-in + reduced-motion 대체

## AC Coverage

- AC-F016-1: ⌘K/Ctrl+K/`/` open + input 자동 포커스 → ✅ (useCommandPalette + CommandPalette tests)
- AC-F016-2: input/textarea/contenteditable 포커스 시 단축키 무시 → ✅
- AC-F016-3: "rou nav" 토큰 AND + 가중 스코어 + 그룹 헤더 → ✅
- AC-F016-4: ↓↑/↵/Esc 키보드 + 마우스 hover 동기화 → ✅
- AC-F016-5: gzip ≤100KB + body 미포함 + 세션당 1회 fetch → ✅

## Test plan

- [x] `bun run test` — 296 tests pass (T016 추가 48건: token-search 8, build-search-index 7, recent-visits 8, useCommandPalette 15, CommandPalette 10)
- [x] `bun run lint` — clean
- [x] `bun run typecheck` — clean
- [x] `bun run velite:build` — `public/search-index.json` 924B raw / 552B gzip 자동 생성
- [ ] dev server 에서 macOS Chrome 다크/라이트 토글 확인 (수동)
- [ ] iOS Safari 모바일에서 Topbar trigger 클릭 동작 확인 (수동)

## Phase 3 Review 결과

- **code-reviewer**: APPROVE WITH FIXES (1 recommended, 3 optional). MINOR-1+2 (stale-closure + handler churn) 적용. MINOR-3/4 는 follow-up.
- **ux-design-lead**: APPROVE WITH FIXES (11). CRITICAL (Topbar disabled) + HIGH×2 (active row 조용한 elevation + ▸ accent arrow) 적용. MEDIUM 6 (focus trap, footer text-faint AA, numeric drift, --color-scrim 토큰 신설 등) + LOW 2 는 디자인 시스템 follow-up Issue 로 분리 추천.

Closes #62

🤖 Generated with [Claude Code](https://claude.com/claude-code)