### PR TITLE
✨ feat: T019 — F018 SEO Meta + Sitemap + Robots + JSON-LD (차등 인덱싱)

### DIFF
--- a/app/application/seo/services/__tests__/build-sitemap.service.test.ts
+++ b/app/application/seo/services/__tests__/build-sitemap.service.test.ts
@@ -1,0 +1,211 @@
+import { describe, expect, it } from "vitest";
+import type { Post } from "~/domain/post/post.entity";
+import type { Project } from "~/domain/project/project.entity";
+import { buildSitemap } from "../build-sitemap.service";
+
+// 공통 픽스처
+const ORIGIN = "https://tkstar.dev";
+const GENERATED_AT = new Date("2026-05-04T12:00:00Z");
+const STATIC_LASTMOD = "2026-05-04";
+
+type SitemapProject = Pick<Project, "slug" | "date">;
+type SitemapPost = Pick<Post, "slug" | "date">;
+
+const baseInput = {
+	origin: ORIGIN,
+	projects: [] as SitemapProject[],
+	posts: [] as SitemapPost[],
+	generatedAt: GENERATED_AT,
+};
+
+describe("buildSitemap — 출력 구조", () => {
+	it("XML 선언으로 시작한다", () => {
+		// Arrange & Act
+		const xml = buildSitemap(baseInput);
+
+		// Assert
+		expect(xml.startsWith('<?xml version="1.0" encoding="UTF-8"?>\n')).toBe(true);
+	});
+
+	it("urlset 여는 태그에 sitemaps.org namespace가 포함된다", () => {
+		// Arrange & Act
+		const xml = buildSitemap(baseInput);
+
+		// Assert
+		expect(xml).toContain('<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">');
+	});
+
+	it("</urlset>로 끝난다", () => {
+		// Arrange & Act
+		const xml = buildSitemap(baseInput);
+
+		// Assert
+		expect(xml.trimEnd().endsWith("</urlset>")).toBe(true);
+	});
+});
+
+describe("buildSitemap — 정적 URL (projects/posts 없음)", () => {
+	it("루트 URL과 lastmod를 포함한다", () => {
+		// Arrange & Act
+		const xml = buildSitemap(baseInput);
+
+		// Assert
+		expect(xml).toContain(`<loc>${ORIGIN}/</loc>`);
+		expect(xml).toContain(`<lastmod>${STATIC_LASTMOD}</lastmod>`);
+	});
+
+	it("/about URL을 포함한다", () => {
+		// Arrange & Act
+		const xml = buildSitemap(baseInput);
+
+		// Assert
+		expect(xml).toContain(`<loc>${ORIGIN}/about</loc>`);
+	});
+
+	it("/projects URL을 포함한다", () => {
+		// Arrange & Act
+		const xml = buildSitemap(baseInput);
+
+		// Assert
+		expect(xml).toContain(`<loc>${ORIGIN}/projects</loc>`);
+	});
+
+	it("/blog URL을 포함한다", () => {
+		// Arrange & Act
+		const xml = buildSitemap(baseInput);
+
+		// Assert
+		expect(xml).toContain(`<loc>${ORIGIN}/blog</loc>`);
+	});
+
+	it("/contact URL을 포함한다", () => {
+		// Arrange & Act
+		const xml = buildSitemap(baseInput);
+
+		// Assert
+		expect(xml).toContain(`<loc>${ORIGIN}/contact</loc>`);
+	});
+
+	it("/legal URL을 포함한다", () => {
+		// Arrange & Act
+		const xml = buildSitemap(baseInput);
+
+		// Assert
+		expect(xml).toContain(`<loc>${ORIGIN}/legal</loc>`);
+	});
+});
+
+describe("buildSitemap — 동적 프로젝트 URL", () => {
+	const projects: SitemapProject[] = [
+		{ slug: "alpha", date: "2025-12-01" },
+		{ slug: "beta", date: "2026-01-15" },
+	];
+
+	it("alpha 슬러그와 lastmod를 포함한다", () => {
+		// Arrange & Act
+		const xml = buildSitemap({ ...baseInput, projects });
+
+		// Assert
+		expect(xml).toContain(`<loc>${ORIGIN}/projects/alpha</loc>`);
+		expect(xml).toContain(`<lastmod>2025-12-01</lastmod>`);
+	});
+
+	it("beta 슬러그와 lastmod를 포함한다", () => {
+		// Arrange & Act
+		const xml = buildSitemap({ ...baseInput, projects });
+
+		// Assert
+		expect(xml).toContain(`<loc>${ORIGIN}/projects/beta</loc>`);
+		expect(xml).toContain(`<lastmod>2026-01-15</lastmod>`);
+	});
+});
+
+describe("buildSitemap — 동적 포스트 URL", () => {
+	const posts: SitemapPost[] = [{ slug: "first-post", date: "2026-04-15" }];
+
+	it("first-post 슬러그와 lastmod를 포함한다", () => {
+		// Arrange & Act
+		const xml = buildSitemap({ ...baseInput, posts });
+
+		// Assert
+		expect(xml).toContain(`<loc>${ORIGIN}/blog/first-post</loc>`);
+		expect(xml).toContain(`<lastmod>2026-04-15</lastmod>`);
+	});
+});
+
+describe("buildSitemap — 날짜 정규화", () => {
+	it("post.date가 ISO 타임스탬프여도 lastmod는 날짜만 출력된다", () => {
+		// Arrange
+		const posts: SitemapPost[] = [{ slug: "ts-post", date: "2026-04-15T10:30:00Z" }];
+
+		// Act
+		const xml = buildSitemap({ ...baseInput, posts });
+
+		// Assert
+		expect(xml).toContain(`<lastmod>2026-04-15</lastmod>`);
+		expect(xml).not.toContain("T10:30:00");
+	});
+});
+
+describe("buildSitemap — 제외 URL 검증", () => {
+	it("/legal/:app/terms 경로가 출력에 포함되지 않는다", () => {
+		// Arrange — 슬러그 값이 앱 이름과 같더라도 /legal/:app/terms는 생성 안 됨
+		const projects: SitemapProject[] = [{ slug: "some-app", date: "2026-01-01" }];
+
+		// Act
+		const xml = buildSitemap({ ...baseInput, projects });
+
+		// Assert
+		expect(xml).not.toContain("/legal/some-app/terms");
+		expect(xml).not.toContain("/legal/some-app/privacy");
+	});
+
+	it("/og/, /rss.xml, /sitemap.xml, /robots.txt 경로가 포함되지 않는다", () => {
+		// Arrange & Act
+		const xml = buildSitemap(baseInput);
+
+		// Assert
+		expect(xml).not.toContain("/og/");
+		expect(xml).not.toContain("/rss.xml");
+		expect(xml).not.toContain("/sitemap.xml");
+		expect(xml).not.toContain("/robots.txt");
+	});
+});
+
+describe("buildSitemap — XML 이스케이프", () => {
+	it("슬러그에 & 또는 < 이 포함될 경우 올바르게 이스케이프된다", () => {
+		// Arrange
+		const projects: SitemapProject[] = [{ slug: "a&b", date: "2026-01-01" }];
+
+		// Act
+		const xml = buildSitemap({ ...baseInput, projects });
+
+		// Assert
+		expect(xml).toContain("&amp;");
+		expect(xml).not.toContain("a&b");
+	});
+});
+
+describe("buildSitemap — 커스텀 origin", () => {
+	it("origin이 다른 도메인이면 해당 도메인으로 URL이 생성된다", () => {
+		// Arrange
+		const previewOrigin = "https://preview.example.com";
+
+		// Act
+		const xml = buildSitemap({ ...baseInput, origin: previewOrigin });
+
+		// Assert
+		expect(xml).toContain(`<loc>${previewOrigin}/about</loc>`);
+	});
+});
+
+describe("buildSitemap — 빈 입력", () => {
+	it("projects와 posts가 모두 빈 배열이면 정적 URL 6개만 포함된다", () => {
+		// Arrange & Act
+		const xml = buildSitemap(baseInput);
+
+		// Assert
+		const locCount = xml.match(/<loc>/g)?.length ?? 0;
+		expect(locCount).toBe(6);
+	});
+});

--- a/app/application/seo/services/build-sitemap.service.ts
+++ b/app/application/seo/services/build-sitemap.service.ts
@@ -1,0 +1,13 @@
+import type { Post } from "~/domain/post/post.entity";
+import type { Project } from "~/domain/project/project.entity";
+
+type SitemapInput = {
+	origin: string;
+	projects: Pick<Project, "slug" | "date">[];
+	posts: Pick<Post, "slug" | "date">[];
+	generatedAt: Date;
+};
+
+export const buildSitemap = (_input: SitemapInput): string => {
+	throw new Error("not implemented");
+};

--- a/app/application/seo/services/build-sitemap.service.ts
+++ b/app/application/seo/services/build-sitemap.service.ts
@@ -8,6 +8,37 @@ type SitemapInput = {
 	generatedAt: Date;
 };
 
-export const buildSitemap = (_input: SitemapInput): string => {
-	throw new Error("not implemented");
+const STATIC_PATHS = ["/", "/about", "/projects", "/blog", "/contact", "/legal"] as const;
+
+const escapeXml = (s: string): string =>
+	s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+
+const toDateOnly = (s: string): string => s.slice(0, 10);
+
+export const buildSitemap = ({ origin, projects, posts, generatedAt }: SitemapInput): string => {
+	const staticLastmod = toDateOnly(generatedAt.toISOString());
+
+	const staticEntries = STATIC_PATHS.map(
+		(path) =>
+			`  <url>\n    <loc>${origin}${path}</loc>\n    <lastmod>${staticLastmod}</lastmod>\n  </url>`,
+	);
+
+	const projectEntries = projects.map(
+		(p) =>
+			`  <url>\n    <loc>${origin}/projects/${escapeXml(p.slug)}</loc>\n    <lastmod>${toDateOnly(p.date)}</lastmod>\n  </url>`,
+	);
+
+	const postEntries = posts.map(
+		(p) =>
+			`  <url>\n    <loc>${origin}/blog/${escapeXml(p.slug)}</loc>\n    <lastmod>${toDateOnly(p.date)}</lastmod>\n  </url>`,
+	);
+
+	return [
+		'<?xml version="1.0" encoding="UTF-8"?>',
+		'<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">',
+		...staticEntries,
+		...projectEntries,
+		...postEntries,
+		"</urlset>",
+	].join("\n");
 };

--- a/app/infrastructure/config/container.ts
+++ b/app/infrastructure/config/container.ts
@@ -12,6 +12,7 @@ import {
 	type SubmitContactFormParams,
 } from "~/application/contact/services/submit-contact-form.service";
 import { buildRssFeed } from "~/application/feed/services/build-rss-feed.service";
+import { buildSitemap } from "~/application/seo/services/build-sitemap.service";
 import { renderPostOg } from "~/application/og/services/render-post-og.service";
 import { renderProjectOg } from "~/application/og/services/render-project-og.service";
 import type { AppLegalDoc } from "~/domain/legal/app-legal-doc.entity";
@@ -42,6 +43,7 @@ export type Container = {
 	getPostDetail: (slug: string) => Promise<{ post: Post; prev: Post | null; next: Post | null }>;
 	getRecentPosts: (n: number) => Promise<Post[]>;
 	buildRssFeed: () => Promise<string>;
+	buildSitemap: (origin: string) => Promise<string>;
 	listApps: () => Promise<string[]>;
 	findAppDoc: (appSlug: string, docType: "terms" | "privacy") => Promise<AppLegalDoc | null>;
 	submitContactForm: (params: Pick<SubmitContactFormParams, "submission" | "ip">) => Promise<void>;
@@ -72,6 +74,15 @@ export const buildContainer = (env: Env): Container => {
 		getPostDetail: (slug) => getPostDetail(postRepo, slug),
 		getRecentPosts: (n) => getRecentPosts(postRepo, n),
 		buildRssFeed: async () => buildRssFeed(await postRepo.findAll()),
+		buildSitemap: async (origin: string) => {
+			const [projects, posts] = await Promise.all([projectRepo.findAll(), postRepo.findAll()]);
+			return buildSitemap({
+				origin,
+				projects: projects.map((p) => ({ slug: p.slug, date: p.date })),
+				posts: posts.map((p) => ({ slug: p.slug, date: p.date })),
+				generatedAt: new Date(),
+			});
+		},
 		listApps: () => legalRepo.listApps(),
 		findAppDoc: (appSlug, docType) => legalRepo.findAppDoc(appSlug, docType),
 		submitContactForm: ({ submission, ip }) =>

--- a/app/presentation/lib/__tests__/jsonld.test.ts
+++ b/app/presentation/lib/__tests__/jsonld.test.ts
@@ -4,7 +4,6 @@ import {
 	buildBreadcrumbListLd,
 	buildCreativeWorkLd,
 	buildPersonLd,
-	renderJsonLd,
 } from "~/presentation/lib/jsonld";
 
 describe("buildPersonLd", () => {
@@ -429,43 +428,5 @@ describe("buildBreadcrumbListLd", () => {
 
 		// Assert
 		expect(result.itemListElement).toEqual([]);
-	});
-});
-
-describe("renderJsonLd", () => {
-	it("입력 객체와 deep equal한 JSON 문자열을 반환한다", () => {
-		// Arrange
-		const obj = {
-			"@context": "https://schema.org",
-			"@type": "Person",
-			name: "김태곤",
-			nested: { key: "value" },
-		};
-
-		// Act
-		const result = renderJsonLd(obj);
-
-		// Assert
-		expect(JSON.parse(result)).toEqual(obj);
-	});
-
-	it("HTML 이스케이프 없이 순수한 JSON.stringify 결과를 반환한다", () => {
-		// Arrange
-		const obj = {
-			url: "https://tkstar.dev/blog/my-post?a=1&b=2",
-			description: "태그: <script>",
-		};
-
-		// Act
-		const result = renderJsonLd(obj);
-
-		// Assert
-		// HTML 엔티티(&amp;, &lt; 등)가 포함되지 않아야 한다
-		expect(result).not.toContain("&amp;");
-		expect(result).not.toContain("&lt;");
-		expect(result).not.toContain("&gt;");
-		// 원본 문자가 그대로 포함된다
-		expect(result).toContain("&b=2");
-		expect(result).toContain("<script>");
 	});
 });

--- a/app/presentation/lib/__tests__/jsonld.test.ts
+++ b/app/presentation/lib/__tests__/jsonld.test.ts
@@ -1,0 +1,471 @@
+import { describe, expect, it } from "vitest";
+import {
+	buildBlogPostingLd,
+	buildBreadcrumbListLd,
+	buildCreativeWorkLd,
+	buildPersonLd,
+	renderJsonLd,
+} from "~/presentation/lib/jsonld";
+
+describe("buildPersonLd", () => {
+	it("@context와 @type이 올바르게 설정된다", () => {
+		// Arrange
+		const input = { origin: "https://tkstar.dev" };
+
+		// Act
+		const result = buildPersonLd(input);
+
+		// Assert
+		expect(result["@context"]).toBe("https://schema.org");
+		expect(result["@type"]).toBe("Person");
+	});
+
+	it("name, email, url 필드가 올바른 값으로 포함된다", () => {
+		// Arrange
+		const input = { origin: "https://tkstar.dev" };
+
+		// Act
+		const result = buildPersonLd(input);
+
+		// Assert
+		expect(result.name).toBe("김태곤");
+		expect(result.email).toBe("hello@tkstar.dev");
+		expect(result.url).toBe("https://tkstar.dev");
+	});
+
+	it("sameAs 배열에 GitHub URL이 포함된다", () => {
+		// Arrange
+		const input = { origin: "https://tkstar.dev" };
+
+		// Act
+		const result = buildPersonLd(input);
+
+		// Assert
+		expect(result.sameAs).toEqual(["https://github.com/onepunch-tk"]);
+	});
+
+	it("image 필드를 포함하지 않는다", () => {
+		// Arrange
+		const input = { origin: "https://tkstar.dev" };
+
+		// Act
+		const result = buildPersonLd(input);
+
+		// Assert
+		expect(result).not.toHaveProperty("image");
+	});
+});
+
+describe("buildBlogPostingLd", () => {
+	it("@context와 @type이 올바르게 설정된다", () => {
+		// Arrange
+		const post = {
+			slug: "my-post",
+			title: "My Post",
+			lede: "post lede",
+			date: "2026-04-15",
+			tags: ["typescript"],
+			read: 5,
+		};
+		const origin = "https://tkstar.dev";
+		const ogImage = "https://tkstar.dev/og/blog/my-post.png";
+
+		// Act
+		const result = buildBlogPostingLd({ post, origin, ogImage });
+
+		// Assert
+		expect(result["@context"]).toBe("https://schema.org");
+		expect(result["@type"]).toBe("BlogPosting");
+	});
+
+	it("headline과 description이 post의 title, lede로 설정된다", () => {
+		// Arrange
+		const post = {
+			slug: "my-post",
+			title: "My Post",
+			lede: "post lede",
+			date: "2026-04-15",
+			tags: ["typescript"],
+			read: 5,
+		};
+		const origin = "https://tkstar.dev";
+		const ogImage = "https://tkstar.dev/og/blog/my-post.png";
+
+		// Act
+		const result = buildBlogPostingLd({ post, origin, ogImage });
+
+		// Assert
+		expect(result.headline).toBe("My Post");
+		expect(result.description).toBe("post lede");
+	});
+
+	it("datePublished이 post.date로 설정된다", () => {
+		// Arrange
+		const post = {
+			slug: "my-post",
+			title: "My Post",
+			lede: "post lede",
+			date: "2026-04-15",
+			tags: ["typescript"],
+			read: 5,
+		};
+		const origin = "https://tkstar.dev";
+		const ogImage = "https://tkstar.dev/og/blog/my-post.png";
+
+		// Act
+		const result = buildBlogPostingLd({ post, origin, ogImage });
+
+		// Assert
+		expect(result.datePublished).toBe("2026-04-15");
+	});
+
+	it("image가 ogImage URL로 설정된다", () => {
+		// Arrange
+		const post = {
+			slug: "my-post",
+			title: "My Post",
+			lede: "post lede",
+			date: "2026-04-15",
+			tags: ["typescript"],
+			read: 5,
+		};
+		const origin = "https://tkstar.dev";
+		const ogImage = "https://tkstar.dev/og/blog/my-post.png";
+
+		// Act
+		const result = buildBlogPostingLd({ post, origin, ogImage });
+
+		// Assert
+		expect(result.image).toBe("https://tkstar.dev/og/blog/my-post.png");
+	});
+
+	it("mainEntityOfPage가 origin + /blog/:slug 경로로 설정된다", () => {
+		// Arrange
+		const post = {
+			slug: "my-post",
+			title: "My Post",
+			lede: "post lede",
+			date: "2026-04-15",
+			tags: ["typescript"],
+			read: 5,
+		};
+		const origin = "https://tkstar.dev";
+		const ogImage = "https://tkstar.dev/og/blog/my-post.png";
+
+		// Act
+		const result = buildBlogPostingLd({ post, origin, ogImage });
+
+		// Assert
+		expect(result.mainEntityOfPage).toBe("https://tkstar.dev/blog/my-post");
+	});
+
+	it("inLanguage가 'ko'로 설정된다", () => {
+		// Arrange
+		const post = {
+			slug: "my-post",
+			title: "My Post",
+			lede: "post lede",
+			date: "2026-04-15",
+			tags: ["typescript"],
+			read: 5,
+		};
+		const origin = "https://tkstar.dev";
+		const ogImage = "https://tkstar.dev/og/blog/my-post.png";
+
+		// Act
+		const result = buildBlogPostingLd({ post, origin, ogImage });
+
+		// Assert
+		expect(result.inLanguage).toBe("ko");
+	});
+
+	it("author가 Person 타입의 김태곤으로 설정된다", () => {
+		// Arrange
+		const post = {
+			slug: "my-post",
+			title: "My Post",
+			lede: "post lede",
+			date: "2026-04-15",
+			tags: ["typescript"],
+			read: 5,
+		};
+		const origin = "https://tkstar.dev";
+		const ogImage = "https://tkstar.dev/og/blog/my-post.png";
+
+		// Act
+		const result = buildBlogPostingLd({ post, origin, ogImage });
+
+		// Assert
+		expect(result.author).toEqual(
+			expect.objectContaining({
+				"@type": "Person",
+				name: "김태곤",
+				url: "https://tkstar.dev",
+			}),
+		);
+	});
+});
+
+describe("buildCreativeWorkLd", () => {
+	it("@context와 @type이 올바르게 설정된다", () => {
+		// Arrange
+		const project = {
+			slug: "my-project",
+			title: "My Project",
+			summary: "project summary",
+			date: "2025-12-01",
+			tags: [] as string[],
+			stack: [] as string[],
+			metrics: [] as [string, string][],
+		};
+		const origin = "https://tkstar.dev";
+		const ogImage = "https://tkstar.dev/og/projects/my-project.png";
+
+		// Act
+		const result = buildCreativeWorkLd({ project, origin, ogImage });
+
+		// Assert
+		expect(result["@context"]).toBe("https://schema.org");
+		expect(result["@type"]).toBe("CreativeWork");
+	});
+
+	it("name과 description이 project의 title, summary로 설정된다", () => {
+		// Arrange
+		const project = {
+			slug: "my-project",
+			title: "My Project",
+			summary: "project summary",
+			date: "2025-12-01",
+			tags: [] as string[],
+			stack: [] as string[],
+			metrics: [] as [string, string][],
+		};
+		const origin = "https://tkstar.dev";
+		const ogImage = "https://tkstar.dev/og/projects/my-project.png";
+
+		// Act
+		const result = buildCreativeWorkLd({ project, origin, ogImage });
+
+		// Assert
+		expect(result.name).toBe("My Project");
+		expect(result.description).toBe("project summary");
+	});
+
+	it("datePublished이 project.date로 설정된다", () => {
+		// Arrange
+		const project = {
+			slug: "my-project",
+			title: "My Project",
+			summary: "project summary",
+			date: "2025-12-01",
+			tags: [] as string[],
+			stack: [] as string[],
+			metrics: [] as [string, string][],
+		};
+		const origin = "https://tkstar.dev";
+		const ogImage = "https://tkstar.dev/og/projects/my-project.png";
+
+		// Act
+		const result = buildCreativeWorkLd({ project, origin, ogImage });
+
+		// Assert
+		expect(result.datePublished).toBe("2025-12-01");
+	});
+
+	it("image가 ogImage URL로 설정된다", () => {
+		// Arrange
+		const project = {
+			slug: "my-project",
+			title: "My Project",
+			summary: "project summary",
+			date: "2025-12-01",
+			tags: [] as string[],
+			stack: [] as string[],
+			metrics: [] as [string, string][],
+		};
+		const origin = "https://tkstar.dev";
+		const ogImage = "https://tkstar.dev/og/projects/my-project.png";
+
+		// Act
+		const result = buildCreativeWorkLd({ project, origin, ogImage });
+
+		// Assert
+		expect(result.image).toBe("https://tkstar.dev/og/projects/my-project.png");
+	});
+
+	it("url이 origin + /projects/:slug 경로로 설정된다", () => {
+		// Arrange
+		const project = {
+			slug: "my-project",
+			title: "My Project",
+			summary: "project summary",
+			date: "2025-12-01",
+			tags: [] as string[],
+			stack: [] as string[],
+			metrics: [] as [string, string][],
+		};
+		const origin = "https://tkstar.dev";
+		const ogImage = "https://tkstar.dev/og/projects/my-project.png";
+
+		// Act
+		const result = buildCreativeWorkLd({ project, origin, ogImage });
+
+		// Assert
+		expect(result.url).toBe("https://tkstar.dev/projects/my-project");
+	});
+
+	it("inLanguage가 'ko'로 설정된다", () => {
+		// Arrange
+		const project = {
+			slug: "my-project",
+			title: "My Project",
+			summary: "project summary",
+			date: "2025-12-01",
+			tags: [] as string[],
+			stack: [] as string[],
+			metrics: [] as [string, string][],
+		};
+		const origin = "https://tkstar.dev";
+		const ogImage = "https://tkstar.dev/og/projects/my-project.png";
+
+		// Act
+		const result = buildCreativeWorkLd({ project, origin, ogImage });
+
+		// Assert
+		expect(result.inLanguage).toBe("ko");
+	});
+
+	it("author가 Person 타입의 김태곤으로 설정된다", () => {
+		// Arrange
+		const project = {
+			slug: "my-project",
+			title: "My Project",
+			summary: "project summary",
+			date: "2025-12-01",
+			tags: [] as string[],
+			stack: [] as string[],
+			metrics: [] as [string, string][],
+		};
+		const origin = "https://tkstar.dev";
+		const ogImage = "https://tkstar.dev/og/projects/my-project.png";
+
+		// Act
+		const result = buildCreativeWorkLd({ project, origin, ogImage });
+
+		// Assert
+		expect(result.author).toEqual(
+			expect.objectContaining({
+				"@type": "Person",
+				name: "김태곤",
+				url: "https://tkstar.dev",
+			}),
+		);
+	});
+});
+
+describe("buildBreadcrumbListLd", () => {
+	it("@context와 @type이 올바르게 설정된다", () => {
+		// Arrange
+		const items = [
+			{ name: "Home", url: "https://tkstar.dev/" },
+			{ name: "Blog", url: "https://tkstar.dev/blog" },
+			{ name: "My Post", url: "https://tkstar.dev/blog/my-post" },
+		];
+
+		// Act
+		const result = buildBreadcrumbListLd({ items });
+
+		// Assert
+		expect(result["@context"]).toBe("https://schema.org");
+		expect(result["@type"]).toBe("BreadcrumbList");
+	});
+
+	it("itemListElement가 items 수와 동일한 3개 항목의 배열로 구성된다", () => {
+		// Arrange
+		const items = [
+			{ name: "Home", url: "https://tkstar.dev/" },
+			{ name: "Blog", url: "https://tkstar.dev/blog" },
+			{ name: "My Post", url: "https://tkstar.dev/blog/my-post" },
+		];
+
+		// Act
+		const result = buildBreadcrumbListLd({ items });
+
+		// Assert
+		expect(Array.isArray(result.itemListElement)).toBe(true);
+		expect((result.itemListElement as unknown[]).length).toBe(3);
+	});
+
+	it("각 항목이 ListItem 타입으로 1-based position, name, item 필드를 포함한다", () => {
+		// Arrange
+		const items = [
+			{ name: "Home", url: "https://tkstar.dev/" },
+			{ name: "Blog", url: "https://tkstar.dev/blog" },
+			{ name: "My Post", url: "https://tkstar.dev/blog/my-post" },
+		];
+
+		// Act
+		const result = buildBreadcrumbListLd({ items });
+
+		// Assert
+		expect(result.itemListElement).toEqual([
+			{ "@type": "ListItem", position: 1, name: "Home", item: "https://tkstar.dev/" },
+			{ "@type": "ListItem", position: 2, name: "Blog", item: "https://tkstar.dev/blog" },
+			{
+				"@type": "ListItem",
+				position: 3,
+				name: "My Post",
+				item: "https://tkstar.dev/blog/my-post",
+			},
+		]);
+	});
+
+	it("빈 items 배열 전달 시 itemListElement가 빈 배열로 설정된다", () => {
+		// Arrange
+		const items: { name: string; url: string }[] = [];
+
+		// Act
+		const result = buildBreadcrumbListLd({ items });
+
+		// Assert
+		expect(result.itemListElement).toEqual([]);
+	});
+});
+
+describe("renderJsonLd", () => {
+	it("입력 객체와 deep equal한 JSON 문자열을 반환한다", () => {
+		// Arrange
+		const obj = {
+			"@context": "https://schema.org",
+			"@type": "Person",
+			name: "김태곤",
+			nested: { key: "value" },
+		};
+
+		// Act
+		const result = renderJsonLd(obj);
+
+		// Assert
+		expect(JSON.parse(result)).toEqual(obj);
+	});
+
+	it("HTML 이스케이프 없이 순수한 JSON.stringify 결과를 반환한다", () => {
+		// Arrange
+		const obj = {
+			url: "https://tkstar.dev/blog/my-post?a=1&b=2",
+			description: "태그: <script>",
+		};
+
+		// Act
+		const result = renderJsonLd(obj);
+
+		// Assert
+		// HTML 엔티티(&amp;, &lt; 등)가 포함되지 않아야 한다
+		expect(result).not.toContain("&amp;");
+		expect(result).not.toContain("&lt;");
+		expect(result).not.toContain("&gt;");
+		// 원본 문자가 그대로 포함된다
+		expect(result).toContain("&b=2");
+		expect(result).toContain("<script>");
+	});
+});

--- a/app/presentation/lib/__tests__/meta.test.ts
+++ b/app/presentation/lib/__tests__/meta.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { MetaDescriptor } from "react-router";
-import { buildMeta, getCanonicalUrl } from "../meta";
+import { buildMeta } from "../meta";
 
 describe("buildMeta", () => {
 	describe("기본 최소 입력 (title, description, canonical, ogImage 만 전달)", () => {
@@ -289,43 +289,5 @@ describe("buildMeta", () => {
 				]),
 			);
 		});
-	});
-});
-
-describe("getCanonicalUrl", () => {
-	it("origin과 pathname을 합쳐 절대 URL을 반환한다", () => {
-		// Arrange
-		const origin = "https://tkstar.dev";
-		const pathname = "/about";
-
-		// Act
-		const result = getCanonicalUrl(origin, pathname);
-
-		// Assert
-		expect(result).toBe("https://tkstar.dev/about");
-	});
-
-	it("루트 pathname('/')에 대해 trailing slash가 포함된 URL을 반환한다", () => {
-		// Arrange
-		const origin = "https://preview.example.com";
-		const pathname = "/";
-
-		// Act
-		const result = getCanonicalUrl(origin, pathname);
-
-		// Assert
-		expect(result).toBe("https://preview.example.com/");
-	});
-
-	it("중첩 경로에 대해 올바른 절대 URL을 반환한다", () => {
-		// Arrange
-		const origin = "https://tkstar.dev";
-		const pathname = "/projects/my-awesome-project";
-
-		// Act
-		const result = getCanonicalUrl(origin, pathname);
-
-		// Assert
-		expect(result).toBe("https://tkstar.dev/projects/my-awesome-project");
 	});
 });

--- a/app/presentation/lib/__tests__/meta.test.ts
+++ b/app/presentation/lib/__tests__/meta.test.ts
@@ -1,0 +1,331 @@
+import { describe, expect, it } from "vitest";
+import type { MetaDescriptor } from "react-router";
+import { buildMeta, getCanonicalUrl } from "../meta";
+
+describe("buildMeta", () => {
+	describe("기본 최소 입력 (title, description, canonical, ogImage 만 전달)", () => {
+		it("title 메타 태그를 포함한다", () => {
+			// Arrange
+			const input = {
+				title: "테스트 페이지",
+				description: "페이지 설명입니다.",
+				canonical: "https://tkstar.dev/about",
+				ogImage: "https://tkstar.dev/og/fallback.png",
+			};
+
+			// Act
+			const result = buildMeta(input);
+
+			// Assert
+			expect(result).toEqual(
+				expect.arrayContaining([expect.objectContaining({ title: "테스트 페이지" })]),
+			);
+		});
+
+		it("description 메타 태그를 포함한다", () => {
+			// Arrange
+			const input = {
+				title: "테스트 페이지",
+				description: "페이지 설명입니다.",
+				canonical: "https://tkstar.dev/about",
+				ogImage: "https://tkstar.dev/og/fallback.png",
+			};
+
+			// Act
+			const result = buildMeta(input);
+
+			// Assert
+			expect(result).toEqual(
+				expect.arrayContaining([
+					expect.objectContaining({ name: "description", content: "페이지 설명입니다." }),
+				]),
+			);
+		});
+
+		it("canonical link 태그를 포함한다", () => {
+			// Arrange
+			const input = {
+				title: "테스트 페이지",
+				description: "페이지 설명입니다.",
+				canonical: "https://tkstar.dev/about",
+				ogImage: "https://tkstar.dev/og/fallback.png",
+			};
+
+			// Act
+			const result = buildMeta(input);
+
+			// Assert
+			expect(result).toEqual(
+				expect.arrayContaining([
+					expect.objectContaining({
+						tagName: "link",
+						rel: "canonical",
+						href: "https://tkstar.dev/about",
+					}),
+				]),
+			);
+		});
+
+		it("OG 태그(og:title, og:description, og:url, og:image, og:type=website)를 포함한다", () => {
+			// Arrange
+			const input = {
+				title: "테스트 페이지",
+				description: "페이지 설명입니다.",
+				canonical: "https://tkstar.dev/about",
+				ogImage: "https://tkstar.dev/og/fallback.png",
+			};
+
+			// Act
+			const result = buildMeta(input);
+
+			// Assert
+			expect(result).toEqual(
+				expect.arrayContaining([
+					expect.objectContaining({ property: "og:title", content: "테스트 페이지" }),
+					expect.objectContaining({ property: "og:description", content: "페이지 설명입니다." }),
+					expect.objectContaining({ property: "og:url", content: "https://tkstar.dev/about" }),
+					expect.objectContaining({
+						property: "og:image",
+						content: "https://tkstar.dev/og/fallback.png",
+					}),
+					expect.objectContaining({ property: "og:type", content: "website" }),
+				]),
+			);
+		});
+
+		it("OG 이미지 기본 크기(1200×630)를 포함한다", () => {
+			// Arrange
+			const input = {
+				title: "테스트 페이지",
+				description: "페이지 설명입니다.",
+				canonical: "https://tkstar.dev/about",
+				ogImage: "https://tkstar.dev/og/fallback.png",
+			};
+
+			// Act
+			const result = buildMeta(input);
+
+			// Assert
+			expect(result).toEqual(
+				expect.arrayContaining([
+					expect.objectContaining({ property: "og:image:width", content: "1200" }),
+					expect.objectContaining({ property: "og:image:height", content: "630" }),
+				]),
+			);
+		});
+
+		it("Twitter Card 태그(summary_large_image, title, description, image)를 포함한다", () => {
+			// Arrange
+			const input = {
+				title: "테스트 페이지",
+				description: "페이지 설명입니다.",
+				canonical: "https://tkstar.dev/about",
+				ogImage: "https://tkstar.dev/og/fallback.png",
+			};
+
+			// Act
+			const result = buildMeta(input);
+
+			// Assert
+			expect(result).toEqual(
+				expect.arrayContaining([
+					expect.objectContaining({ name: "twitter:card", content: "summary_large_image" }),
+					expect.objectContaining({ name: "twitter:title", content: "테스트 페이지" }),
+					expect.objectContaining({ name: "twitter:description", content: "페이지 설명입니다." }),
+					expect.objectContaining({
+						name: "twitter:image",
+						content: "https://tkstar.dev/og/fallback.png",
+					}),
+				]),
+			);
+		});
+
+		it("robots 미전달 시 robots 메타 태그를 포함하지 않는다", () => {
+			// Arrange
+			const input = {
+				title: "테스트 페이지",
+				description: "페이지 설명입니다.",
+				canonical: "https://tkstar.dev/about",
+				ogImage: "https://tkstar.dev/og/fallback.png",
+			};
+
+			// Act
+			const result = buildMeta(input);
+
+			// Assert
+			const hasRobots = (result as MetaDescriptor[]).some(
+				(tag) => "name" in tag && tag.name === "robots",
+			);
+			expect(hasRobots).toBe(false);
+		});
+	});
+
+	describe("ogType: 'article' 전달 시", () => {
+		it("og:type 값이 'article'로 설정된다", () => {
+			// Arrange
+			const input = {
+				title: "블로그 글",
+				description: "글 설명",
+				canonical: "https://tkstar.dev/blog/my-post",
+				ogImage: "https://tkstar.dev/og/blog/my-post.png",
+				ogType: "article" as const,
+			};
+
+			// Act
+			const result = buildMeta(input);
+
+			// Assert
+			expect(result).toEqual(
+				expect.arrayContaining([
+					expect.objectContaining({ property: "og:type", content: "article" }),
+				]),
+			);
+		});
+	});
+
+	describe("robots: 'noindex, follow' 전달 시", () => {
+		it("robots 메타 태그가 'noindex, follow' 값으로 포함된다", () => {
+			// Arrange
+			const input = {
+				title: "약관 페이지",
+				description: "이용약관",
+				canonical: "https://tkstar.dev/legal/some-app/terms",
+				ogImage: "https://tkstar.dev/og/fallback.png",
+				robots: "noindex, follow" as const,
+			};
+
+			// Act
+			const result = buildMeta(input);
+
+			// Assert
+			expect(result).toEqual(
+				expect.arrayContaining([
+					expect.objectContaining({ name: "robots", content: "noindex, follow" }),
+				]),
+			);
+		});
+	});
+
+	describe("robots: 'noindex, nofollow' 전달 시", () => {
+		it("robots 메타 태그가 'noindex, nofollow' 값으로 포함된다", () => {
+			// Arrange
+			const input = {
+				title: "404 페이지",
+				description: "찾을 수 없는 페이지",
+				canonical: "https://tkstar.dev/not-found",
+				ogImage: "https://tkstar.dev/og/fallback.png",
+				robots: "noindex, nofollow" as const,
+			};
+
+			// Act
+			const result = buildMeta(input);
+
+			// Assert
+			expect(result).toEqual(
+				expect.arrayContaining([
+					expect.objectContaining({ name: "robots", content: "noindex, nofollow" }),
+				]),
+			);
+		});
+	});
+
+	describe("커스텀 ogImageWidth / ogImageHeight 전달 시", () => {
+		it("og:image:width와 og:image:height가 지정된 값으로 오버라이드된다", () => {
+			// Arrange
+			const input = {
+				title: "커스텀 이미지 페이지",
+				description: "커스텀 크기 OG 이미지",
+				canonical: "https://tkstar.dev/projects/my-project",
+				ogImage: "https://tkstar.dev/og/projects/my-project.png",
+				ogImageWidth: 800,
+				ogImageHeight: 400,
+			};
+
+			// Act
+			const result = buildMeta(input);
+
+			// Assert
+			expect(result).toEqual(
+				expect.arrayContaining([
+					expect.objectContaining({ property: "og:image:width", content: "800" }),
+					expect.objectContaining({ property: "og:image:height", content: "400" }),
+				]),
+			);
+		});
+	});
+
+	describe("모든 입력을 함께 전달하는 조합 스모크 테스트", () => {
+		it("article + noindex + 커스텀 크기 조합에서 모든 태그가 올바르게 포함된다", () => {
+			// Arrange
+			const input = {
+				title: "종합 테스트",
+				description: "모든 옵션 조합 테스트",
+				canonical: "https://tkstar.dev/blog/full-test",
+				ogImage: "https://tkstar.dev/og/blog/full-test.png",
+				ogType: "article" as const,
+				robots: "noindex, follow" as const,
+				ogImageWidth: 1000,
+				ogImageHeight: 500,
+			};
+
+			// Act
+			const result = buildMeta(input);
+
+			// Assert
+			expect(result).toEqual(
+				expect.arrayContaining([
+					expect.objectContaining({ title: "종합 테스트" }),
+					expect.objectContaining({ name: "description", content: "모든 옵션 조합 테스트" }),
+					expect.objectContaining({
+						tagName: "link",
+						rel: "canonical",
+						href: "https://tkstar.dev/blog/full-test",
+					}),
+					expect.objectContaining({ property: "og:type", content: "article" }),
+					expect.objectContaining({ name: "robots", content: "noindex, follow" }),
+					expect.objectContaining({ property: "og:image:width", content: "1000" }),
+					expect.objectContaining({ property: "og:image:height", content: "500" }),
+					expect.objectContaining({ name: "twitter:card", content: "summary_large_image" }),
+				]),
+			);
+		});
+	});
+});
+
+describe("getCanonicalUrl", () => {
+	it("origin과 pathname을 합쳐 절대 URL을 반환한다", () => {
+		// Arrange
+		const origin = "https://tkstar.dev";
+		const pathname = "/about";
+
+		// Act
+		const result = getCanonicalUrl(origin, pathname);
+
+		// Assert
+		expect(result).toBe("https://tkstar.dev/about");
+	});
+
+	it("루트 pathname('/')에 대해 trailing slash가 포함된 URL을 반환한다", () => {
+		// Arrange
+		const origin = "https://preview.example.com";
+		const pathname = "/";
+
+		// Act
+		const result = getCanonicalUrl(origin, pathname);
+
+		// Assert
+		expect(result).toBe("https://preview.example.com/");
+	});
+
+	it("중첩 경로에 대해 올바른 절대 URL을 반환한다", () => {
+		// Arrange
+		const origin = "https://tkstar.dev";
+		const pathname = "/projects/my-awesome-project";
+
+		// Act
+		const result = getCanonicalUrl(origin, pathname);
+
+		// Assert
+		expect(result).toBe("https://tkstar.dev/projects/my-awesome-project");
+	});
+});

--- a/app/presentation/lib/jsonld.ts
+++ b/app/presentation/lib/jsonld.ts
@@ -75,5 +75,3 @@ export const buildBreadcrumbListLd = ({
 		item: item.url,
 	})),
 });
-
-export const renderJsonLd = (obj: Record<string, unknown>): string => JSON.stringify(obj);

--- a/app/presentation/lib/jsonld.ts
+++ b/app/presentation/lib/jsonld.ts
@@ -1,0 +1,32 @@
+import type { Post } from "~/domain/post/post.entity";
+import type { Project } from "~/domain/project/project.entity";
+
+export const buildPersonLd = (_input: { origin: string }): Record<string, unknown> => {
+	throw new Error("not implemented");
+};
+
+export const buildBlogPostingLd = (_input: {
+	post: Post;
+	origin: string;
+	ogImage: string;
+}): Record<string, unknown> => {
+	throw new Error("not implemented");
+};
+
+export const buildCreativeWorkLd = (_input: {
+	project: Project;
+	origin: string;
+	ogImage: string;
+}): Record<string, unknown> => {
+	throw new Error("not implemented");
+};
+
+export const buildBreadcrumbListLd = (_input: {
+	items: { name: string; url: string }[];
+}): Record<string, unknown> => {
+	throw new Error("not implemented");
+};
+
+export const renderJsonLd = (_obj: Record<string, unknown>): string => {
+	throw new Error("not implemented");
+};

--- a/app/presentation/lib/jsonld.ts
+++ b/app/presentation/lib/jsonld.ts
@@ -1,32 +1,79 @@
 import type { Post } from "~/domain/post/post.entity";
 import type { Project } from "~/domain/project/project.entity";
 
-export const buildPersonLd = (_input: { origin: string }): Record<string, unknown> => {
-	throw new Error("not implemented");
-};
+const SCHEMA_CONTEXT = "https://schema.org";
+const PERSON_NAME = "김태곤";
+const PERSON_EMAIL = "hello@tkstar.dev";
+const PERSON_SAME_AS = ["https://github.com/onepunch-tk"];
 
-export const buildBlogPostingLd = (_input: {
+const buildAuthor = (origin: string) => ({
+	"@type": "Person",
+	name: PERSON_NAME,
+	url: origin,
+});
+
+export const buildPersonLd = ({ origin }: { origin: string }): Record<string, unknown> => ({
+	"@context": SCHEMA_CONTEXT,
+	"@type": "Person",
+	name: PERSON_NAME,
+	email: PERSON_EMAIL,
+	url: origin,
+	sameAs: PERSON_SAME_AS,
+});
+
+export const buildBlogPostingLd = ({
+	post,
+	origin,
+	ogImage,
+}: {
 	post: Post;
 	origin: string;
 	ogImage: string;
-}): Record<string, unknown> => {
-	throw new Error("not implemented");
-};
+}): Record<string, unknown> => ({
+	"@context": SCHEMA_CONTEXT,
+	"@type": "BlogPosting",
+	headline: post.title,
+	description: post.lede,
+	datePublished: post.date,
+	image: ogImage,
+	mainEntityOfPage: `${origin}/blog/${post.slug}`,
+	inLanguage: "ko",
+	author: buildAuthor(origin),
+});
 
-export const buildCreativeWorkLd = (_input: {
+export const buildCreativeWorkLd = ({
+	project,
+	origin,
+	ogImage,
+}: {
 	project: Project;
 	origin: string;
 	ogImage: string;
-}): Record<string, unknown> => {
-	throw new Error("not implemented");
-};
+}): Record<string, unknown> => ({
+	"@context": SCHEMA_CONTEXT,
+	"@type": "CreativeWork",
+	name: project.title,
+	description: project.summary,
+	datePublished: project.date,
+	image: ogImage,
+	url: `${origin}/projects/${project.slug}`,
+	inLanguage: "ko",
+	author: buildAuthor(origin),
+});
 
-export const buildBreadcrumbListLd = (_input: {
+export const buildBreadcrumbListLd = ({
+	items,
+}: {
 	items: { name: string; url: string }[];
-}): Record<string, unknown> => {
-	throw new Error("not implemented");
-};
+}): Record<string, unknown> => ({
+	"@context": SCHEMA_CONTEXT,
+	"@type": "BreadcrumbList",
+	itemListElement: items.map((item, index) => ({
+		"@type": "ListItem",
+		position: index + 1,
+		name: item.name,
+		item: item.url,
+	})),
+});
 
-export const renderJsonLd = (_obj: Record<string, unknown>): string => {
-	throw new Error("not implemented");
-};
+export const renderJsonLd = (obj: Record<string, unknown>): string => JSON.stringify(obj);

--- a/app/presentation/lib/meta.ts
+++ b/app/presentation/lib/meta.ts
@@ -1,0 +1,20 @@
+import type { MetaDescriptor } from "react-router";
+
+type BuildMetaInput = {
+	title: string;
+	description: string;
+	canonical: string;
+	ogImage: string;
+	ogType?: "website" | "article" | "profile";
+	robots?: "noindex, follow" | "noindex, nofollow";
+	ogImageWidth?: number;
+	ogImageHeight?: number;
+};
+
+export const buildMeta = (_input: BuildMetaInput): MetaDescriptor[] => {
+	throw new Error("not implemented");
+};
+
+export const getCanonicalUrl = (_origin: string, _pathname: string): string => {
+	throw new Error("not implemented");
+};

--- a/app/presentation/lib/meta.ts
+++ b/app/presentation/lib/meta.ts
@@ -40,5 +40,3 @@ export const buildMeta = ({
 	if (robots) tags.push({ name: "robots", content: robots });
 	return tags;
 };
-
-export const getCanonicalUrl = (origin: string, pathname: string): string => `${origin}${pathname}`;

--- a/app/presentation/lib/meta.ts
+++ b/app/presentation/lib/meta.ts
@@ -11,10 +11,34 @@ type BuildMetaInput = {
 	ogImageHeight?: number;
 };
 
-export const buildMeta = (_input: BuildMetaInput): MetaDescriptor[] => {
-	throw new Error("not implemented");
+export const buildMeta = ({
+	title,
+	description,
+	canonical,
+	ogImage,
+	ogType = "website",
+	robots,
+	ogImageWidth = 1200,
+	ogImageHeight = 630,
+}: BuildMetaInput): MetaDescriptor[] => {
+	const tags: MetaDescriptor[] = [
+		{ title },
+		{ name: "description", content: description },
+		{ tagName: "link", rel: "canonical", href: canonical },
+		{ property: "og:title", content: title },
+		{ property: "og:description", content: description },
+		{ property: "og:url", content: canonical },
+		{ property: "og:image", content: ogImage },
+		{ property: "og:image:width", content: String(ogImageWidth) },
+		{ property: "og:image:height", content: String(ogImageHeight) },
+		{ property: "og:type", content: ogType },
+		{ name: "twitter:card", content: "summary_large_image" },
+		{ name: "twitter:title", content: title },
+		{ name: "twitter:description", content: description },
+		{ name: "twitter:image", content: ogImage },
+	];
+	if (robots) tags.push({ name: "robots", content: robots });
+	return tags;
 };
 
-export const getCanonicalUrl = (_origin: string, _pathname: string): string => {
-	throw new Error("not implemented");
-};
+export const getCanonicalUrl = (origin: string, pathname: string): string => `${origin}${pathname}`;

--- a/app/presentation/routes/$.tsx
+++ b/app/presentation/routes/$.tsx
@@ -1,9 +1,30 @@
-import type { MetaFunction } from "react-router";
 import { useLocation } from "react-router";
+import { buildMeta } from "~/presentation/lib/meta";
+import type { Route } from "./+types/$";
 
-export const meta: MetaFunction = () => [{ title: "Not Found — tkstar.dev" }];
+export const loader = ({ request }: Route.LoaderArgs) => {
+	const url = new URL(request.url);
+	const origin = url.origin;
+	return {
+		origin,
+		canonicalUrl: `${origin}${url.pathname}`,
+		ogImageUrl: `${origin}/og/fallback.png`,
+	};
+};
 
-// TODO(T019): return HTTP 404 + add `noindex, nofollow` per indexing policy
+export const meta: Route.MetaFunction = ({ data }) => {
+	if (!data) {
+		return [{ title: "Not Found — tkstar.dev" }, { name: "robots", content: "noindex, nofollow" }];
+	}
+	return buildMeta({
+		title: "Not Found — tkstar.dev",
+		description: "요청한 경로를 찾을 수 없습니다.",
+		canonical: data.canonicalUrl,
+		ogImage: data.ogImageUrl,
+		robots: "noindex, nofollow",
+	});
+};
+
 export default function NotFound() {
 	const { pathname } = useLocation();
 	return (

--- a/app/presentation/routes/__tests__/$.meta.test.ts
+++ b/app/presentation/routes/__tests__/$.meta.test.ts
@@ -85,3 +85,20 @@ describe("$.tsx (404 splat) meta export", () => {
 		});
 	});
 });
+
+describe("$ data 미지정 fallback 분기 — 추가 커버리지", () => {
+	it("data 가 undefined 이어도 title + robots noindex,nofollow 만 포함", () => {
+		const result = meta({
+			data: undefined,
+			params: {},
+			location: { pathname: "/x", search: "", hash: "", state: null, key: "" },
+			matches: [],
+		} as unknown as Parameters<typeof meta>[0]);
+		expect(
+			(result as { name?: string; content?: string }[]).some(
+				(m) => m.name === "robots" && m.content === "noindex, nofollow",
+			),
+		).toBe(true);
+		expect((result as { tagName?: string }[]).some((m) => m.tagName === "link")).toBe(false);
+	});
+});

--- a/app/presentation/routes/__tests__/$.meta.test.ts
+++ b/app/presentation/routes/__tests__/$.meta.test.ts
@@ -2,7 +2,7 @@ import type { MetaDescriptor } from "react-router";
 import { describe, expect, it } from "vitest";
 import { meta } from "../$";
 
-type LdScript = { "script:ld+json": string };
+type LdScript = { "script:ld+json": Record<string, unknown> };
 const isLd = (m: MetaDescriptor): m is LdScript => "script:ld+json" in m;
 
 // 시나리오 A: data 없음 (loader 없거나 throw 한 경우)

--- a/app/presentation/routes/__tests__/$.meta.test.ts
+++ b/app/presentation/routes/__tests__/$.meta.test.ts
@@ -1,0 +1,87 @@
+import type { MetaDescriptor } from "react-router";
+import { describe, expect, it } from "vitest";
+import { meta } from "../$";
+
+type LdScript = { "script:ld+json": string };
+const isLd = (m: MetaDescriptor): m is LdScript => "script:ld+json" in m;
+
+// 시나리오 A: data 없음 (loader 없거나 throw 한 경우)
+const callMetaNoData = () =>
+	meta({
+		data: undefined,
+		params: { "*": "some-broken-path" },
+		location: { pathname: "/some-broken-path", search: "", hash: "", state: null, key: "" },
+		matches: [],
+	} as unknown as Parameters<typeof meta>[0]);
+
+// 시나리오 B: loader 가 canonicalUrl / ogImageUrl / origin 을 내려준 경우
+const dataWithUrls = {
+	origin: "https://tkstar.dev",
+	canonicalUrl: "https://tkstar.dev/some-broken-path",
+	ogImageUrl: "https://tkstar.dev/og/fallback.png",
+};
+
+const callMetaWithData = () =>
+	meta({
+		data: dataWithUrls,
+		params: { "*": "some-broken-path" },
+		location: { pathname: "/some-broken-path", search: "", hash: "", state: null, key: "" },
+		matches: [],
+	} as unknown as Parameters<typeof meta>[0]);
+
+describe("$.tsx (404 splat) meta export", () => {
+	describe("(A) data 없음 시나리오", () => {
+		it("title 에 'Not Found — tkstar.dev' 를 포함한다", () => {
+			const result = callMetaNoData();
+			expect(result).toEqual(
+				expect.arrayContaining([expect.objectContaining({ title: "Not Found — tkstar.dev" })]),
+			);
+		});
+
+		it("robots 메타태그가 'noindex, nofollow' 이다", () => {
+			const result = callMetaNoData();
+			expect(result).toEqual(
+				expect.arrayContaining([
+					expect.objectContaining({ name: "robots", content: "noindex, nofollow" }),
+				]),
+			);
+		});
+	});
+
+	describe("(B) data 있음 시나리오", () => {
+		it("full meta + robots 가 'noindex, nofollow' 이다 (title / canonical / og:image 모두 포함)", () => {
+			const result = callMetaWithData();
+			expect(result).toEqual(
+				expect.arrayContaining([expect.objectContaining({ title: "Not Found — tkstar.dev" })]),
+			);
+			expect(result).toEqual(
+				expect.arrayContaining([
+					expect.objectContaining({
+						tagName: "link",
+						rel: "canonical",
+						href: "https://tkstar.dev/some-broken-path",
+					}),
+				]),
+			);
+			expect(result).toEqual(
+				expect.arrayContaining([
+					expect.objectContaining({
+						property: "og:image",
+						content: "https://tkstar.dev/og/fallback.png",
+					}),
+				]),
+			);
+			expect(result).toEqual(
+				expect.arrayContaining([
+					expect.objectContaining({ name: "robots", content: "noindex, nofollow" }),
+				]),
+			);
+		});
+
+		it("JSON-LD 스크립트가 없다 (404 페이지는 schema 없음)", () => {
+			const result = callMetaWithData();
+			const ldScripts = (result as MetaDescriptor[]).filter(isLd);
+			expect(ldScripts.length).toBe(0);
+		});
+	});
+});

--- a/app/presentation/routes/__tests__/_index.meta.test.ts
+++ b/app/presentation/routes/__tests__/_index.meta.test.ts
@@ -1,0 +1,70 @@
+import type { MetaDescriptor } from "react-router";
+import { describe, expect, it } from "vitest";
+import { meta } from "../_index";
+
+type LdScript = { "script:ld+json": string };
+const isLd = (m: MetaDescriptor): m is LdScript => "script:ld+json" in m;
+
+const data = {
+	origin: "https://tkstar.dev",
+	canonicalUrl: "https://tkstar.dev/",
+	ogImageUrl: "https://tkstar.dev/og/fallback.png",
+	featured: null,
+	posts: [],
+};
+
+const callMeta = () =>
+	meta({
+		data,
+		params: {},
+		location: { pathname: "/", search: "", hash: "", state: null, key: "" },
+		matches: [],
+	} as unknown as Parameters<typeof meta>[0]);
+
+describe("Home(_index) meta export", () => {
+	it("title 이 tkstar.dev 를 포함한다", () => {
+		const result = callMeta();
+		expect(result).toEqual(
+			expect.arrayContaining([expect.objectContaining({ title: "tkstar.dev" })]),
+		);
+	});
+
+	it("canonical link 태그를 포함한다", () => {
+		const result = callMeta();
+		expect(result).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					tagName: "link",
+					rel: "canonical",
+					href: "https://tkstar.dev/",
+				}),
+			]),
+		);
+	});
+
+	it("og:image 에 절대 URL 을 포함한다", () => {
+		const result = callMeta();
+		expect(result).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					property: "og:image",
+					content: "https://tkstar.dev/og/fallback.png",
+				}),
+			]),
+		);
+	});
+
+	it("JSON-LD 스크립트에 Person 타입을 포함한다", () => {
+		const result = callMeta();
+		const ldScripts = (result as MetaDescriptor[]).filter(isLd);
+		const types = ldScripts.map((s) => JSON.parse(s["script:ld+json"])["@type"]);
+		expect(types).toContain("Person");
+	});
+
+	it("JSON-LD 스크립트에 BreadcrumbList 타입을 포함하지 않는다", () => {
+		const result = callMeta();
+		const ldScripts = (result as MetaDescriptor[]).filter(isLd);
+		const types = ldScripts.map((s) => JSON.parse(s["script:ld+json"])["@type"]);
+		expect(types).not.toContain("BreadcrumbList");
+	});
+});

--- a/app/presentation/routes/__tests__/_index.meta.test.ts
+++ b/app/presentation/routes/__tests__/_index.meta.test.ts
@@ -68,3 +68,16 @@ describe("Home(_index) meta export", () => {
 		expect(types).not.toContain("BreadcrumbList");
 	});
 });
+
+describe("data 가 undefined 이면 fallback meta 만 반환한다", () => {
+	it("title 만 포함하고 canonical/og:image/JSON-LD 는 제외", () => {
+		const result = meta({
+			data: undefined,
+			params: {},
+			location: { pathname: "/", search: "", hash: "", state: null, key: "" },
+			matches: [],
+		} as unknown as Parameters<typeof meta>[0]);
+		expect((result as { title?: string }[]).some((m) => "title" in m)).toBe(true);
+		expect((result as { tagName?: string }[]).some((m) => m.tagName === "link")).toBe(false);
+	});
+});

--- a/app/presentation/routes/__tests__/_index.meta.test.ts
+++ b/app/presentation/routes/__tests__/_index.meta.test.ts
@@ -2,7 +2,7 @@ import type { MetaDescriptor } from "react-router";
 import { describe, expect, it } from "vitest";
 import { meta } from "../_index";
 
-type LdScript = { "script:ld+json": string };
+type LdScript = { "script:ld+json": Record<string, unknown> };
 const isLd = (m: MetaDescriptor): m is LdScript => "script:ld+json" in m;
 
 const data = {
@@ -57,14 +57,14 @@ describe("Home(_index) meta export", () => {
 	it("JSON-LD 스크립트에 Person 타입을 포함한다", () => {
 		const result = callMeta();
 		const ldScripts = (result as MetaDescriptor[]).filter(isLd);
-		const types = ldScripts.map((s) => JSON.parse(s["script:ld+json"])["@type"]);
+		const types = ldScripts.map((s) => s["script:ld+json"]["@type"]);
 		expect(types).toContain("Person");
 	});
 
 	it("JSON-LD 스크립트에 BreadcrumbList 타입을 포함하지 않는다", () => {
 		const result = callMeta();
 		const ldScripts = (result as MetaDescriptor[]).filter(isLd);
-		const types = ldScripts.map((s) => JSON.parse(s["script:ld+json"])["@type"]);
+		const types = ldScripts.map((s) => s["script:ld+json"]["@type"]);
 		expect(types).not.toContain("BreadcrumbList");
 	});
 });

--- a/app/presentation/routes/__tests__/about.meta.test.ts
+++ b/app/presentation/routes/__tests__/about.meta.test.ts
@@ -2,7 +2,7 @@ import type { MetaDescriptor } from "react-router";
 import { describe, expect, it } from "vitest";
 import { meta } from "../about";
 
-type LdScript = { "script:ld+json": string };
+type LdScript = { "script:ld+json": Record<string, unknown> };
 const isLd = (m: MetaDescriptor): m is LdScript => "script:ld+json" in m;
 
 const data = {
@@ -55,14 +55,14 @@ describe("About meta export", () => {
 	it("JSON-LD 스크립트에 Person 타입을 포함한다", () => {
 		const result = callMeta();
 		const ldScripts = (result as MetaDescriptor[]).filter(isLd);
-		const types = ldScripts.map((s) => JSON.parse(s["script:ld+json"])["@type"]);
+		const types = ldScripts.map((s) => s["script:ld+json"]["@type"]);
 		expect(types).toContain("Person");
 	});
 
 	it("JSON-LD 스크립트에 BreadcrumbList 타입을 포함한다", () => {
 		const result = callMeta();
 		const ldScripts = (result as MetaDescriptor[]).filter(isLd);
-		const types = ldScripts.map((s) => JSON.parse(s["script:ld+json"])["@type"]);
+		const types = ldScripts.map((s) => s["script:ld+json"]["@type"]);
 		expect(types).toContain("BreadcrumbList");
 	});
 });

--- a/app/presentation/routes/__tests__/about.meta.test.ts
+++ b/app/presentation/routes/__tests__/about.meta.test.ts
@@ -1,0 +1,68 @@
+import type { MetaDescriptor } from "react-router";
+import { describe, expect, it } from "vitest";
+import { meta } from "../about";
+
+type LdScript = { "script:ld+json": string };
+const isLd = (m: MetaDescriptor): m is LdScript => "script:ld+json" in m;
+
+const data = {
+	origin: "https://tkstar.dev",
+	canonicalUrl: "https://tkstar.dev/about",
+	ogImageUrl: "https://tkstar.dev/og/fallback.png",
+};
+
+const callMeta = () =>
+	meta({
+		data,
+		params: {},
+		location: { pathname: "/about", search: "", hash: "", state: null, key: "" },
+		matches: [],
+	} as unknown as Parameters<typeof meta>[0]);
+
+describe("About meta export", () => {
+	it("title 이 About — tkstar.dev 를 포함한다", () => {
+		const result = callMeta();
+		expect(result).toEqual(
+			expect.arrayContaining([expect.objectContaining({ title: "About — tkstar.dev" })]),
+		);
+	});
+
+	it("canonical link 태그를 포함한다", () => {
+		const result = callMeta();
+		expect(result).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					tagName: "link",
+					rel: "canonical",
+					href: "https://tkstar.dev/about",
+				}),
+			]),
+		);
+	});
+
+	it("og:image 에 절대 URL 을 포함한다", () => {
+		const result = callMeta();
+		expect(result).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					property: "og:image",
+					content: "https://tkstar.dev/og/fallback.png",
+				}),
+			]),
+		);
+	});
+
+	it("JSON-LD 스크립트에 Person 타입을 포함한다", () => {
+		const result = callMeta();
+		const ldScripts = (result as MetaDescriptor[]).filter(isLd);
+		const types = ldScripts.map((s) => JSON.parse(s["script:ld+json"])["@type"]);
+		expect(types).toContain("Person");
+	});
+
+	it("JSON-LD 스크립트에 BreadcrumbList 타입을 포함한다", () => {
+		const result = callMeta();
+		const ldScripts = (result as MetaDescriptor[]).filter(isLd);
+		const types = ldScripts.map((s) => JSON.parse(s["script:ld+json"])["@type"]);
+		expect(types).toContain("BreadcrumbList");
+	});
+});

--- a/app/presentation/routes/__tests__/about.meta.test.ts
+++ b/app/presentation/routes/__tests__/about.meta.test.ts
@@ -66,3 +66,16 @@ describe("About meta export", () => {
 		expect(types).toContain("BreadcrumbList");
 	});
 });
+
+describe("data 가 undefined 이면 fallback meta 만 반환한다", () => {
+	it("title 만 포함하고 canonical/og:image/JSON-LD 는 제외", () => {
+		const result = meta({
+			data: undefined,
+			params: {},
+			location: { pathname: "/", search: "", hash: "", state: null, key: "" },
+			matches: [],
+		} as unknown as Parameters<typeof meta>[0]);
+		expect((result as { title?: string }[]).some((m) => "title" in m)).toBe(true);
+		expect((result as { tagName?: string }[]).some((m) => m.tagName === "link")).toBe(false);
+	});
+});

--- a/app/presentation/routes/__tests__/blog.$slug.meta.test.ts
+++ b/app/presentation/routes/__tests__/blog.$slug.meta.test.ts
@@ -1,0 +1,121 @@
+import type { MetaDescriptor } from "react-router";
+import { describe, expect, it } from "vitest";
+import { meta } from "../blog.$slug";
+
+type LdScript = { "script:ld+json": string };
+const isLd = (m: MetaDescriptor): m is LdScript => "script:ld+json" in m;
+
+const post = {
+	slug: "my-post",
+	title: "My Post",
+	lede: "post lede",
+	date: "2026-04-15",
+	tags: ["typescript"] as string[],
+	read: 5,
+};
+
+const data = {
+	post,
+	prev: null,
+	next: null,
+	origin: "https://tkstar.dev",
+	canonicalUrl: "https://tkstar.dev/blog/my-post",
+	ogImageUrl: "https://tkstar.dev/og/blog/my-post.png",
+};
+
+const callMeta = () =>
+	meta({
+		data,
+		params: { slug: "my-post" },
+		location: { pathname: "/blog/my-post", search: "", hash: "", state: null, key: "" },
+		matches: [],
+	} as unknown as Parameters<typeof meta>[0]);
+
+describe("blog.$slug meta export", () => {
+	it("title 이 'My Post — tkstar.dev' 를 포함한다", () => {
+		const result = callMeta();
+		expect(result).toEqual(
+			expect.arrayContaining([expect.objectContaining({ title: "My Post — tkstar.dev" })]),
+		);
+	});
+
+	it("description 메타태그에 post.lede 를 사용한다", () => {
+		const result = callMeta();
+		expect(result).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({ name: "description", content: "post lede" }),
+			]),
+		);
+	});
+
+	it("canonical link 태그를 포함한다", () => {
+		const result = callMeta();
+		expect(result).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					tagName: "link",
+					rel: "canonical",
+					href: "https://tkstar.dev/blog/my-post",
+				}),
+			]),
+		);
+	});
+
+	it("og:image 에 동적 Satori OG URL 을 포함한다", () => {
+		const result = callMeta();
+		expect(result).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					property: "og:image",
+					content: "https://tkstar.dev/og/blog/my-post.png",
+				}),
+			]),
+		);
+	});
+
+	it("og:type 이 article 이다", () => {
+		const result = callMeta();
+		expect(result).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({ property: "og:type", content: "article" }),
+			]),
+		);
+	});
+
+	it("JSON-LD 스크립트에 BlogPosting 타입을 포함한다", () => {
+		const result = callMeta();
+		const ldScripts = (result as MetaDescriptor[]).filter(isLd);
+		const types = ldScripts.map((s) => JSON.parse(s["script:ld+json"])["@type"]);
+		expect(types).toContain("BlogPosting");
+	});
+
+	it("JSON-LD 스크립트에 BreadcrumbList 타입을 포함한다", () => {
+		const result = callMeta();
+		const ldScripts = (result as MetaDescriptor[]).filter(isLd);
+		const types = ldScripts.map((s) => JSON.parse(s["script:ld+json"])["@type"]);
+		expect(types).toContain("BreadcrumbList");
+	});
+
+	it("BlogPosting JSON-LD 에 올바른 필드를 포함한다", () => {
+		const result = callMeta();
+		const ldScripts = (result as MetaDescriptor[]).filter(isLd);
+		const ld = ldScripts
+			.map((s) => JSON.parse(s["script:ld+json"]))
+			.find((o) => o["@type"] === "BlogPosting");
+		expect(ld?.headline).toBe("My Post");
+		expect(ld?.description).toBe("post lede");
+		expect(ld?.datePublished).toBe("2026-04-15");
+		expect(ld?.image).toBe("https://tkstar.dev/og/blog/my-post.png");
+		expect(ld?.mainEntityOfPage).toBe("https://tkstar.dev/blog/my-post");
+		expect(ld?.inLanguage).toBe("ko");
+	});
+
+	it("BreadcrumbList itemListElement 길이가 3 이다 (Home / Blog / 현재 포스트)", () => {
+		const result = callMeta();
+		const ldScripts = (result as MetaDescriptor[]).filter(isLd);
+		const ld = ldScripts
+			.map((s) => JSON.parse(s["script:ld+json"]))
+			.find((o) => o["@type"] === "BreadcrumbList");
+		expect(ld?.itemListElement).toHaveLength(3);
+	});
+});

--- a/app/presentation/routes/__tests__/blog.$slug.meta.test.ts
+++ b/app/presentation/routes/__tests__/blog.$slug.meta.test.ts
@@ -119,3 +119,16 @@ describe("blog.$slug meta export", () => {
 		expect(ld?.itemListElement).toHaveLength(3);
 	});
 });
+
+describe("data 가 undefined 이면 fallback meta 만 반환한다", () => {
+	it("title 만 포함하고 canonical/og:image/JSON-LD 는 제외", () => {
+		const result = meta({
+			data: undefined,
+			params: {},
+			location: { pathname: "/", search: "", hash: "", state: null, key: "" },
+			matches: [],
+		} as unknown as Parameters<typeof meta>[0]);
+		expect((result as { title?: string }[]).some((m) => "title" in m)).toBe(true);
+		expect((result as { tagName?: string }[]).some((m) => m.tagName === "link")).toBe(false);
+	});
+});

--- a/app/presentation/routes/__tests__/blog.$slug.meta.test.ts
+++ b/app/presentation/routes/__tests__/blog.$slug.meta.test.ts
@@ -2,7 +2,7 @@ import type { MetaDescriptor } from "react-router";
 import { describe, expect, it } from "vitest";
 import { meta } from "../blog.$slug";
 
-type LdScript = { "script:ld+json": string };
+type LdScript = { "script:ld+json": Record<string, unknown> };
 const isLd = (m: MetaDescriptor): m is LdScript => "script:ld+json" in m;
 
 const post = {
@@ -85,14 +85,14 @@ describe("blog.$slug meta export", () => {
 	it("JSON-LD 스크립트에 BlogPosting 타입을 포함한다", () => {
 		const result = callMeta();
 		const ldScripts = (result as MetaDescriptor[]).filter(isLd);
-		const types = ldScripts.map((s) => JSON.parse(s["script:ld+json"])["@type"]);
+		const types = ldScripts.map((s) => s["script:ld+json"]["@type"]);
 		expect(types).toContain("BlogPosting");
 	});
 
 	it("JSON-LD 스크립트에 BreadcrumbList 타입을 포함한다", () => {
 		const result = callMeta();
 		const ldScripts = (result as MetaDescriptor[]).filter(isLd);
-		const types = ldScripts.map((s) => JSON.parse(s["script:ld+json"])["@type"]);
+		const types = ldScripts.map((s) => s["script:ld+json"]["@type"]);
 		expect(types).toContain("BreadcrumbList");
 	});
 
@@ -100,7 +100,7 @@ describe("blog.$slug meta export", () => {
 		const result = callMeta();
 		const ldScripts = (result as MetaDescriptor[]).filter(isLd);
 		const ld = ldScripts
-			.map((s) => JSON.parse(s["script:ld+json"]))
+			.map((s) => s["script:ld+json"])
 			.find((o) => o["@type"] === "BlogPosting");
 		expect(ld?.headline).toBe("My Post");
 		expect(ld?.description).toBe("post lede");
@@ -114,7 +114,7 @@ describe("blog.$slug meta export", () => {
 		const result = callMeta();
 		const ldScripts = (result as MetaDescriptor[]).filter(isLd);
 		const ld = ldScripts
-			.map((s) => JSON.parse(s["script:ld+json"]))
+			.map((s) => s["script:ld+json"])
 			.find((o) => o["@type"] === "BreadcrumbList");
 		expect(ld?.itemListElement).toHaveLength(3);
 	});

--- a/app/presentation/routes/__tests__/blog._index.meta.test.ts
+++ b/app/presentation/routes/__tests__/blog._index.meta.test.ts
@@ -2,7 +2,7 @@ import type { MetaDescriptor } from "react-router";
 import { describe, expect, it } from "vitest";
 import { meta } from "../blog._index";
 
-type LdScript = { "script:ld+json": string };
+type LdScript = { "script:ld+json": Record<string, unknown> };
 const isLd = (m: MetaDescriptor): m is LdScript => "script:ld+json" in m;
 
 const data = {
@@ -58,14 +58,14 @@ describe("Blog(_index) meta export", () => {
 	it("JSON-LD 스크립트에 BreadcrumbList 타입을 포함한다", () => {
 		const result = callMeta();
 		const ldScripts = (result as MetaDescriptor[]).filter(isLd);
-		const types = ldScripts.map((s) => JSON.parse(s["script:ld+json"])["@type"]);
+		const types = ldScripts.map((s) => s["script:ld+json"]["@type"]);
 		expect(types).toContain("BreadcrumbList");
 	});
 
 	it("JSON-LD 스크립트에 Person 타입을 포함하지 않는다", () => {
 		const result = callMeta();
 		const ldScripts = (result as MetaDescriptor[]).filter(isLd);
-		const types = ldScripts.map((s) => JSON.parse(s["script:ld+json"])["@type"]);
+		const types = ldScripts.map((s) => s["script:ld+json"]["@type"]);
 		expect(types).not.toContain("Person");
 	});
 });

--- a/app/presentation/routes/__tests__/blog._index.meta.test.ts
+++ b/app/presentation/routes/__tests__/blog._index.meta.test.ts
@@ -1,0 +1,71 @@
+import type { MetaDescriptor } from "react-router";
+import { describe, expect, it } from "vitest";
+import { meta } from "../blog._index";
+
+type LdScript = { "script:ld+json": string };
+const isLd = (m: MetaDescriptor): m is LdScript => "script:ld+json" in m;
+
+const data = {
+	origin: "https://tkstar.dev",
+	canonicalUrl: "https://tkstar.dev/blog",
+	ogImageUrl: "https://tkstar.dev/og/fallback.png",
+	posts: [],
+	allTags: [],
+	activeTag: null,
+};
+
+const callMeta = () =>
+	meta({
+		data,
+		params: {},
+		location: { pathname: "/blog", search: "", hash: "", state: null, key: "" },
+		matches: [],
+	} as unknown as Parameters<typeof meta>[0]);
+
+describe("Blog(_index) meta export", () => {
+	it("title 이 Blog — tkstar.dev 를 포함한다", () => {
+		const result = callMeta();
+		expect(result).toEqual(
+			expect.arrayContaining([expect.objectContaining({ title: "Blog — tkstar.dev" })]),
+		);
+	});
+
+	it("canonical link 태그를 포함한다", () => {
+		const result = callMeta();
+		expect(result).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					tagName: "link",
+					rel: "canonical",
+					href: "https://tkstar.dev/blog",
+				}),
+			]),
+		);
+	});
+
+	it("og:image 에 절대 URL 을 포함한다", () => {
+		const result = callMeta();
+		expect(result).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					property: "og:image",
+					content: "https://tkstar.dev/og/fallback.png",
+				}),
+			]),
+		);
+	});
+
+	it("JSON-LD 스크립트에 BreadcrumbList 타입을 포함한다", () => {
+		const result = callMeta();
+		const ldScripts = (result as MetaDescriptor[]).filter(isLd);
+		const types = ldScripts.map((s) => JSON.parse(s["script:ld+json"])["@type"]);
+		expect(types).toContain("BreadcrumbList");
+	});
+
+	it("JSON-LD 스크립트에 Person 타입을 포함하지 않는다", () => {
+		const result = callMeta();
+		const ldScripts = (result as MetaDescriptor[]).filter(isLd);
+		const types = ldScripts.map((s) => JSON.parse(s["script:ld+json"])["@type"]);
+		expect(types).not.toContain("Person");
+	});
+});

--- a/app/presentation/routes/__tests__/blog._index.meta.test.ts
+++ b/app/presentation/routes/__tests__/blog._index.meta.test.ts
@@ -69,3 +69,16 @@ describe("Blog(_index) meta export", () => {
 		expect(types).not.toContain("Person");
 	});
 });
+
+describe("data 가 undefined 이면 fallback meta 만 반환한다", () => {
+	it("title 만 포함하고 canonical/og:image/JSON-LD 는 제외", () => {
+		const result = meta({
+			data: undefined,
+			params: {},
+			location: { pathname: "/", search: "", hash: "", state: null, key: "" },
+			matches: [],
+		} as unknown as Parameters<typeof meta>[0]);
+		expect((result as { title?: string }[]).some((m) => "title" in m)).toBe(true);
+		expect((result as { tagName?: string }[]).some((m) => m.tagName === "link")).toBe(false);
+	});
+});

--- a/app/presentation/routes/__tests__/contact.meta.test.ts
+++ b/app/presentation/routes/__tests__/contact.meta.test.ts
@@ -1,0 +1,70 @@
+import type { MetaDescriptor } from "react-router";
+import { describe, expect, it } from "vitest";
+import { meta } from "../contact";
+
+type LdScript = { "script:ld+json": string };
+const isLd = (m: MetaDescriptor): m is LdScript => "script:ld+json" in m;
+
+const data = {
+	origin: "https://tkstar.dev",
+	canonicalUrl: "https://tkstar.dev/contact",
+	ogImageUrl: "https://tkstar.dev/og/fallback.png",
+	siteKey: "1x00000000000000000000AA",
+	contactEmail: "hello@tkstar.dev",
+};
+
+const callMeta = () =>
+	meta({
+		data,
+		params: {},
+		location: { pathname: "/contact", search: "", hash: "", state: null, key: "" },
+		matches: [],
+	} as unknown as Parameters<typeof meta>[0]);
+
+describe("Contact meta export", () => {
+	it("title 이 Contact — tkstar.dev 를 포함한다", () => {
+		const result = callMeta();
+		expect(result).toEqual(
+			expect.arrayContaining([expect.objectContaining({ title: "Contact — tkstar.dev" })]),
+		);
+	});
+
+	it("canonical link 태그를 포함한다", () => {
+		const result = callMeta();
+		expect(result).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					tagName: "link",
+					rel: "canonical",
+					href: "https://tkstar.dev/contact",
+				}),
+			]),
+		);
+	});
+
+	it("og:image 에 절대 URL 을 포함한다", () => {
+		const result = callMeta();
+		expect(result).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					property: "og:image",
+					content: "https://tkstar.dev/og/fallback.png",
+				}),
+			]),
+		);
+	});
+
+	it("JSON-LD 스크립트에 BreadcrumbList 타입을 포함한다", () => {
+		const result = callMeta();
+		const ldScripts = (result as MetaDescriptor[]).filter(isLd);
+		const types = ldScripts.map((s) => JSON.parse(s["script:ld+json"])["@type"]);
+		expect(types).toContain("BreadcrumbList");
+	});
+
+	it("JSON-LD 스크립트에 Person 타입을 포함하지 않는다", () => {
+		const result = callMeta();
+		const ldScripts = (result as MetaDescriptor[]).filter(isLd);
+		const types = ldScripts.map((s) => JSON.parse(s["script:ld+json"])["@type"]);
+		expect(types).not.toContain("Person");
+	});
+});

--- a/app/presentation/routes/__tests__/contact.meta.test.ts
+++ b/app/presentation/routes/__tests__/contact.meta.test.ts
@@ -2,7 +2,7 @@ import type { MetaDescriptor } from "react-router";
 import { describe, expect, it } from "vitest";
 import { meta } from "../contact";
 
-type LdScript = { "script:ld+json": string };
+type LdScript = { "script:ld+json": Record<string, unknown> };
 const isLd = (m: MetaDescriptor): m is LdScript => "script:ld+json" in m;
 
 const data = {
@@ -57,14 +57,14 @@ describe("Contact meta export", () => {
 	it("JSON-LD 스크립트에 BreadcrumbList 타입을 포함한다", () => {
 		const result = callMeta();
 		const ldScripts = (result as MetaDescriptor[]).filter(isLd);
-		const types = ldScripts.map((s) => JSON.parse(s["script:ld+json"])["@type"]);
+		const types = ldScripts.map((s) => s["script:ld+json"]["@type"]);
 		expect(types).toContain("BreadcrumbList");
 	});
 
 	it("JSON-LD 스크립트에 Person 타입을 포함하지 않는다", () => {
 		const result = callMeta();
 		const ldScripts = (result as MetaDescriptor[]).filter(isLd);
-		const types = ldScripts.map((s) => JSON.parse(s["script:ld+json"])["@type"]);
+		const types = ldScripts.map((s) => s["script:ld+json"]["@type"]);
 		expect(types).not.toContain("Person");
 	});
 });

--- a/app/presentation/routes/__tests__/contact.meta.test.ts
+++ b/app/presentation/routes/__tests__/contact.meta.test.ts
@@ -68,3 +68,16 @@ describe("Contact meta export", () => {
 		expect(types).not.toContain("Person");
 	});
 });
+
+describe("data 가 undefined 이면 fallback meta 만 반환한다", () => {
+	it("title 만 포함하고 canonical/og:image/JSON-LD 는 제외", () => {
+		const result = meta({
+			data: undefined,
+			params: {},
+			location: { pathname: "/", search: "", hash: "", state: null, key: "" },
+			matches: [],
+		} as unknown as Parameters<typeof meta>[0]);
+		expect((result as { title?: string }[]).some((m) => "title" in m)).toBe(true);
+		expect((result as { tagName?: string }[]).some((m) => m.tagName === "link")).toBe(false);
+	});
+});

--- a/app/presentation/routes/__tests__/contact.test.tsx
+++ b/app/presentation/routes/__tests__/contact.test.tsx
@@ -69,7 +69,7 @@ describe("Group A — contact loader", () => {
 			params: {},
 			request: new Request("http://localhost/contact"),
 		} as never);
-		expect(result).toEqual({
+		expect(result).toMatchObject({
 			siteKey: "1x00000000000000000000AA",
 			contactEmail: "hello@tkstar.dev",
 		});

--- a/app/presentation/routes/__tests__/legal.$app.privacy.meta.test.ts
+++ b/app/presentation/routes/__tests__/legal.$app.privacy.meta.test.ts
@@ -94,3 +94,16 @@ describe("legal.$app.privacy meta export", () => {
 		expect(ld?.itemListElement).toHaveLength(3);
 	});
 });
+
+describe("data 가 undefined 이면 fallback meta 만 반환한다", () => {
+	it("title 만 포함하고 canonical/og:image/JSON-LD 는 제외", () => {
+		const result = meta({
+			data: undefined,
+			params: {},
+			location: { pathname: "/", search: "", hash: "", state: null, key: "" },
+			matches: [],
+		} as unknown as Parameters<typeof meta>[0]);
+		expect((result as { title?: string }[]).some((m) => "title" in m)).toBe(true);
+		expect((result as { tagName?: string }[]).some((m) => m.tagName === "link")).toBe(false);
+	});
+});

--- a/app/presentation/routes/__tests__/legal.$app.privacy.meta.test.ts
+++ b/app/presentation/routes/__tests__/legal.$app.privacy.meta.test.ts
@@ -2,7 +2,7 @@ import type { MetaDescriptor } from "react-router";
 import { describe, expect, it } from "vitest";
 import { meta } from "../legal.$app.privacy";
 
-type LdScript = { "script:ld+json": string };
+type LdScript = { "script:ld+json": Record<string, unknown> };
 const isLd = (m: MetaDescriptor): m is LdScript => "script:ld+json" in m;
 
 const data = {
@@ -72,14 +72,14 @@ describe("legal.$app.privacy meta export", () => {
 	it("JSON-LD 스크립트에 BreadcrumbList 타입을 포함한다", () => {
 		const result = callMeta();
 		const ldScripts = (result as MetaDescriptor[]).filter(isLd);
-		const types = ldScripts.map((s) => JSON.parse(s["script:ld+json"])["@type"]);
+		const types = ldScripts.map((s) => s["script:ld+json"]["@type"]);
 		expect(types).toContain("BreadcrumbList");
 	});
 
 	it("JSON-LD 스크립트에 BreadcrumbList 만 포함한다 (Person / BlogPosting / CreativeWork 미포함)", () => {
 		const result = callMeta();
 		const ldScripts = (result as MetaDescriptor[]).filter(isLd);
-		const types = ldScripts.map((s) => JSON.parse(s["script:ld+json"])["@type"]);
+		const types = ldScripts.map((s) => s["script:ld+json"]["@type"]);
 		expect(types).not.toContain("Person");
 		expect(types).not.toContain("BlogPosting");
 		expect(types).not.toContain("CreativeWork");
@@ -89,7 +89,7 @@ describe("legal.$app.privacy meta export", () => {
 		const result = callMeta();
 		const ldScripts = (result as MetaDescriptor[]).filter(isLd);
 		const ld = ldScripts
-			.map((s) => JSON.parse(s["script:ld+json"]))
+			.map((s) => s["script:ld+json"])
 			.find((o) => o["@type"] === "BreadcrumbList");
 		expect(ld?.itemListElement).toHaveLength(3);
 	});

--- a/app/presentation/routes/__tests__/legal.$app.privacy.meta.test.ts
+++ b/app/presentation/routes/__tests__/legal.$app.privacy.meta.test.ts
@@ -1,0 +1,96 @@
+import type { MetaDescriptor } from "react-router";
+import { describe, expect, it } from "vitest";
+import { meta } from "../legal.$app.privacy";
+
+type LdScript = { "script:ld+json": string };
+const isLd = (m: MetaDescriptor): m is LdScript => "script:ld+json" in m;
+
+const data = {
+	doc: {
+		app_slug: "moai",
+		doc_type: "privacy" as const,
+		version: "1.0",
+		effective_date: "2026-01-01",
+	},
+	origin: "https://tkstar.dev",
+	canonicalUrl: "https://tkstar.dev/legal/moai/privacy",
+	ogImageUrl: "https://tkstar.dev/og/fallback.png",
+};
+
+const callMeta = () =>
+	meta({
+		data,
+		params: { app: "moai" },
+		location: { pathname: "/legal/moai/privacy", search: "", hash: "", state: null, key: "" },
+		matches: [],
+	} as unknown as Parameters<typeof meta>[0]);
+
+describe("legal.$app.privacy meta export", () => {
+	it("title 이 'moai 개인정보 처리방침 — tkstar.dev' 를 포함한다", () => {
+		const result = callMeta();
+		expect(result).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({ title: "moai 개인정보 처리방침 — tkstar.dev" }),
+			]),
+		);
+	});
+
+	it("canonical link 태그를 포함한다", () => {
+		const result = callMeta();
+		expect(result).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					tagName: "link",
+					rel: "canonical",
+					href: "https://tkstar.dev/legal/moai/privacy",
+				}),
+			]),
+		);
+	});
+
+	it("og:image 에 절대 URL 을 포함한다", () => {
+		const result = callMeta();
+		expect(result).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					property: "og:image",
+					content: "https://tkstar.dev/og/fallback.png",
+				}),
+			]),
+		);
+	});
+
+	it("robots 메타태그가 'noindex, follow' 이다", () => {
+		const result = callMeta();
+		expect(result).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({ name: "robots", content: "noindex, follow" }),
+			]),
+		);
+	});
+
+	it("JSON-LD 스크립트에 BreadcrumbList 타입을 포함한다", () => {
+		const result = callMeta();
+		const ldScripts = (result as MetaDescriptor[]).filter(isLd);
+		const types = ldScripts.map((s) => JSON.parse(s["script:ld+json"])["@type"]);
+		expect(types).toContain("BreadcrumbList");
+	});
+
+	it("JSON-LD 스크립트에 BreadcrumbList 만 포함한다 (Person / BlogPosting / CreativeWork 미포함)", () => {
+		const result = callMeta();
+		const ldScripts = (result as MetaDescriptor[]).filter(isLd);
+		const types = ldScripts.map((s) => JSON.parse(s["script:ld+json"])["@type"]);
+		expect(types).not.toContain("Person");
+		expect(types).not.toContain("BlogPosting");
+		expect(types).not.toContain("CreativeWork");
+	});
+
+	it("BreadcrumbList itemListElement 길이가 3 이다 (Home / Legal / moai 개인정보 처리방침)", () => {
+		const result = callMeta();
+		const ldScripts = (result as MetaDescriptor[]).filter(isLd);
+		const ld = ldScripts
+			.map((s) => JSON.parse(s["script:ld+json"]))
+			.find((o) => o["@type"] === "BreadcrumbList");
+		expect(ld?.itemListElement).toHaveLength(3);
+	});
+});

--- a/app/presentation/routes/__tests__/legal.$app.privacy.test.tsx
+++ b/app/presentation/routes/__tests__/legal.$app.privacy.test.tsx
@@ -66,7 +66,7 @@ describe("Group A — legal.$app.privacy loader", () => {
 
 		// Assert
 		expect(spies.findAppDoc).toHaveBeenCalledWith("moai", "privacy");
-		expect(result).toEqual({ doc: moaiPrivacy });
+		expect(result).toMatchObject({ doc: moaiPrivacy });
 	});
 
 	it("params.app 이 미정의이면 Response 404 를 throw 한다", async () => {

--- a/app/presentation/routes/__tests__/legal.$app.terms.meta.test.ts
+++ b/app/presentation/routes/__tests__/legal.$app.terms.meta.test.ts
@@ -94,3 +94,16 @@ describe("legal.$app.terms meta export", () => {
 		expect(ld?.itemListElement).toHaveLength(3);
 	});
 });
+
+describe("data 가 undefined 이면 fallback meta 만 반환한다", () => {
+	it("title 만 포함하고 canonical/og:image/JSON-LD 는 제외", () => {
+		const result = meta({
+			data: undefined,
+			params: {},
+			location: { pathname: "/", search: "", hash: "", state: null, key: "" },
+			matches: [],
+		} as unknown as Parameters<typeof meta>[0]);
+		expect((result as { title?: string }[]).some((m) => "title" in m)).toBe(true);
+		expect((result as { tagName?: string }[]).some((m) => m.tagName === "link")).toBe(false);
+	});
+});

--- a/app/presentation/routes/__tests__/legal.$app.terms.meta.test.ts
+++ b/app/presentation/routes/__tests__/legal.$app.terms.meta.test.ts
@@ -2,7 +2,7 @@ import type { MetaDescriptor } from "react-router";
 import { describe, expect, it } from "vitest";
 import { meta } from "../legal.$app.terms";
 
-type LdScript = { "script:ld+json": string };
+type LdScript = { "script:ld+json": Record<string, unknown> };
 const isLd = (m: MetaDescriptor): m is LdScript => "script:ld+json" in m;
 
 const data = {
@@ -72,14 +72,14 @@ describe("legal.$app.terms meta export", () => {
 	it("JSON-LD 스크립트에 BreadcrumbList 타입을 포함한다", () => {
 		const result = callMeta();
 		const ldScripts = (result as MetaDescriptor[]).filter(isLd);
-		const types = ldScripts.map((s) => JSON.parse(s["script:ld+json"])["@type"]);
+		const types = ldScripts.map((s) => s["script:ld+json"]["@type"]);
 		expect(types).toContain("BreadcrumbList");
 	});
 
 	it("JSON-LD 스크립트에 BreadcrumbList 만 포함한다 (Person / BlogPosting / CreativeWork 미포함)", () => {
 		const result = callMeta();
 		const ldScripts = (result as MetaDescriptor[]).filter(isLd);
-		const types = ldScripts.map((s) => JSON.parse(s["script:ld+json"])["@type"]);
+		const types = ldScripts.map((s) => s["script:ld+json"]["@type"]);
 		expect(types).not.toContain("Person");
 		expect(types).not.toContain("BlogPosting");
 		expect(types).not.toContain("CreativeWork");
@@ -89,7 +89,7 @@ describe("legal.$app.terms meta export", () => {
 		const result = callMeta();
 		const ldScripts = (result as MetaDescriptor[]).filter(isLd);
 		const ld = ldScripts
-			.map((s) => JSON.parse(s["script:ld+json"]))
+			.map((s) => s["script:ld+json"])
 			.find((o) => o["@type"] === "BreadcrumbList");
 		expect(ld?.itemListElement).toHaveLength(3);
 	});

--- a/app/presentation/routes/__tests__/legal.$app.terms.meta.test.ts
+++ b/app/presentation/routes/__tests__/legal.$app.terms.meta.test.ts
@@ -1,0 +1,96 @@
+import type { MetaDescriptor } from "react-router";
+import { describe, expect, it } from "vitest";
+import { meta } from "../legal.$app.terms";
+
+type LdScript = { "script:ld+json": string };
+const isLd = (m: MetaDescriptor): m is LdScript => "script:ld+json" in m;
+
+const data = {
+	doc: {
+		app_slug: "moai",
+		doc_type: "terms" as const,
+		version: "1.0",
+		effective_date: "2026-01-01",
+	},
+	origin: "https://tkstar.dev",
+	canonicalUrl: "https://tkstar.dev/legal/moai/terms",
+	ogImageUrl: "https://tkstar.dev/og/fallback.png",
+};
+
+const callMeta = () =>
+	meta({
+		data,
+		params: { app: "moai" },
+		location: { pathname: "/legal/moai/terms", search: "", hash: "", state: null, key: "" },
+		matches: [],
+	} as unknown as Parameters<typeof meta>[0]);
+
+describe("legal.$app.terms meta export", () => {
+	it("title 이 'moai 서비스 이용약관 — tkstar.dev' 를 포함한다", () => {
+		const result = callMeta();
+		expect(result).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({ title: "moai 서비스 이용약관 — tkstar.dev" }),
+			]),
+		);
+	});
+
+	it("canonical link 태그를 포함한다", () => {
+		const result = callMeta();
+		expect(result).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					tagName: "link",
+					rel: "canonical",
+					href: "https://tkstar.dev/legal/moai/terms",
+				}),
+			]),
+		);
+	});
+
+	it("og:image 에 절대 URL 을 포함한다", () => {
+		const result = callMeta();
+		expect(result).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					property: "og:image",
+					content: "https://tkstar.dev/og/fallback.png",
+				}),
+			]),
+		);
+	});
+
+	it("robots 메타태그가 'noindex, follow' 이다", () => {
+		const result = callMeta();
+		expect(result).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({ name: "robots", content: "noindex, follow" }),
+			]),
+		);
+	});
+
+	it("JSON-LD 스크립트에 BreadcrumbList 타입을 포함한다", () => {
+		const result = callMeta();
+		const ldScripts = (result as MetaDescriptor[]).filter(isLd);
+		const types = ldScripts.map((s) => JSON.parse(s["script:ld+json"])["@type"]);
+		expect(types).toContain("BreadcrumbList");
+	});
+
+	it("JSON-LD 스크립트에 BreadcrumbList 만 포함한다 (Person / BlogPosting / CreativeWork 미포함)", () => {
+		const result = callMeta();
+		const ldScripts = (result as MetaDescriptor[]).filter(isLd);
+		const types = ldScripts.map((s) => JSON.parse(s["script:ld+json"])["@type"]);
+		expect(types).not.toContain("Person");
+		expect(types).not.toContain("BlogPosting");
+		expect(types).not.toContain("CreativeWork");
+	});
+
+	it("BreadcrumbList itemListElement 길이가 3 이다 (Home / Legal / moai 서비스 이용약관)", () => {
+		const result = callMeta();
+		const ldScripts = (result as MetaDescriptor[]).filter(isLd);
+		const ld = ldScripts
+			.map((s) => JSON.parse(s["script:ld+json"]))
+			.find((o) => o["@type"] === "BreadcrumbList");
+		expect(ld?.itemListElement).toHaveLength(3);
+	});
+});

--- a/app/presentation/routes/__tests__/legal.$app.terms.test.tsx
+++ b/app/presentation/routes/__tests__/legal.$app.terms.test.tsx
@@ -66,7 +66,7 @@ describe("Group A — legal.$app.terms loader", () => {
 
 		// Assert
 		expect(spies.findAppDoc).toHaveBeenCalledWith("moai", "terms");
-		expect(result).toEqual({ doc: moaiTerms });
+		expect(result).toMatchObject({ doc: moaiTerms });
 	});
 
 	it("params.app 이 미정의이면 Response 404 를 throw 한다", async () => {

--- a/app/presentation/routes/__tests__/legal._index.meta.test.ts
+++ b/app/presentation/routes/__tests__/legal._index.meta.test.ts
@@ -1,0 +1,69 @@
+import type { MetaDescriptor } from "react-router";
+import { describe, expect, it } from "vitest";
+import { meta } from "../legal._index";
+
+type LdScript = { "script:ld+json": string };
+const isLd = (m: MetaDescriptor): m is LdScript => "script:ld+json" in m;
+
+const data = {
+	origin: "https://tkstar.dev",
+	canonicalUrl: "https://tkstar.dev/legal",
+	ogImageUrl: "https://tkstar.dev/og/fallback.png",
+	apps: [],
+};
+
+const callMeta = () =>
+	meta({
+		data,
+		params: {},
+		location: { pathname: "/legal", search: "", hash: "", state: null, key: "" },
+		matches: [],
+	} as unknown as Parameters<typeof meta>[0]);
+
+describe("Legal(_index) meta export", () => {
+	it("title 이 Legal — tkstar.dev 를 포함한다", () => {
+		const result = callMeta();
+		expect(result).toEqual(
+			expect.arrayContaining([expect.objectContaining({ title: "Legal — tkstar.dev" })]),
+		);
+	});
+
+	it("canonical link 태그를 포함한다", () => {
+		const result = callMeta();
+		expect(result).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					tagName: "link",
+					rel: "canonical",
+					href: "https://tkstar.dev/legal",
+				}),
+			]),
+		);
+	});
+
+	it("og:image 에 절대 URL 을 포함한다", () => {
+		const result = callMeta();
+		expect(result).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					property: "og:image",
+					content: "https://tkstar.dev/og/fallback.png",
+				}),
+			]),
+		);
+	});
+
+	it("JSON-LD 스크립트에 BreadcrumbList 타입을 포함한다", () => {
+		const result = callMeta();
+		const ldScripts = (result as MetaDescriptor[]).filter(isLd);
+		const types = ldScripts.map((s) => JSON.parse(s["script:ld+json"])["@type"]);
+		expect(types).toContain("BreadcrumbList");
+	});
+
+	it("JSON-LD 스크립트에 Person 타입을 포함하지 않는다", () => {
+		const result = callMeta();
+		const ldScripts = (result as MetaDescriptor[]).filter(isLd);
+		const types = ldScripts.map((s) => JSON.parse(s["script:ld+json"])["@type"]);
+		expect(types).not.toContain("Person");
+	});
+});

--- a/app/presentation/routes/__tests__/legal._index.meta.test.ts
+++ b/app/presentation/routes/__tests__/legal._index.meta.test.ts
@@ -2,7 +2,7 @@ import type { MetaDescriptor } from "react-router";
 import { describe, expect, it } from "vitest";
 import { meta } from "../legal._index";
 
-type LdScript = { "script:ld+json": string };
+type LdScript = { "script:ld+json": Record<string, unknown> };
 const isLd = (m: MetaDescriptor): m is LdScript => "script:ld+json" in m;
 
 const data = {
@@ -56,14 +56,14 @@ describe("Legal(_index) meta export", () => {
 	it("JSON-LD 스크립트에 BreadcrumbList 타입을 포함한다", () => {
 		const result = callMeta();
 		const ldScripts = (result as MetaDescriptor[]).filter(isLd);
-		const types = ldScripts.map((s) => JSON.parse(s["script:ld+json"])["@type"]);
+		const types = ldScripts.map((s) => s["script:ld+json"]["@type"]);
 		expect(types).toContain("BreadcrumbList");
 	});
 
 	it("JSON-LD 스크립트에 Person 타입을 포함하지 않는다", () => {
 		const result = callMeta();
 		const ldScripts = (result as MetaDescriptor[]).filter(isLd);
-		const types = ldScripts.map((s) => JSON.parse(s["script:ld+json"])["@type"]);
+		const types = ldScripts.map((s) => s["script:ld+json"]["@type"]);
 		expect(types).not.toContain("Person");
 	});
 });

--- a/app/presentation/routes/__tests__/legal._index.meta.test.ts
+++ b/app/presentation/routes/__tests__/legal._index.meta.test.ts
@@ -67,3 +67,16 @@ describe("Legal(_index) meta export", () => {
 		expect(types).not.toContain("Person");
 	});
 });
+
+describe("data 가 undefined 이면 fallback meta 만 반환한다", () => {
+	it("title 만 포함하고 canonical/og:image/JSON-LD 는 제외", () => {
+		const result = meta({
+			data: undefined,
+			params: {},
+			location: { pathname: "/", search: "", hash: "", state: null, key: "" },
+			matches: [],
+		} as unknown as Parameters<typeof meta>[0]);
+		expect((result as { title?: string }[]).some((m) => "title" in m)).toBe(true);
+		expect((result as { tagName?: string }[]).some((m) => m.tagName === "link")).toBe(false);
+	});
+});

--- a/app/presentation/routes/__tests__/legal._index.test.tsx
+++ b/app/presentation/routes/__tests__/legal._index.test.tsx
@@ -45,7 +45,7 @@ describe("Group A — legal._index loader", () => {
 		} as never);
 
 		// Assert
-		expect(result).toEqual({ apps: ["moai", "jagi"] });
+		expect(result).toMatchObject({ apps: ["moai", "jagi"] });
 		expect(spies.listApps).toHaveBeenCalledOnce();
 	});
 
@@ -60,7 +60,7 @@ describe("Group A — legal._index loader", () => {
 		} as never);
 
 		// Assert
-		expect(result).toEqual({ apps: [] });
+		expect(result).toMatchObject({ apps: [] });
 	});
 });
 

--- a/app/presentation/routes/__tests__/projects.$slug.meta.test.ts
+++ b/app/presentation/routes/__tests__/projects.$slug.meta.test.ts
@@ -2,7 +2,7 @@ import type { MetaDescriptor } from "react-router";
 import { describe, expect, it } from "vitest";
 import { meta } from "../projects.$slug";
 
-type LdScript = { "script:ld+json": string };
+type LdScript = { "script:ld+json": Record<string, unknown> };
 const isLd = (m: MetaDescriptor): m is LdScript => "script:ld+json" in m;
 
 const project = {
@@ -86,14 +86,14 @@ describe("projects.$slug meta export", () => {
 	it("JSON-LD 스크립트에 CreativeWork 타입을 포함한다", () => {
 		const result = callMeta();
 		const ldScripts = (result as MetaDescriptor[]).filter(isLd);
-		const types = ldScripts.map((s) => JSON.parse(s["script:ld+json"])["@type"]);
+		const types = ldScripts.map((s) => s["script:ld+json"]["@type"]);
 		expect(types).toContain("CreativeWork");
 	});
 
 	it("JSON-LD 스크립트에 BreadcrumbList 타입을 포함한다", () => {
 		const result = callMeta();
 		const ldScripts = (result as MetaDescriptor[]).filter(isLd);
-		const types = ldScripts.map((s) => JSON.parse(s["script:ld+json"])["@type"]);
+		const types = ldScripts.map((s) => s["script:ld+json"]["@type"]);
 		expect(types).toContain("BreadcrumbList");
 	});
 
@@ -101,7 +101,7 @@ describe("projects.$slug meta export", () => {
 		const result = callMeta();
 		const ldScripts = (result as MetaDescriptor[]).filter(isLd);
 		const ld = ldScripts
-			.map((s) => JSON.parse(s["script:ld+json"]))
+			.map((s) => s["script:ld+json"])
 			.find((o) => o["@type"] === "CreativeWork");
 		expect(ld?.name).toBe("My Project");
 		expect(ld?.description).toBe("project summary");
@@ -114,7 +114,7 @@ describe("projects.$slug meta export", () => {
 		const result = callMeta();
 		const ldScripts = (result as MetaDescriptor[]).filter(isLd);
 		const ld = ldScripts
-			.map((s) => JSON.parse(s["script:ld+json"]))
+			.map((s) => s["script:ld+json"])
 			.find((o) => o["@type"] === "BreadcrumbList");
 		expect(ld?.itemListElement).toHaveLength(3);
 	});

--- a/app/presentation/routes/__tests__/projects.$slug.meta.test.ts
+++ b/app/presentation/routes/__tests__/projects.$slug.meta.test.ts
@@ -119,3 +119,16 @@ describe("projects.$slug meta export", () => {
 		expect(ld?.itemListElement).toHaveLength(3);
 	});
 });
+
+describe("data 가 undefined 이면 fallback meta 만 반환한다", () => {
+	it("title 만 포함하고 canonical/og:image/JSON-LD 는 제외", () => {
+		const result = meta({
+			data: undefined,
+			params: {},
+			location: { pathname: "/", search: "", hash: "", state: null, key: "" },
+			matches: [],
+		} as unknown as Parameters<typeof meta>[0]);
+		expect((result as { title?: string }[]).some((m) => "title" in m)).toBe(true);
+		expect((result as { tagName?: string }[]).some((m) => m.tagName === "link")).toBe(false);
+	});
+});

--- a/app/presentation/routes/__tests__/projects.$slug.meta.test.ts
+++ b/app/presentation/routes/__tests__/projects.$slug.meta.test.ts
@@ -1,0 +1,121 @@
+import type { MetaDescriptor } from "react-router";
+import { describe, expect, it } from "vitest";
+import { meta } from "../projects.$slug";
+
+type LdScript = { "script:ld+json": string };
+const isLd = (m: MetaDescriptor): m is LdScript => "script:ld+json" in m;
+
+const project = {
+	slug: "my-project",
+	title: "My Project",
+	summary: "project summary",
+	date: "2025-12-01",
+	tags: [] as string[],
+	stack: [] as string[],
+	metrics: [] as [string, string][],
+};
+
+const data = {
+	project,
+	prev: null,
+	next: null,
+	origin: "https://tkstar.dev",
+	canonicalUrl: "https://tkstar.dev/projects/my-project",
+	ogImageUrl: "https://tkstar.dev/og/projects/my-project.png",
+};
+
+const callMeta = () =>
+	meta({
+		data,
+		params: { slug: "my-project" },
+		location: { pathname: "/projects/my-project", search: "", hash: "", state: null, key: "" },
+		matches: [],
+	} as unknown as Parameters<typeof meta>[0]);
+
+describe("projects.$slug meta export", () => {
+	it("title 이 'My Project — tkstar.dev' 를 포함한다", () => {
+		const result = callMeta();
+		expect(result).toEqual(
+			expect.arrayContaining([expect.objectContaining({ title: "My Project — tkstar.dev" })]),
+		);
+	});
+
+	it("description 메타태그에 project.summary 를 사용한다", () => {
+		const result = callMeta();
+		expect(result).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({ name: "description", content: "project summary" }),
+			]),
+		);
+	});
+
+	it("canonical link 태그를 포함한다", () => {
+		const result = callMeta();
+		expect(result).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					tagName: "link",
+					rel: "canonical",
+					href: "https://tkstar.dev/projects/my-project",
+				}),
+			]),
+		);
+	});
+
+	it("og:image 에 동적 Satori OG URL 을 포함한다", () => {
+		const result = callMeta();
+		expect(result).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					property: "og:image",
+					content: "https://tkstar.dev/og/projects/my-project.png",
+				}),
+			]),
+		);
+	});
+
+	it("og:type 이 article 이다", () => {
+		const result = callMeta();
+		expect(result).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({ property: "og:type", content: "article" }),
+			]),
+		);
+	});
+
+	it("JSON-LD 스크립트에 CreativeWork 타입을 포함한다", () => {
+		const result = callMeta();
+		const ldScripts = (result as MetaDescriptor[]).filter(isLd);
+		const types = ldScripts.map((s) => JSON.parse(s["script:ld+json"])["@type"]);
+		expect(types).toContain("CreativeWork");
+	});
+
+	it("JSON-LD 스크립트에 BreadcrumbList 타입을 포함한다", () => {
+		const result = callMeta();
+		const ldScripts = (result as MetaDescriptor[]).filter(isLd);
+		const types = ldScripts.map((s) => JSON.parse(s["script:ld+json"])["@type"]);
+		expect(types).toContain("BreadcrumbList");
+	});
+
+	it("CreativeWork JSON-LD 에 올바른 필드를 포함한다", () => {
+		const result = callMeta();
+		const ldScripts = (result as MetaDescriptor[]).filter(isLd);
+		const ld = ldScripts
+			.map((s) => JSON.parse(s["script:ld+json"]))
+			.find((o) => o["@type"] === "CreativeWork");
+		expect(ld?.name).toBe("My Project");
+		expect(ld?.description).toBe("project summary");
+		expect(ld?.url).toBe("https://tkstar.dev/projects/my-project");
+		expect(ld?.image).toBe("https://tkstar.dev/og/projects/my-project.png");
+		expect(ld?.inLanguage).toBe("ko");
+	});
+
+	it("BreadcrumbList itemListElement 길이가 3 이다 (Home / Projects / 현재 프로젝트)", () => {
+		const result = callMeta();
+		const ldScripts = (result as MetaDescriptor[]).filter(isLd);
+		const ld = ldScripts
+			.map((s) => JSON.parse(s["script:ld+json"]))
+			.find((o) => o["@type"] === "BreadcrumbList");
+		expect(ld?.itemListElement).toHaveLength(3);
+	});
+});

--- a/app/presentation/routes/__tests__/projects.$slug.test.tsx
+++ b/app/presentation/routes/__tests__/projects.$slug.test.tsx
@@ -88,7 +88,7 @@ describe("Group A — projects.$slug loader", () => {
 
 		// Assert
 		expect(spies.getProjectDetail.mock.calls[0][0]).toBe("alpha");
-		expect(result).toEqual(mockReturn);
+		expect(result).toMatchObject(mockReturn);
 	});
 
 	it("params.slug 가 undefined 이면 throw 한다", async () => {

--- a/app/presentation/routes/__tests__/projects._index.meta.test.ts
+++ b/app/presentation/routes/__tests__/projects._index.meta.test.ts
@@ -69,3 +69,16 @@ describe("Projects(_index) meta export", () => {
 		expect(types).not.toContain("Person");
 	});
 });
+
+describe("data 가 undefined 이면 fallback meta 만 반환한다", () => {
+	it("title 만 포함하고 canonical/og:image/JSON-LD 는 제외", () => {
+		const result = meta({
+			data: undefined,
+			params: {},
+			location: { pathname: "/", search: "", hash: "", state: null, key: "" },
+			matches: [],
+		} as unknown as Parameters<typeof meta>[0]);
+		expect((result as { title?: string }[]).some((m) => "title" in m)).toBe(true);
+		expect((result as { tagName?: string }[]).some((m) => m.tagName === "link")).toBe(false);
+	});
+});

--- a/app/presentation/routes/__tests__/projects._index.meta.test.ts
+++ b/app/presentation/routes/__tests__/projects._index.meta.test.ts
@@ -2,7 +2,7 @@ import type { MetaDescriptor } from "react-router";
 import { describe, expect, it } from "vitest";
 import { meta } from "../projects._index";
 
-type LdScript = { "script:ld+json": string };
+type LdScript = { "script:ld+json": Record<string, unknown> };
 const isLd = (m: MetaDescriptor): m is LdScript => "script:ld+json" in m;
 
 const data = {
@@ -58,14 +58,14 @@ describe("Projects(_index) meta export", () => {
 	it("JSON-LD 스크립트에 BreadcrumbList 타입을 포함한다", () => {
 		const result = callMeta();
 		const ldScripts = (result as MetaDescriptor[]).filter(isLd);
-		const types = ldScripts.map((s) => JSON.parse(s["script:ld+json"])["@type"]);
+		const types = ldScripts.map((s) => s["script:ld+json"]["@type"]);
 		expect(types).toContain("BreadcrumbList");
 	});
 
 	it("JSON-LD 스크립트에 Person 타입을 포함하지 않는다", () => {
 		const result = callMeta();
 		const ldScripts = (result as MetaDescriptor[]).filter(isLd);
-		const types = ldScripts.map((s) => JSON.parse(s["script:ld+json"])["@type"]);
+		const types = ldScripts.map((s) => s["script:ld+json"]["@type"]);
 		expect(types).not.toContain("Person");
 	});
 });

--- a/app/presentation/routes/__tests__/projects._index.meta.test.ts
+++ b/app/presentation/routes/__tests__/projects._index.meta.test.ts
@@ -1,0 +1,71 @@
+import type { MetaDescriptor } from "react-router";
+import { describe, expect, it } from "vitest";
+import { meta } from "../projects._index";
+
+type LdScript = { "script:ld+json": string };
+const isLd = (m: MetaDescriptor): m is LdScript => "script:ld+json" in m;
+
+const data = {
+	origin: "https://tkstar.dev",
+	canonicalUrl: "https://tkstar.dev/projects",
+	ogImageUrl: "https://tkstar.dev/og/fallback.png",
+	projects: [],
+	allTags: [],
+	activeTag: null,
+};
+
+const callMeta = () =>
+	meta({
+		data,
+		params: {},
+		location: { pathname: "/projects", search: "", hash: "", state: null, key: "" },
+		matches: [],
+	} as unknown as Parameters<typeof meta>[0]);
+
+describe("Projects(_index) meta export", () => {
+	it("title 이 Projects — tkstar.dev 를 포함한다", () => {
+		const result = callMeta();
+		expect(result).toEqual(
+			expect.arrayContaining([expect.objectContaining({ title: "Projects — tkstar.dev" })]),
+		);
+	});
+
+	it("canonical link 태그를 포함한다", () => {
+		const result = callMeta();
+		expect(result).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					tagName: "link",
+					rel: "canonical",
+					href: "https://tkstar.dev/projects",
+				}),
+			]),
+		);
+	});
+
+	it("og:image 에 절대 URL 을 포함한다", () => {
+		const result = callMeta();
+		expect(result).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					property: "og:image",
+					content: "https://tkstar.dev/og/fallback.png",
+				}),
+			]),
+		);
+	});
+
+	it("JSON-LD 스크립트에 BreadcrumbList 타입을 포함한다", () => {
+		const result = callMeta();
+		const ldScripts = (result as MetaDescriptor[]).filter(isLd);
+		const types = ldScripts.map((s) => JSON.parse(s["script:ld+json"])["@type"]);
+		expect(types).toContain("BreadcrumbList");
+	});
+
+	it("JSON-LD 스크립트에 Person 타입을 포함하지 않는다", () => {
+		const result = callMeta();
+		const ldScripts = (result as MetaDescriptor[]).filter(isLd);
+		const types = ldScripts.map((s) => JSON.parse(s["script:ld+json"])["@type"]);
+		expect(types).not.toContain("Person");
+	});
+});

--- a/app/presentation/routes/__tests__/robots.test.ts
+++ b/app/presentation/routes/__tests__/robots.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+
+import { loader } from "../robots[.txt]";
+
+describe("robots[.txt] loader", () => {
+	it("Content-Type 헤더가 text/plain으로 설정된다", async () => {
+		const request = new Request("https://tkstar.dev/robots.txt");
+
+		const res = await loader({ request } as never);
+
+		expect(res.headers.get("Content-Type")).toMatch(/^text\/plain/);
+	});
+
+	it("응답 body에 User-agent: *가 포함된다", async () => {
+		const request = new Request("https://tkstar.dev/robots.txt");
+
+		const res = await loader({ request } as never);
+		const body = await res.text();
+
+		expect(body).toContain("User-agent: *");
+	});
+
+	it("응답 body에 Allow: /가 포함된다", async () => {
+		const request = new Request("https://tkstar.dev/robots.txt");
+
+		const res = await loader({ request } as never);
+		const body = await res.text();
+
+		expect(body).toContain("Allow: /");
+	});
+
+	it("응답 body에 Sitemap 절대 URL 라인이 포함된다", async () => {
+		const request = new Request("https://tkstar.dev/robots.txt");
+
+		const res = await loader({ request } as never);
+		const body = await res.text();
+
+		expect(body).toContain("Sitemap: https://tkstar.dev/sitemap.xml");
+	});
+
+	it("커스텀 origin의 Sitemap URL이 body에 포함된다", async () => {
+		const request = new Request("https://preview.example.com/robots.txt");
+
+		const res = await loader({ request } as never);
+		const body = await res.text();
+
+		expect(body).toContain("Sitemap: https://preview.example.com/sitemap.xml");
+	});
+
+	it("응답 body가 개행 문자로 끝난다", async () => {
+		const request = new Request("https://tkstar.dev/robots.txt");
+
+		const res = await loader({ request } as never);
+		const body = await res.text();
+
+		expect(body.endsWith("\n")).toBe(true);
+	});
+});

--- a/app/presentation/routes/__tests__/sitemap.test.ts
+++ b/app/presentation/routes/__tests__/sitemap.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { loader } from "../sitemap[.xml]";
+
+const makeContext = (xml: string) => {
+	const buildSitemap = vi.fn().mockResolvedValue(xml);
+	return {
+		context: {
+			container: {
+				listProjects: vi.fn(),
+				getProjectDetail: vi.fn(),
+				getFeaturedProject: vi.fn(),
+				listPosts: vi.fn(),
+				getPostDetail: vi.fn(),
+				getRecentPosts: vi.fn(),
+				buildRssFeed: vi.fn(),
+				buildSitemap,
+			},
+			cloudflare: { env: {}, ctx: {} },
+		},
+		spies: { buildSitemap },
+	};
+};
+
+describe("sitemap[.xml] loader", () => {
+	it("Content-Type 헤더가 application/xml로 설정된다", async () => {
+		const { context } = makeContext(
+			'<?xml version="1.0"?><urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"></urlset>',
+		);
+		const request = new Request("https://tkstar.dev/sitemap.xml");
+
+		const res = await loader({ context, request } as never);
+
+		expect(res.headers.get("Content-Type")).toMatch(/^application\/xml/);
+	});
+
+	it("응답 body가 <?xml로 시작한다", async () => {
+		const { context } = makeContext(
+			'<?xml version="1.0"?><urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"></urlset>',
+		);
+		const request = new Request("https://tkstar.dev/sitemap.xml");
+
+		const res = await loader({ context, request } as never);
+		const body = await res.text();
+
+		expect(body.startsWith("<?xml")).toBe(true);
+	});
+
+	it("응답 body가 buildSitemap의 반환값과 동일하다", async () => {
+		const xml =
+			'<?xml version="1.0"?><urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"><url><loc>https://tkstar.dev/</loc></url></urlset>';
+		const { context } = makeContext(xml);
+		const request = new Request("https://tkstar.dev/sitemap.xml");
+
+		const res = await loader({ context, request } as never);
+		const body = await res.text();
+
+		expect(body).toBe(xml);
+	});
+
+	it("container.buildSitemap이 request URL의 origin으로 1회 호출된다", async () => {
+		const { context, spies } = makeContext(
+			'<?xml version="1.0"?><urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"></urlset>',
+		);
+		const request = new Request("https://tkstar.dev/sitemap.xml");
+
+		await loader({ context, request } as never);
+
+		expect(spies.buildSitemap).toHaveBeenCalledOnce();
+		expect(spies.buildSitemap).toHaveBeenCalledWith("https://tkstar.dev");
+	});
+
+	it("커스텀 origin이 buildSitemap에 전달된다", async () => {
+		const { context, spies } = makeContext(
+			'<?xml version="1.0"?><urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"></urlset>',
+		);
+		const request = new Request("https://preview.example.com/sitemap.xml");
+
+		await loader({ context, request } as never);
+
+		expect(spies.buildSitemap).toHaveBeenCalledWith("https://preview.example.com");
+	});
+});

--- a/app/presentation/routes/_index.tsx
+++ b/app/presentation/routes/_index.tsx
@@ -1,4 +1,4 @@
-import { buildPersonLd, renderJsonLd } from "~/presentation/lib/jsonld";
+import { buildPersonLd } from "~/presentation/lib/jsonld";
 import { buildMeta } from "~/presentation/lib/meta";
 import FeaturedProjectCard from "../components/home/FeaturedProjectCard";
 import HeroWhoami from "../components/home/HeroWhoami";
@@ -30,7 +30,7 @@ export const meta: Route.MetaFunction = ({ data }) => {
 			canonical: data.canonicalUrl,
 			ogImage: data.ogImageUrl,
 		}),
-		{ "script:ld+json": renderJsonLd(buildPersonLd({ origin: data.origin })) },
+		{ "script:ld+json": buildPersonLd({ origin: data.origin }) },
 	];
 };
 

--- a/app/presentation/routes/_index.tsx
+++ b/app/presentation/routes/_index.tsx
@@ -1,19 +1,37 @@
+import { buildPersonLd, renderJsonLd } from "~/presentation/lib/jsonld";
+import { buildMeta } from "~/presentation/lib/meta";
 import FeaturedProjectCard from "../components/home/FeaturedProjectCard";
 import HeroWhoami from "../components/home/HeroWhoami";
 import RecentPostsList from "../components/home/RecentPostsList";
 import type { Route } from "./+types/_index";
 
-export const meta: Route.MetaFunction = () => [
-	{ title: "tkstar.dev" },
-	{ name: "description", content: "1인 개발자 김태곤의 풀스택 작업물 · 글 · 이력." },
-];
-
-export const loader = async ({ context }: Route.LoaderArgs) => {
+export const loader = async ({ context, request }: Route.LoaderArgs) => {
+	const url = new URL(request.url);
+	const origin = url.origin;
 	const [featured, posts] = await Promise.all([
 		context.container.getFeaturedProject(),
 		context.container.getRecentPosts(3),
 	]);
-	return { featured, posts };
+	return {
+		featured,
+		posts,
+		origin,
+		canonicalUrl: `${origin}${url.pathname}`,
+		ogImageUrl: `${origin}/og/fallback.png`,
+	};
+};
+
+export const meta: Route.MetaFunction = ({ data }) => {
+	if (!data) return [{ title: "tkstar.dev" }];
+	return [
+		...buildMeta({
+			title: "tkstar.dev",
+			description: "1인 개발자 김태곤의 풀스택 작업물 · 글 · 이력.",
+			canonical: data.canonicalUrl,
+			ogImage: data.ogImageUrl,
+		}),
+		{ "script:ld+json": renderJsonLd(buildPersonLd({ origin: data.origin })) },
+	];
 };
 
 const SECTION_HEADER_CLASS =

--- a/app/presentation/routes/about.tsx
+++ b/app/presentation/routes/about.tsx
@@ -1,11 +1,44 @@
-import type { MetaFunction } from "react-router";
+import { buildBreadcrumbListLd, buildPersonLd, renderJsonLd } from "~/presentation/lib/jsonld";
+import { buildMeta } from "~/presentation/lib/meta";
 import AboutHeader from "../components/about/AboutHeader";
 import AwardsCard from "../components/about/AwardsCard";
 import CareerTimeline from "../components/about/CareerTimeline";
 import EducationCard from "../components/about/EducationCard";
 import StackCards from "../components/about/StackCards";
+import type { Route } from "./+types/about";
 
-export const meta: MetaFunction = () => [{ title: "About — tkstar.dev" }];
+export const loader = ({ request }: Route.LoaderArgs) => {
+	const url = new URL(request.url);
+	const origin = url.origin;
+	return {
+		origin,
+		canonicalUrl: `${origin}${url.pathname}`,
+		ogImageUrl: `${origin}/og/fallback.png`,
+	};
+};
+
+export const meta: Route.MetaFunction = ({ data }) => {
+	if (!data) return [{ title: "About — tkstar.dev" }];
+	return [
+		...buildMeta({
+			title: "About — tkstar.dev",
+			description: "1인 개발자 김태곤 — 풀스택 · 제품 설계부터 운영까지.",
+			canonical: data.canonicalUrl,
+			ogImage: data.ogImageUrl,
+		}),
+		{ "script:ld+json": renderJsonLd(buildPersonLd({ origin: data.origin })) },
+		{
+			"script:ld+json": renderJsonLd(
+				buildBreadcrumbListLd({
+					items: [
+						{ name: "Home", url: `${data.origin}/` },
+						{ name: "About", url: data.canonicalUrl },
+					],
+				}),
+			),
+		},
+	];
+};
 
 export default function About() {
 	return (

--- a/app/presentation/routes/about.tsx
+++ b/app/presentation/routes/about.tsx
@@ -1,4 +1,4 @@
-import { buildBreadcrumbListLd, buildPersonLd, renderJsonLd } from "~/presentation/lib/jsonld";
+import { buildBreadcrumbListLd, buildPersonLd } from "~/presentation/lib/jsonld";
 import { buildMeta } from "~/presentation/lib/meta";
 import AboutHeader from "../components/about/AboutHeader";
 import AwardsCard from "../components/about/AwardsCard";
@@ -26,16 +26,14 @@ export const meta: Route.MetaFunction = ({ data }) => {
 			canonical: data.canonicalUrl,
 			ogImage: data.ogImageUrl,
 		}),
-		{ "script:ld+json": renderJsonLd(buildPersonLd({ origin: data.origin })) },
+		{ "script:ld+json": buildPersonLd({ origin: data.origin }) },
 		{
-			"script:ld+json": renderJsonLd(
-				buildBreadcrumbListLd({
+			"script:ld+json": 				buildBreadcrumbListLd({
 					items: [
 						{ name: "Home", url: `${data.origin}/` },
 						{ name: "About", url: data.canonicalUrl },
 					],
 				}),
-			),
 		},
 	];
 };

--- a/app/presentation/routes/blog.$slug.tsx
+++ b/app/presentation/routes/blog.$slug.tsx
@@ -1,4 +1,4 @@
-import { buildBlogPostingLd, buildBreadcrumbListLd, renderJsonLd } from "~/presentation/lib/jsonld";
+import { buildBlogPostingLd, buildBreadcrumbListLd } from "~/presentation/lib/jsonld";
 import { buildMeta } from "~/presentation/lib/meta";
 import MdxRenderer from "../components/content/MdxRenderer";
 import PostFooterNav from "../components/post/PostFooterNav";
@@ -31,18 +31,16 @@ export const meta: Route.MetaFunction = ({ data }) => {
 			ogType: "article",
 		}),
 		{
-			"script:ld+json": renderJsonLd(buildBlogPostingLd({ post, origin, ogImage: ogImageUrl })),
+			"script:ld+json": buildBlogPostingLd({ post, origin, ogImage: ogImageUrl }),
 		},
 		{
-			"script:ld+json": renderJsonLd(
-				buildBreadcrumbListLd({
+			"script:ld+json": 				buildBreadcrumbListLd({
 					items: [
 						{ name: "Home", url: `${origin}/` },
 						{ name: "Blog", url: `${origin}/blog` },
 						{ name: post.title, url: canonicalUrl },
 					],
 				}),
-			),
 		},
 	];
 };

--- a/app/presentation/routes/blog.$slug.tsx
+++ b/app/presentation/routes/blog.$slug.tsx
@@ -1,17 +1,50 @@
+import { buildBlogPostingLd, buildBreadcrumbListLd, renderJsonLd } from "~/presentation/lib/jsonld";
+import { buildMeta } from "~/presentation/lib/meta";
 import MdxRenderer from "../components/content/MdxRenderer";
 import PostFooterNav from "../components/post/PostFooterNav";
 import ShareTools from "../components/post/ShareTools";
 import OnThisPageToc from "../components/project/OnThisPageToc";
-
 import type { Route } from "./+types/blog.$slug";
-
-export const meta: Route.MetaFunction = () => [{ title: "Post — tkstar.dev" }];
 
 export const loader = async ({ context, params, request }: Route.LoaderArgs) => {
 	if (!params.slug) throw new Response("Not Found", { status: 404 });
 	const detail = await context.container.getPostDetail(params.slug);
 	const url = new URL(request.url);
-	return { ...detail, canonicalUrl: `${url.origin}${url.pathname}` };
+	const origin = url.origin;
+	return {
+		...detail,
+		origin,
+		canonicalUrl: `${origin}${url.pathname}`,
+		ogImageUrl: `${origin}/og/blog/${params.slug}.png`,
+	};
+};
+
+export const meta: Route.MetaFunction = ({ data }) => {
+	if (!data) return [{ title: "Post — tkstar.dev" }];
+	const { post, origin, canonicalUrl, ogImageUrl } = data;
+	return [
+		...buildMeta({
+			title: `${post.title} — tkstar.dev`,
+			description: post.lede,
+			canonical: canonicalUrl,
+			ogImage: ogImageUrl,
+			ogType: "article",
+		}),
+		{
+			"script:ld+json": renderJsonLd(buildBlogPostingLd({ post, origin, ogImage: ogImageUrl })),
+		},
+		{
+			"script:ld+json": renderJsonLd(
+				buildBreadcrumbListLd({
+					items: [
+						{ name: "Home", url: `${origin}/` },
+						{ name: "Blog", url: `${origin}/blog` },
+						{ name: post.title, url: canonicalUrl },
+					],
+				}),
+			),
+		},
+	];
 };
 
 export default function BlogDetail({ loaderData }: Route.ComponentProps) {

--- a/app/presentation/routes/blog._index.tsx
+++ b/app/presentation/routes/blog._index.tsx
@@ -1,19 +1,48 @@
+import { buildBreadcrumbListLd, renderJsonLd } from "~/presentation/lib/jsonld";
+import { buildMeta } from "~/presentation/lib/meta";
 import PostRow from "../components/post/PostRow";
 import TagFilterChips from "../components/project/TagFilterChips";
-
 import type { Route } from "./+types/blog._index";
-
-export const meta: Route.MetaFunction = () => [{ title: "Blog — tkstar.dev" }];
 
 export const loader = async ({ context, request }: Route.LoaderArgs) => {
 	const url = new URL(request.url);
+	const origin = url.origin;
 	const tag = url.searchParams.get("tag") ?? undefined;
 	const [posts, all] = await Promise.all([
 		context.container.listPosts({ tag }),
 		context.container.listPosts(),
 	]);
 	const allTags = Array.from(new Set(all.flatMap((p) => p.tags))).sort();
-	return { posts, allTags, activeTag: tag ?? null };
+	return {
+		posts,
+		allTags,
+		activeTag: tag ?? null,
+		origin,
+		canonicalUrl: `${origin}${url.pathname}`,
+		ogImageUrl: `${origin}/og/fallback.png`,
+	};
+};
+
+export const meta: Route.MetaFunction = ({ data }) => {
+	if (!data) return [{ title: "Blog — tkstar.dev" }];
+	return [
+		...buildMeta({
+			title: "Blog — tkstar.dev",
+			description: "1인 개발자 김태곤의 기술 블로그 · 월 1편 운영.",
+			canonical: data.canonicalUrl,
+			ogImage: data.ogImageUrl,
+		}),
+		{
+			"script:ld+json": renderJsonLd(
+				buildBreadcrumbListLd({
+					items: [
+						{ name: "Home", url: `${data.origin}/` },
+						{ name: "Blog", url: data.canonicalUrl },
+					],
+				}),
+			),
+		},
+	];
 };
 
 export default function BlogIndex({ loaderData }: Route.ComponentProps) {

--- a/app/presentation/routes/blog._index.tsx
+++ b/app/presentation/routes/blog._index.tsx
@@ -1,4 +1,4 @@
-import { buildBreadcrumbListLd, renderJsonLd } from "~/presentation/lib/jsonld";
+import { buildBreadcrumbListLd } from "~/presentation/lib/jsonld";
 import { buildMeta } from "~/presentation/lib/meta";
 import PostRow from "../components/post/PostRow";
 import TagFilterChips from "../components/project/TagFilterChips";
@@ -33,14 +33,12 @@ export const meta: Route.MetaFunction = ({ data }) => {
 			ogImage: data.ogImageUrl,
 		}),
 		{
-			"script:ld+json": renderJsonLd(
-				buildBreadcrumbListLd({
+			"script:ld+json": 				buildBreadcrumbListLd({
 					items: [
 						{ name: "Home", url: `${data.origin}/` },
 						{ name: "Blog", url: data.canonicalUrl },
 					],
 				}),
-			),
 		},
 	];
 };

--- a/app/presentation/routes/contact.tsx
+++ b/app/presentation/routes/contact.tsx
@@ -7,7 +7,7 @@ import {
 } from "~/application/contact/errors";
 import ContactForm from "~/presentation/components/contact/ContactForm";
 import { contactSubmissionSchema } from "~/domain/contact/contact-submission.schema";
-import { buildBreadcrumbListLd, renderJsonLd } from "~/presentation/lib/jsonld";
+import { buildBreadcrumbListLd } from "~/presentation/lib/jsonld";
 import { buildMeta } from "~/presentation/lib/meta";
 
 interface LoaderData {
@@ -28,14 +28,12 @@ export const meta: MetaFunction<typeof loader> = ({ data }) => {
 			ogImage: data.ogImageUrl,
 		}),
 		{
-			"script:ld+json": renderJsonLd(
-				buildBreadcrumbListLd({
+			"script:ld+json": 				buildBreadcrumbListLd({
 					items: [
 						{ name: "Home", url: `${data.origin}/` },
 						{ name: "Contact", url: data.canonicalUrl },
 					],
 				}),
-			),
 		},
 	];
 };

--- a/app/presentation/routes/contact.tsx
+++ b/app/presentation/routes/contact.tsx
@@ -7,14 +7,38 @@ import {
 } from "~/application/contact/errors";
 import ContactForm from "~/presentation/components/contact/ContactForm";
 import { contactSubmissionSchema } from "~/domain/contact/contact-submission.schema";
+import { buildBreadcrumbListLd, renderJsonLd } from "~/presentation/lib/jsonld";
+import { buildMeta } from "~/presentation/lib/meta";
 
-export const meta: MetaFunction = () => [
-	{ title: "Contact — tkstar.dev" },
-	{
-		name: "description",
-		content: "tkstar.dev 컨택 — 채용 / 의뢰 / 그 외 문의 모두 환영합니다.",
-	},
-];
+interface LoaderData {
+	siteKey: string;
+	contactEmail: string;
+	origin: string;
+	canonicalUrl: string;
+	ogImageUrl: string;
+}
+
+export const meta: MetaFunction<typeof loader> = ({ data }) => {
+	if (!data) return [{ title: "Contact — tkstar.dev" }];
+	return [
+		...buildMeta({
+			title: "Contact — tkstar.dev",
+			description: "tkstar.dev 컨택 — 채용 / 의뢰 / 그 외 문의 모두 환영합니다.",
+			canonical: data.canonicalUrl,
+			ogImage: data.ogImageUrl,
+		}),
+		{
+			"script:ld+json": renderJsonLd(
+				buildBreadcrumbListLd({
+					items: [
+						{ name: "Home", url: `${data.origin}/` },
+						{ name: "Contact", url: data.canonicalUrl },
+					],
+				}),
+			),
+		},
+	];
+};
 
 export type ContactActionData =
 	| { ok: true }
@@ -25,16 +49,16 @@ export type ContactActionData =
 			mailtoBody?: string;
 	  };
 
-interface LoaderData {
-	siteKey: string;
-	contactEmail: string;
-}
-
-export const loader = ({ context }: LoaderFunctionArgs): LoaderData => {
+export const loader = ({ context, request }: LoaderFunctionArgs): LoaderData => {
 	const env = context.cloudflare.env as Env;
+	const url = new URL(request.url);
+	const origin = url.origin;
 	return {
 		siteKey: env.TURNSTILE_SITE_KEY,
 		contactEmail: env.CONTACT_TO_EMAIL,
+		origin,
+		canonicalUrl: `${origin}${url.pathname}`,
+		ogImageUrl: `${origin}/og/fallback.png`,
 	};
 };
 

--- a/app/presentation/routes/legal.$app.privacy.tsx
+++ b/app/presentation/routes/legal.$app.privacy.tsx
@@ -1,4 +1,4 @@
-import { buildBreadcrumbListLd, renderJsonLd } from "~/presentation/lib/jsonld";
+import { buildBreadcrumbListLd } from "~/presentation/lib/jsonld";
 import { buildMeta } from "~/presentation/lib/meta";
 import MdxRenderer from "../components/content/MdxRenderer";
 import LegalDocLayout from "../components/legal/LegalDocLayout";
@@ -31,15 +31,13 @@ export const meta: Route.MetaFunction = ({ data }) => {
 			robots: "noindex, follow",
 		}),
 		{
-			"script:ld+json": renderJsonLd(
-				buildBreadcrumbListLd({
+			"script:ld+json": 				buildBreadcrumbListLd({
 					items: [
 						{ name: "Home", url: `${origin}/` },
 						{ name: "Legal", url: `${origin}/legal` },
 						{ name: docTitle, url: canonicalUrl },
 					],
 				}),
-			),
 		},
 	];
 };

--- a/app/presentation/routes/legal.$app.privacy.tsx
+++ b/app/presentation/routes/legal.$app.privacy.tsx
@@ -1,15 +1,47 @@
+import { buildBreadcrumbListLd, renderJsonLd } from "~/presentation/lib/jsonld";
+import { buildMeta } from "~/presentation/lib/meta";
 import MdxRenderer from "../components/content/MdxRenderer";
 import LegalDocLayout from "../components/legal/LegalDocLayout";
-
 import type { Route } from "./+types/legal.$app.privacy";
 
-export const meta: Route.MetaFunction = () => [{ title: "Privacy — tkstar.dev" }];
-
-export const loader = async ({ context, params }: Route.LoaderArgs) => {
+export const loader = async ({ context, params, request }: Route.LoaderArgs) => {
 	if (!params.app) throw new Response(null, { status: 404 });
 	const doc = await context.container.findAppDoc(params.app, "privacy");
 	if (!doc) throw new Response(null, { status: 404 });
-	return { doc };
+	const url = new URL(request.url);
+	const origin = url.origin;
+	return {
+		doc,
+		origin,
+		canonicalUrl: `${origin}${url.pathname}`,
+		ogImageUrl: `${origin}/og/fallback.png`,
+	};
+};
+
+export const meta: Route.MetaFunction = ({ data }) => {
+	if (!data) return [{ title: "Privacy — tkstar.dev" }];
+	const { doc, origin, canonicalUrl, ogImageUrl } = data;
+	const docTitle = `${doc.app_slug} 개인정보 처리방침`;
+	return [
+		...buildMeta({
+			title: `${docTitle} — tkstar.dev`,
+			description: `${doc.app_slug} 앱의 개인정보 처리방침 (v${doc.version}, 시행일 ${doc.effective_date}).`,
+			canonical: canonicalUrl,
+			ogImage: ogImageUrl,
+			robots: "noindex, follow",
+		}),
+		{
+			"script:ld+json": renderJsonLd(
+				buildBreadcrumbListLd({
+					items: [
+						{ name: "Home", url: `${origin}/` },
+						{ name: "Legal", url: `${origin}/legal` },
+						{ name: docTitle, url: canonicalUrl },
+					],
+				}),
+			),
+		},
+	];
 };
 
 export default function AppPrivacy({ loaderData }: Route.ComponentProps) {

--- a/app/presentation/routes/legal.$app.terms.tsx
+++ b/app/presentation/routes/legal.$app.terms.tsx
@@ -1,4 +1,4 @@
-import { buildBreadcrumbListLd, renderJsonLd } from "~/presentation/lib/jsonld";
+import { buildBreadcrumbListLd } from "~/presentation/lib/jsonld";
 import { buildMeta } from "~/presentation/lib/meta";
 import MdxRenderer from "../components/content/MdxRenderer";
 import LegalDocLayout from "../components/legal/LegalDocLayout";
@@ -31,15 +31,13 @@ export const meta: Route.MetaFunction = ({ data }) => {
 			robots: "noindex, follow",
 		}),
 		{
-			"script:ld+json": renderJsonLd(
-				buildBreadcrumbListLd({
+			"script:ld+json": 				buildBreadcrumbListLd({
 					items: [
 						{ name: "Home", url: `${origin}/` },
 						{ name: "Legal", url: `${origin}/legal` },
 						{ name: docTitle, url: canonicalUrl },
 					],
 				}),
-			),
 		},
 	];
 };

--- a/app/presentation/routes/legal.$app.terms.tsx
+++ b/app/presentation/routes/legal.$app.terms.tsx
@@ -1,15 +1,47 @@
+import { buildBreadcrumbListLd, renderJsonLd } from "~/presentation/lib/jsonld";
+import { buildMeta } from "~/presentation/lib/meta";
 import MdxRenderer from "../components/content/MdxRenderer";
 import LegalDocLayout from "../components/legal/LegalDocLayout";
-
 import type { Route } from "./+types/legal.$app.terms";
 
-export const meta: Route.MetaFunction = () => [{ title: "Terms — tkstar.dev" }];
-
-export const loader = async ({ context, params }: Route.LoaderArgs) => {
+export const loader = async ({ context, params, request }: Route.LoaderArgs) => {
 	if (!params.app) throw new Response(null, { status: 404 });
 	const doc = await context.container.findAppDoc(params.app, "terms");
 	if (!doc) throw new Response(null, { status: 404 });
-	return { doc };
+	const url = new URL(request.url);
+	const origin = url.origin;
+	return {
+		doc,
+		origin,
+		canonicalUrl: `${origin}${url.pathname}`,
+		ogImageUrl: `${origin}/og/fallback.png`,
+	};
+};
+
+export const meta: Route.MetaFunction = ({ data }) => {
+	if (!data) return [{ title: "Terms — tkstar.dev" }];
+	const { doc, origin, canonicalUrl, ogImageUrl } = data;
+	const docTitle = `${doc.app_slug} 서비스 이용약관`;
+	return [
+		...buildMeta({
+			title: `${docTitle} — tkstar.dev`,
+			description: `${doc.app_slug} 앱의 서비스 이용약관 (v${doc.version}, 시행일 ${doc.effective_date}).`,
+			canonical: canonicalUrl,
+			ogImage: ogImageUrl,
+			robots: "noindex, follow",
+		}),
+		{
+			"script:ld+json": renderJsonLd(
+				buildBreadcrumbListLd({
+					items: [
+						{ name: "Home", url: `${origin}/` },
+						{ name: "Legal", url: `${origin}/legal` },
+						{ name: docTitle, url: canonicalUrl },
+					],
+				}),
+			),
+		},
+	];
 };
 
 export default function AppTerms({ loaderData }: Route.ComponentProps) {

--- a/app/presentation/routes/legal._index.tsx
+++ b/app/presentation/routes/legal._index.tsx
@@ -1,4 +1,4 @@
-import { buildBreadcrumbListLd, renderJsonLd } from "~/presentation/lib/jsonld";
+import { buildBreadcrumbListLd } from "~/presentation/lib/jsonld";
 import { buildMeta } from "~/presentation/lib/meta";
 import AppCard from "../components/legal/AppCard";
 import type { Route } from "./+types/legal._index";
@@ -25,14 +25,12 @@ export const meta: Route.MetaFunction = ({ data }) => {
 			ogImage: data.ogImageUrl,
 		}),
 		{
-			"script:ld+json": renderJsonLd(
-				buildBreadcrumbListLd({
+			"script:ld+json": 				buildBreadcrumbListLd({
 					items: [
 						{ name: "Home", url: `${data.origin}/` },
 						{ name: "Legal", url: data.canonicalUrl },
 					],
 				}),
-			),
 		},
 	];
 };

--- a/app/presentation/routes/legal._index.tsx
+++ b/app/presentation/routes/legal._index.tsx
@@ -1,12 +1,40 @@
+import { buildBreadcrumbListLd, renderJsonLd } from "~/presentation/lib/jsonld";
+import { buildMeta } from "~/presentation/lib/meta";
 import AppCard from "../components/legal/AppCard";
-
 import type { Route } from "./+types/legal._index";
 
-export const meta: Route.MetaFunction = () => [{ title: "Legal — tkstar.dev" }];
-
-export const loader = async ({ context }: Route.LoaderArgs) => {
+export const loader = async ({ context, request }: Route.LoaderArgs) => {
+	const url = new URL(request.url);
+	const origin = url.origin;
 	const apps = await context.container.listApps();
-	return { apps };
+	return {
+		apps,
+		origin,
+		canonicalUrl: `${origin}${url.pathname}`,
+		ogImageUrl: `${origin}/og/fallback.png`,
+	};
+};
+
+export const meta: Route.MetaFunction = ({ data }) => {
+	if (!data) return [{ title: "Legal — tkstar.dev" }];
+	return [
+		...buildMeta({
+			title: "Legal — tkstar.dev",
+			description: "tkstar.dev 가 운영하는 앱들의 약관과 개인정보 처리방침.",
+			canonical: data.canonicalUrl,
+			ogImage: data.ogImageUrl,
+		}),
+		{
+			"script:ld+json": renderJsonLd(
+				buildBreadcrumbListLd({
+					items: [
+						{ name: "Home", url: `${data.origin}/` },
+						{ name: "Legal", url: data.canonicalUrl },
+					],
+				}),
+			),
+		},
+	];
 };
 
 export default function LegalIndex({ loaderData }: Route.ComponentProps) {

--- a/app/presentation/routes/projects.$slug.tsx
+++ b/app/presentation/routes/projects.$slug.tsx
@@ -1,15 +1,54 @@
+import {
+	buildBreadcrumbListLd,
+	buildCreativeWorkLd,
+	renderJsonLd,
+} from "~/presentation/lib/jsonld";
+import { buildMeta } from "~/presentation/lib/meta";
 import MdxRenderer from "../components/content/MdxRenderer";
 import OnThisPageToc from "../components/project/OnThisPageToc";
 import ProjectFooterNav from "../components/project/ProjectFooterNav";
 import ProjectMetaSidebar from "../components/project/ProjectMetaSidebar";
-
 import type { Route } from "./+types/projects.$slug";
 
-export const meta: Route.MetaFunction = () => [{ title: "Project — tkstar.dev" }];
-
-export const loader = async ({ context, params }: Route.LoaderArgs) => {
+export const loader = async ({ context, params, request }: Route.LoaderArgs) => {
 	if (!params.slug) throw new Response("Not Found", { status: 404 });
-	return context.container.getProjectDetail(params.slug);
+	const detail = await context.container.getProjectDetail(params.slug);
+	const url = new URL(request.url);
+	const origin = url.origin;
+	return {
+		...detail,
+		origin,
+		canonicalUrl: `${origin}${url.pathname}`,
+		ogImageUrl: `${origin}/og/projects/${params.slug}.png`,
+	};
+};
+
+export const meta: Route.MetaFunction = ({ data }) => {
+	if (!data) return [{ title: "Project — tkstar.dev" }];
+	const { project, origin, canonicalUrl, ogImageUrl } = data;
+	return [
+		...buildMeta({
+			title: `${project.title} — tkstar.dev`,
+			description: project.summary,
+			canonical: canonicalUrl,
+			ogImage: ogImageUrl,
+			ogType: "article",
+		}),
+		{
+			"script:ld+json": renderJsonLd(buildCreativeWorkLd({ project, origin, ogImage: ogImageUrl })),
+		},
+		{
+			"script:ld+json": renderJsonLd(
+				buildBreadcrumbListLd({
+					items: [
+						{ name: "Home", url: `${origin}/` },
+						{ name: "Projects", url: `${origin}/projects` },
+						{ name: project.title, url: canonicalUrl },
+					],
+				}),
+			),
+		},
+	];
 };
 
 export default function ProjectDetail({ loaderData }: Route.ComponentProps) {

--- a/app/presentation/routes/projects.$slug.tsx
+++ b/app/presentation/routes/projects.$slug.tsx
@@ -1,8 +1,4 @@
-import {
-	buildBreadcrumbListLd,
-	buildCreativeWorkLd,
-	renderJsonLd,
-} from "~/presentation/lib/jsonld";
+import { buildBreadcrumbListLd, buildCreativeWorkLd } from "~/presentation/lib/jsonld";
 import { buildMeta } from "~/presentation/lib/meta";
 import MdxRenderer from "../components/content/MdxRenderer";
 import OnThisPageToc from "../components/project/OnThisPageToc";
@@ -35,18 +31,16 @@ export const meta: Route.MetaFunction = ({ data }) => {
 			ogType: "article",
 		}),
 		{
-			"script:ld+json": renderJsonLd(buildCreativeWorkLd({ project, origin, ogImage: ogImageUrl })),
+			"script:ld+json": buildCreativeWorkLd({ project, origin, ogImage: ogImageUrl }),
 		},
 		{
-			"script:ld+json": renderJsonLd(
-				buildBreadcrumbListLd({
-					items: [
-						{ name: "Home", url: `${origin}/` },
-						{ name: "Projects", url: `${origin}/projects` },
-						{ name: project.title, url: canonicalUrl },
-					],
-				}),
-			),
+			"script:ld+json": buildBreadcrumbListLd({
+				items: [
+					{ name: "Home", url: `${origin}/` },
+					{ name: "Projects", url: `${origin}/projects` },
+					{ name: project.title, url: canonicalUrl },
+				],
+			}),
 		},
 	];
 };

--- a/app/presentation/routes/projects._index.tsx
+++ b/app/presentation/routes/projects._index.tsx
@@ -1,19 +1,48 @@
+import { buildBreadcrumbListLd, renderJsonLd } from "~/presentation/lib/jsonld";
+import { buildMeta } from "~/presentation/lib/meta";
 import ProjectRow from "../components/project/ProjectRow";
 import TagFilterChips from "../components/project/TagFilterChips";
-
 import type { Route } from "./+types/projects._index";
-
-export const meta: Route.MetaFunction = () => [{ title: "Projects — tkstar.dev" }];
 
 export const loader = async ({ context, request }: Route.LoaderArgs) => {
 	const url = new URL(request.url);
+	const origin = url.origin;
 	const tag = url.searchParams.get("tag") ?? undefined;
 	const [projects, all] = await Promise.all([
 		context.container.listProjects({ tag }),
 		context.container.listProjects(),
 	]);
 	const allTags = Array.from(new Set(all.flatMap((p) => p.tags))).sort();
-	return { projects, allTags, activeTag: tag ?? null };
+	return {
+		projects,
+		allTags,
+		activeTag: tag ?? null,
+		origin,
+		canonicalUrl: `${origin}${url.pathname}`,
+		ogImageUrl: `${origin}/og/fallback.png`,
+	};
+};
+
+export const meta: Route.MetaFunction = ({ data }) => {
+	if (!data) return [{ title: "Projects — tkstar.dev" }];
+	return [
+		...buildMeta({
+			title: "Projects — tkstar.dev",
+			description: "1인 개발자 김태곤의 프로젝트 모음 · case study.",
+			canonical: data.canonicalUrl,
+			ogImage: data.ogImageUrl,
+		}),
+		{
+			"script:ld+json": renderJsonLd(
+				buildBreadcrumbListLd({
+					items: [
+						{ name: "Home", url: `${data.origin}/` },
+						{ name: "Projects", url: data.canonicalUrl },
+					],
+				}),
+			),
+		},
+	];
 };
 
 export default function ProjectsIndex({ loaderData }: Route.ComponentProps) {

--- a/app/presentation/routes/projects._index.tsx
+++ b/app/presentation/routes/projects._index.tsx
@@ -1,4 +1,4 @@
-import { buildBreadcrumbListLd, renderJsonLd } from "~/presentation/lib/jsonld";
+import { buildBreadcrumbListLd } from "~/presentation/lib/jsonld";
 import { buildMeta } from "~/presentation/lib/meta";
 import ProjectRow from "../components/project/ProjectRow";
 import TagFilterChips from "../components/project/TagFilterChips";
@@ -33,14 +33,12 @@ export const meta: Route.MetaFunction = ({ data }) => {
 			ogImage: data.ogImageUrl,
 		}),
 		{
-			"script:ld+json": renderJsonLd(
-				buildBreadcrumbListLd({
+			"script:ld+json": 				buildBreadcrumbListLd({
 					items: [
 						{ name: "Home", url: `${data.origin}/` },
 						{ name: "Projects", url: data.canonicalUrl },
 					],
 				}),
-			),
 		},
 	];
 };

--- a/app/presentation/routes/robots[.txt].tsx
+++ b/app/presentation/routes/robots[.txt].tsx
@@ -1,7 +1,8 @@
 import type { Route } from "./+types/robots[.txt]";
 
-export const loader = (_args: Route.LoaderArgs) => {
-	const body = "User-agent: *\nAllow: /\n";
+export const loader = ({ request }: Route.LoaderArgs) => {
+	const origin = new URL(request.url).origin;
+	const body = `User-agent: *\nAllow: /\nSitemap: ${origin}/sitemap.xml\n`;
 	return new Response(body, {
 		headers: { "Content-Type": "text/plain; charset=utf-8" },
 	});

--- a/app/presentation/routes/robots[.txt].tsx
+++ b/app/presentation/routes/robots[.txt].tsx
@@ -1,4 +1,6 @@
-export const loader = () => {
+import type { Route } from "./+types/robots[.txt]";
+
+export const loader = (_args: Route.LoaderArgs) => {
 	const body = "User-agent: *\nAllow: /\n";
 	return new Response(body, {
 		headers: { "Content-Type": "text/plain; charset=utf-8" },

--- a/app/presentation/routes/sitemap[.xml].tsx
+++ b/app/presentation/routes/sitemap[.xml].tsx
@@ -1,4 +1,6 @@
-export const loader = () => {
+import type { Route } from "./+types/sitemap[.xml]";
+
+export const loader = (_args: Route.LoaderArgs) => {
 	const body = `<?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"></urlset>`;
 	return new Response(body, {

--- a/app/presentation/routes/sitemap[.xml].tsx
+++ b/app/presentation/routes/sitemap[.xml].tsx
@@ -1,9 +1,9 @@
 import type { Route } from "./+types/sitemap[.xml]";
 
-export const loader = (_args: Route.LoaderArgs) => {
-	const body = `<?xml version="1.0" encoding="UTF-8"?>
-<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"></urlset>`;
-	return new Response(body, {
+export const loader = async ({ context, request }: Route.LoaderArgs) => {
+	const origin = new URL(request.url).origin;
+	const xml = await context.container.buildSitemap(origin);
+	return new Response(xml, {
 		headers: { "Content-Type": "application/xml; charset=utf-8" },
 	});
 };

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -16,6 +16,10 @@ import "./app.css";
 
 const CHROME_FREE_PATHNAME = /^\/legal\/[^/]+\/(terms|privacy)$/;
 
+export const links: Route.LinksFunction = () => [
+	{ rel: "alternate", type: "application/rss+xml", href: "/rss.xml", title: "tkstar.dev — Posts" },
+];
+
 export const loader = async ({ context }: Route.LoaderArgs) => ({
 	appCount: (await context.container.listApps()).length,
 });

--- a/docs/PROJECT-STRUCTURE.md
+++ b/docs/PROJECT-STRUCTURE.md
@@ -334,7 +334,9 @@ app/presentation/
 ├── lib/
 │   ├── format.ts                     # date YYYY-MM 등
 │   ├── print.ts                      # F003 — window.print()
-│   └── chrome-links.ts               # TOPBAR_LINKS / FOOTER_LINKS 상수 (T005)
+│   ├── chrome-links.ts               # TOPBAR_LINKS / FOOTER_LINKS 상수 (T005)
+│   ├── meta.ts                       # F018 — buildMeta(MetaDescriptor[]) (T019)
+│   └── jsonld.ts                     # F018 — Person/BlogPosting/CreativeWork/BreadcrumbList builders (T019)
 ├── providers/
 │   └── ThemeProvider.tsx             # localStorage `proto-theme` + system 추종 (T005)
 └── layouts/

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -469,7 +469,7 @@ tkstarDev는 다음 핵심 가치를 단일 도메인에서 달성한다:
   - 가정 해소: A005 (env.ASSETS Fetcher 채택)
   - PR 1개 / 브랜치: `feature/issue-N-satori-og`
 
-- [ ] **Task 019: F018 SEO Meta + Sitemap + Robots + JSON-LD (차등 인덱싱)**
+- [x] **Task 019: F018 SEO Meta + Sitemap + Robots + JSON-LD (차등 인덱싱)**
   - **Must** Read: [tasks/T019-seo-sitemap-jsonld.md](tasks/T019-seo-sitemap-jsonld.md)
   - blockedBy: Task 008, Task 010~Task 013, Task 014a, Task 014b, Task 015 (페이지별 meta 추가), Task 018 (OG URL)
   - Layer: Application(`build-sitemap.service`) + Resource Route + Presentation(meta export)

--- a/docs/tasks/T019-seo-sitemap-jsonld.md
+++ b/docs/tasks/T019-seo-sitemap-jsonld.md
@@ -11,7 +11,7 @@
 | **PRD Features** | **F018** (SEO 메타 + Sitemap) |
 | **PRD AC** | — (정합성 검증, schema.org 표준) |
 | **예상 작업 시간** | 1.5d |
-| **Status** | Not Started |
+| **Status** | Done |
 
 ## Goal
 페이지별 `meta` export (title/description/canonical/og/twitter) + JSON-LD + `/sitemap.xml` + `/robots.txt`을 가동하고, **차등 인덱싱** 정책(App Terms/Privacy `noindex,follow`, 404 `noindex,nofollow`)을 적용한다.


### PR DESCRIPTION
## Summary

F018 (SEO 메타데이터 + Sitemap + JSON-LD) 의 11개 페이지 cross-cutting concern 을 단일 PR 로 가동. 검색엔진 가시성·SNS 공유 미리보기 일관성을 확보하고 차등 인덱싱(App Terms/Privacy `noindex,follow`, 404 `noindex,nofollow`)을 적용. T020(검색엔진 등록) 의 선행조건 충족.

Closes #70

## Scope

### 신규 파일
- `app/application/seo/services/build-sitemap.service.ts` — sitemaps.org urlset XML 빌더 (6 static + N project + M post entry, app legal/resource route 제외, slug XML escape, ISO timestamp → date-only)
- `app/presentation/lib/meta.ts` — `buildMeta` (RR7 `MetaDescriptor[]` 빌더 — title/description/canonical link/og:* 1200×630/Twitter Card summary_large_image, optional `robots`/`ogType`)
- `app/presentation/lib/jsonld.ts` — schema.org builders (Person/BlogPosting/CreativeWork/BreadcrumbList) — 김태곤 author 공통, sameAs=[GitHub], inLanguage=ko

### 수정
- `app/presentation/routes/sitemap[.xml].tsx` — DI `buildSitemap(origin)` 위임
- `app/presentation/routes/robots[.txt].tsx` — `Sitemap: ${origin}/sitemap.xml` line 추가
- `app/infrastructure/config/container.ts` — `buildSitemap(origin: string)` 등록
- `app/root.tsx` — `<link rel="alternate" type="application/rss+xml">` 추가 (RSS reader/검색엔진 발견 채널)
- 11개 페이지 routes (`_index`, `about`, `projects._index`, `projects.\$slug`, `blog._index`, `blog.\$slug`, `contact`, `legal._index`, `legal.\$app.{terms,privacy}`, `\$`) — loader 가 origin/canonicalUrl/ogImageUrl 내려주고 meta 가 buildMeta + 페이지별 JSON-LD 방출

### Page → JSON-LD 매핑
| Page | JSON-LD | robots |
|------|---------|--------|
| / (Home) | Person | (index) |
| /about | Person + BreadcrumbList | (index) |
| /projects, /blog, /contact, /legal | BreadcrumbList | (index) |
| /projects/:slug | CreativeWork + BreadcrumbList(3) | (index, og:type=article) |
| /blog/:slug | BlogPosting + BreadcrumbList(3) | (index, og:type=article) |
| /legal/:app/{terms,privacy} | BreadcrumbList | noindex, follow |
| splat 404 | 없음 | noindex, nofollow |

## Code Review 반영

code-reviewer Critical: RR7 의 `script:ld+json` descriptor 가 `LdJsonObject` (record) 를 요구하는데 기존 구현이 이미 `JSON.stringify` 한 string 을 넘겨 RR7 가 한 번 더 직렬화 → JSON-LD 가 따옴표로 감싸진 JSON literal 로 렌더되어 schema.org 파서가 객체 인식 불가하던 버그 수정. builder 결과를 그대로 전달하도록 변경, dead code (`renderJsonLd` wrapper, `getCanonicalUrl` 0-importer) 동시 제거.

## Test plan

- [x] Unit tests — 84 files / 470 passing
- [x] Coverage — Statements 88.71%, Branches 75.73%, Functions 88.48%, Lines 90.44% (threshold 충족)
- [x] `bun run typecheck` clean
- [x] `bun run lint` clean
- [x] 수동 검증 (wrangler/vite dev) — `/robots.txt` (Sitemap line 포함), `/sitemap.xml` (8 entries: 6 static + 1 project + 1 post), Home/About/Legal index 페이지 head 의 `<title>` / canonical / og:* / Twitter Card / `<link rel="alternate" type="application/rss+xml">` / JSON-LD `<script type="application/ld+json">{...}</script>` (이중 인코딩 없는 raw object) 확인, splat 404 `<meta name="robots" content="noindex, nofollow">` 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)