### PR TITLE
✨ feat: T020 — F019 검색엔진 인증 meta + F013 Cloudflare Web Analytics (env-gated)

### DIFF
--- a/app/__tests__/root.test.tsx
+++ b/app/__tests__/root.test.tsx
@@ -187,4 +187,27 @@ describe("Layout — verification meta / analytics script 조건부 렌더", () 
 			document.querySelector('script[src="https://static.cloudflareinsights.com/beacon.min.js"]'),
 		).toBeNull();
 	});
+
+	it("일부만 truthy (google 만 설정) → google meta 만 렌더, 나머지 미렌더 — 점진 롤아웃 회귀 가드", () => {
+		useRouteLoaderDataMock.mockReturnValue({
+			appCount: 0,
+			googleVerification: "google-only",
+			naverVerification: "",
+			analyticsToken: "",
+		});
+
+		render(
+			<Layout>
+				<div data-testid="children" />
+			</Layout>,
+		);
+
+		expect(
+			document.querySelector('meta[name="google-site-verification"]')?.getAttribute("content"),
+		).toBe("google-only");
+		expect(document.querySelector('meta[name="naver-site-verification"]')).toBeNull();
+		expect(
+			document.querySelector('script[src="https://static.cloudflareinsights.com/beacon.min.js"]'),
+		).toBeNull();
+	});
 });

--- a/app/__tests__/root.test.tsx
+++ b/app/__tests__/root.test.tsx
@@ -1,13 +1,27 @@
-import { describe, expect, it, vi } from "vitest";
+import { render } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
+vi.mock("react-router", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("react-router")>();
+	return {
+		...actual,
+		useRouteLoaderData: vi.fn(),
+		Meta: () => null,
+		Links: () => null,
+		ScrollRestoration: () => null,
+		Scripts: () => null,
+	};
+});
+
+import { useRouteLoaderData } from "react-router";
 // root.tsx 에 loader 가 없으므로 loader 는 undefined — Red phase 정상
-import { loader } from "../root";
+import { Layout, loader } from "../root";
 
 // ---------------------------------------------------------------------------
 // Mock context 팩토리
 // ---------------------------------------------------------------------------
 
-const makeMockContext = (apps: string[]) => {
+const makeMockContext = (apps: string[], env: Record<string, string> = {}) => {
 	const listApps = vi.fn().mockResolvedValue(apps);
 	return {
 		context: {
@@ -23,7 +37,7 @@ const makeMockContext = (apps: string[]) => {
 				buildRssFeed: vi.fn(),
 				findAppDoc: vi.fn(),
 			},
-			cloudflare: { env: {}, ctx: {} },
+			cloudflare: { env, ctx: {} },
 		},
 		spies: { listApps },
 	};
@@ -45,8 +59,13 @@ describe("root loader", () => {
 			request: new Request("http://localhost/"),
 		} as never);
 
-		// Assert
-		expect(result).toEqual({ appCount: 2 });
+		// Assert — appCount 외 신규 키는 빈 문자열 default
+		expect(result).toEqual({
+			appCount: 2,
+			googleVerification: "",
+			naverVerification: "",
+			analyticsToken: "",
+		});
 	});
 
 	it("listApps() 가 빈 배열이면 appCount: 0", async () => {
@@ -61,6 +80,111 @@ describe("root loader", () => {
 		} as never);
 
 		// Assert
-		expect(result).toEqual({ appCount: 0 });
+		expect(result).toEqual({
+			appCount: 0,
+			googleVerification: "",
+			naverVerification: "",
+			analyticsToken: "",
+		});
+	});
+
+	it("env 의 GOOGLE_SITE_VERIFICATION / NAVER_SITE_VERIFICATION / CLOUDFLARE_ANALYTICS_TOKEN 을 forward한다", async () => {
+		// Arrange
+		const { context } = makeMockContext([], {
+			GOOGLE_SITE_VERIFICATION: "google-abc",
+			NAVER_SITE_VERIFICATION: "naver-xyz",
+			CLOUDFLARE_ANALYTICS_TOKEN: "cf-token-123",
+		});
+
+		// Act
+		const result = await loader({
+			context,
+			params: {},
+			request: new Request("http://localhost/"),
+		} as never);
+
+		// Assert
+		expect(result).toEqual({
+			appCount: 0,
+			googleVerification: "google-abc",
+			naverVerification: "naver-xyz",
+			analyticsToken: "cf-token-123",
+		});
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Layout — verification meta + analytics script 조건부 렌더
+// ---------------------------------------------------------------------------
+
+const useRouteLoaderDataMock = vi.mocked(useRouteLoaderData);
+
+describe("Layout — verification meta / analytics script 조건부 렌더", () => {
+	beforeEach(() => {
+		useRouteLoaderDataMock.mockReset();
+	});
+
+	it("3-key truthy → google/naver meta + cloudflare beacon script 모두 렌더", () => {
+		useRouteLoaderDataMock.mockReturnValue({
+			appCount: 0,
+			googleVerification: "google-abc",
+			naverVerification: "naver-xyz",
+			analyticsToken: "cf-token-123",
+		});
+
+		render(
+			<Layout>
+				<div data-testid="children" />
+			</Layout>,
+		);
+
+		expect(
+			document.querySelector('meta[name="google-site-verification"]')?.getAttribute("content"),
+		).toBe("google-abc");
+		expect(
+			document.querySelector('meta[name="naver-site-verification"]')?.getAttribute("content"),
+		).toBe("naver-xyz");
+		const beacon = document.querySelector(
+			'script[src="https://static.cloudflareinsights.com/beacon.min.js"]',
+		);
+		expect(beacon).not.toBeNull();
+		expect(beacon?.getAttribute("data-cf-beacon")).toBe('{"token":"cf-token-123"}');
+	});
+
+	it("3-key 빈 문자열 → meta / beacon script 미렌더", () => {
+		useRouteLoaderDataMock.mockReturnValue({
+			appCount: 0,
+			googleVerification: "",
+			naverVerification: "",
+			analyticsToken: "",
+		});
+
+		render(
+			<Layout>
+				<div data-testid="children" />
+			</Layout>,
+		);
+
+		expect(document.querySelector('meta[name="google-site-verification"]')).toBeNull();
+		expect(document.querySelector('meta[name="naver-site-verification"]')).toBeNull();
+		expect(
+			document.querySelector('script[src="https://static.cloudflareinsights.com/beacon.min.js"]'),
+		).toBeNull();
+	});
+
+	it("useRouteLoaderData undefined (ErrorBoundary 케이스) → meta / beacon 미렌더, 크래시 X", () => {
+		useRouteLoaderDataMock.mockReturnValue(undefined);
+
+		render(
+			<Layout>
+				<div data-testid="children" />
+			</Layout>,
+		);
+
+		expect(document.querySelector('meta[name="google-site-verification"]')).toBeNull();
+		expect(document.querySelector('meta[name="naver-site-verification"]')).toBeNull();
+		expect(
+			document.querySelector('script[src="https://static.cloudflareinsights.com/beacon.min.js"]'),
+		).toBeNull();
 	});
 });

--- a/app/infrastructure/analytics/__tests__/cloudflare-web-analytics.test.ts
+++ b/app/infrastructure/analytics/__tests__/cloudflare-web-analytics.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { getAnalyticsScriptProps } from "../cloudflare-web-analytics";
+
+describe("getAnalyticsScriptProps", () => {
+	it("token truthy → defer + beacon URL + JSON-encoded data-cf-beacon 반환", () => {
+		const props = getAnalyticsScriptProps("token-abc");
+
+		expect(props).not.toBeNull();
+		expect(props?.defer).toBe(true);
+		expect(props?.src).toBe("https://static.cloudflareinsights.com/beacon.min.js");
+		expect(props?.["data-cf-beacon"]).toBe('{"token":"token-abc"}');
+	});
+
+	it("빈 문자열 토큰 → null", () => {
+		expect(getAnalyticsScriptProps("")).toBeNull();
+	});
+
+	it("undefined 토큰 → null", () => {
+		expect(getAnalyticsScriptProps(undefined)).toBeNull();
+	});
+
+	it("token 에 따옴표 포함 → JSON.stringify 가 escape", () => {
+		const props = getAnalyticsScriptProps('a"b');
+		expect(props?.["data-cf-beacon"]).toBe('{"token":"a\\"b"}');
+	});
+});

--- a/app/infrastructure/analytics/cloudflare-web-analytics.ts
+++ b/app/infrastructure/analytics/cloudflare-web-analytics.ts
@@ -1,14 +1,8 @@
-export type AnalyticsScriptProps = {
-	defer: true;
-	src: "https://static.cloudflareinsights.com/beacon.min.js";
-	"data-cf-beacon": string;
-};
-
-export const getAnalyticsScriptProps = (token: string | undefined): AnalyticsScriptProps | null => {
+export const getAnalyticsScriptProps = (token: string | undefined) => {
 	if (!token) return null;
 	return {
-		defer: true,
-		src: "https://static.cloudflareinsights.com/beacon.min.js",
+		defer: true as const,
+		src: "https://static.cloudflareinsights.com/beacon.min.js" as const,
 		"data-cf-beacon": JSON.stringify({ token }),
 	};
 };

--- a/app/infrastructure/analytics/cloudflare-web-analytics.ts
+++ b/app/infrastructure/analytics/cloudflare-web-analytics.ts
@@ -1,0 +1,14 @@
+export type AnalyticsScriptProps = {
+	defer: true;
+	src: "https://static.cloudflareinsights.com/beacon.min.js";
+	"data-cf-beacon": string;
+};
+
+export const getAnalyticsScriptProps = (token: string | undefined): AnalyticsScriptProps | null => {
+	if (!token) return null;
+	return {
+		defer: true,
+		src: "https://static.cloudflareinsights.com/beacon.min.js",
+		"data-cf-beacon": JSON.stringify({ token }),
+	};
+};

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -16,13 +16,6 @@ import ChromeLayout from "./presentation/layouts/ChromeLayout";
 import ThemeProvider from "./presentation/providers/ThemeProvider";
 import "./app.css";
 
-type RootLoaderData = {
-	appCount: number;
-	googleVerification: string;
-	naverVerification: string;
-	analyticsToken: string;
-};
-
 const CHROME_FREE_PATHNAME = /^\/legal\/[^/]+\/(terms|privacy)$/;
 
 export const links: Route.LinksFunction = () => [
@@ -30,11 +23,7 @@ export const links: Route.LinksFunction = () => [
 ];
 
 export const loader = async ({ context }: Route.LoaderArgs) => {
-	const env = context.cloudflare.env as {
-		GOOGLE_SITE_VERIFICATION?: string;
-		NAVER_SITE_VERIFICATION?: string;
-		CLOUDFLARE_ANALYTICS_TOKEN?: string;
-	};
+	const env = context.cloudflare.env as Env;
 	return {
 		appCount: (await context.container.listApps()).length,
 		googleVerification: env.GOOGLE_SITE_VERIFICATION ?? "",
@@ -47,7 +36,7 @@ export const loader = async ({ context }: Route.LoaderArgs) => {
 const themeScript = `(()=>{try{var s=localStorage.getItem('proto-theme');var t=(s==='dark'||s==='light')?s:(matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light');document.documentElement.dataset.theme=t;}catch(e){document.documentElement.dataset.theme='dark';}})();`;
 
 export function Layout({ children }: { children: React.ReactNode }) {
-	const data = useRouteLoaderData("root") as RootLoaderData | undefined;
+	const data = useRouteLoaderData("root") as Awaited<ReturnType<typeof loader>> | undefined;
 	const googleVerification = data?.googleVerification ?? "";
 	const naverVerification = data?.naverVerification ?? "";
 	const analyticsScript = getAnalyticsScriptProps(data?.analyticsToken);

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -6,13 +6,22 @@ import {
 	Scripts,
 	ScrollRestoration,
 	useLocation,
+	useRouteLoaderData,
 } from "react-router";
 
 import type { Route } from "./+types/root";
+import { getAnalyticsScriptProps } from "./infrastructure/analytics/cloudflare-web-analytics";
 import ChromeFreeLayout from "./presentation/layouts/ChromeFreeLayout";
 import ChromeLayout from "./presentation/layouts/ChromeLayout";
 import ThemeProvider from "./presentation/providers/ThemeProvider";
 import "./app.css";
+
+type RootLoaderData = {
+	appCount: number;
+	googleVerification: string;
+	naverVerification: string;
+	analyticsToken: string;
+};
 
 const CHROME_FREE_PATHNAME = /^\/legal\/[^/]+\/(terms|privacy)$/;
 
@@ -20,19 +29,38 @@ export const links: Route.LinksFunction = () => [
 	{ rel: "alternate", type: "application/rss+xml", href: "/rss.xml", title: "tkstar.dev — Posts" },
 ];
 
-export const loader = async ({ context }: Route.LoaderArgs) => ({
-	appCount: (await context.container.listApps()).length,
-});
+export const loader = async ({ context }: Route.LoaderArgs) => {
+	const env = context.cloudflare.env as {
+		GOOGLE_SITE_VERIFICATION?: string;
+		NAVER_SITE_VERIFICATION?: string;
+		CLOUDFLARE_ANALYTICS_TOKEN?: string;
+	};
+	return {
+		appCount: (await context.container.listApps()).length,
+		googleVerification: env.GOOGLE_SITE_VERIFICATION ?? "",
+		naverVerification: env.NAVER_SITE_VERIFICATION ?? "",
+		analyticsToken: env.CLOUDFLARE_ANALYTICS_TOKEN ?? "",
+	};
+};
 
 // localStorage 값 화이트리스트 — 잘못된 값(브라우저 확장 / 콘솔 조작)이 들어와도 dark/light로만 좁힌다.
 const themeScript = `(()=>{try{var s=localStorage.getItem('proto-theme');var t=(s==='dark'||s==='light')?s:(matchMedia('(prefers-color-scheme: dark)').matches?'dark':'light');document.documentElement.dataset.theme=t;}catch(e){document.documentElement.dataset.theme='dark';}})();`;
 
 export function Layout({ children }: { children: React.ReactNode }) {
+	const data = useRouteLoaderData("root") as RootLoaderData | undefined;
+	const googleVerification = data?.googleVerification ?? "";
+	const naverVerification = data?.naverVerification ?? "";
+	const analyticsScript = getAnalyticsScriptProps(data?.analyticsToken);
+
 	return (
 		<html lang="ko">
 			<head>
 				<meta charSet="utf-8" />
 				<meta name="viewport" content="width=device-width, initial-scale=1" />
+				{googleVerification && (
+					<meta name="google-site-verification" content={googleVerification} />
+				)}
+				{naverVerification && <meta name="naver-site-verification" content={naverVerification} />}
 				<link
 					rel="preload"
 					href="/fonts/Pretendard-Regular.woff2"
@@ -57,6 +85,7 @@ export function Layout({ children }: { children: React.ReactNode }) {
 				{children}
 				<ScrollRestoration />
 				<Scripts />
+				{analyticsScript && <script {...analyticsScript} />}
 			</body>
 		</html>
 	);

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -492,7 +492,7 @@ tkstarDev는 다음 핵심 가치를 단일 도메인에서 달성한다:
     - `app/presentation/lib/jsonld.ts` — schema.org 빌더 헬퍼 (Person/BlogPosting/CreativeWork/BreadcrumbList)
   - PR 1개 / 브랜치: `feature/issue-N-seo-sitemap-jsonld`
 
-- [ ] **Task 020: F019 검색엔진 등록 (Google + Naver) + Cloudflare Web Analytics (F013)**
+- [x] **Task 020: F019 검색엔진 등록 (Google + Naver) + Cloudflare Web Analytics (F013)**
   - **Must** Read: [tasks/T020-search-engine-verification.md](tasks/T020-search-engine-verification.md)
   - blockedBy: Task 019
   - Layer: Presentation(root layout) + Infrastructure(analytics 스니펫)

--- a/docs/tasks/T019-seo-sitemap-jsonld.md
+++ b/docs/tasks/T019-seo-sitemap-jsonld.md
@@ -40,15 +40,15 @@
 - Bing Webmaster Tools (가정 A011, MVP 후)
 
 ## Acceptance Criteria
-- [ ] `/sitemap.xml`이 well-formed XML 응답 + `<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">` + `<url><loc>...</loc>...</url>` 항목들
-- [ ] sitemap에 포함되는 페이지: Home / About / Projects 목록 / Project Detail (모든 slug) / Blog 목록 / Blog Detail (모든 slug) / Contact / Legal Index
-- [ ] sitemap에 **포함되지 않는** 페이지: App Terms / App Privacy / 404 (splat) / OG resource route / RSS / Sitemap / Robots 자체
-- [ ] `/robots.txt` 응답: `User-agent: *\nAllow: /\nSitemap: https://tkstar.dev/sitemap.xml`
-- [ ] 모든 페이지에 `meta` export(title/description/canonical/og:title/og:description/og:image/og:url/og:type/twitter:card) 정의
-- [ ] OG `og:image`는 T018의 `/og/{projects|blog}/:slug.png` URL 또는 정적 fallback
-- [ ] JSON-LD: Home/About → `Person`, Blog Detail → `BlogPosting`, Project Detail → `CreativeWork`(또는 `SoftwareSourceCode`), 모든 페이지 → `BreadcrumbList`
-- [ ] App Terms/Privacy meta `noindex, follow` + canonical 유지, sitemap.xml 미포함
-- [ ] 404 splat meta `noindex, nofollow` + 404 응답 코드 + sitemap.xml 미포함
+- [x] `/sitemap.xml`이 well-formed XML 응답 + `<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">` + `<url><loc>...</loc>...</url>` 항목들
+- [x] sitemap에 포함되는 페이지: Home / About / Projects 목록 / Project Detail (모든 slug) / Blog 목록 / Blog Detail (모든 slug) / Contact / Legal Index
+- [x] sitemap에 **포함되지 않는** 페이지: App Terms / App Privacy / 404 (splat) / OG resource route / RSS / Sitemap / Robots 자체
+- [x] `/robots.txt` 응답: `User-agent: *\nAllow: /\nSitemap: https://tkstar.dev/sitemap.xml`
+- [x] 모든 페이지에 `meta` export(title/description/canonical/og:title/og:description/og:image/og:url/og:type/twitter:card) 정의
+- [x] OG `og:image`는 T018의 `/og/{projects|blog}/:slug.png` URL 또는 정적 fallback
+- [x] JSON-LD: Home/About → `Person`, Blog Detail → `BlogPosting`, Project Detail → `CreativeWork`(또는 `SoftwareSourceCode`), 모든 페이지 → `BreadcrumbList`
+- [x] App Terms/Privacy meta `noindex, follow` + canonical 유지, sitemap.xml 미포함
+- [x] 404 splat meta `noindex, nofollow` + 404 응답 코드 + sitemap.xml 미포함
 
 ## Implementation Plan (TDD Cycle)
 

--- a/docs/tasks/T020-search-engine-verification.md
+++ b/docs/tasks/T020-search-engine-verification.md
@@ -11,7 +11,7 @@
 | **PRD Features** | **F019** (검색엔진 등록), **F013** (Cloudflare Web Analytics) |
 | **PRD AC** | — (배포 후 `site:tkstar.dev` 인덱싱 확인) |
 | **예상 작업 시간** | 0.5d |
-| **Status** | Not Started |
+| **Status** | Completed |
 
 ## Goal
 환경변수(`GOOGLE_SITE_VERIFICATION`, `NAVER_SITE_VERIFICATION`)가 설정되어 있으면 root layout `<head>`에 verification meta 태그를 조건부 렌더하고, Cloudflare Web Analytics 스니펫을 삽입한다 (쿠키 없음).

--- a/docs/tasks/T020-search-engine-verification.md
+++ b/docs/tasks/T020-search-engine-verification.md
@@ -36,12 +36,14 @@
 - DNS / 도메인 등록 — T022
 
 ## Acceptance Criteria
-- [ ] `wrangler dev`에서 `GOOGLE_SITE_VERIFICATION = "abc123"` 설정 시 root `<head>`에 `<meta name="google-site-verification" content="abc123">` 렌더
-- [ ] env 미설정 시 verification meta 미렌더
-- [ ] `NAVER_SITE_VERIFICATION = "xyz789"` 설정 시 `<meta name="naver-site-verification" content="xyz789">` 렌더
-- [ ] `CLOUDFLARE_ANALYTICS_TOKEN = "token123"` 설정 시 root `<body>` 끝에 Cloudflare Web Analytics `<script>` 스니펫 삽입
-- [ ] Web Analytics가 쿠키를 설정하지 않음 (DevTools Application → Cookies 검증)
-- [ ] 가정 A008 — wrangler vars로 토큰 주입 패턴 확정. A011/A012는 MVP 후로 잔존.
+- [x] `wrangler dev`에서 `GOOGLE_SITE_VERIFICATION = "abc123"` 설정 시 root `<head>`에 `<meta name="google-site-verification" content="abc123">` 렌더 (Layout 테스트 + helper 단위 테스트로 검증)
+- [x] env 미설정 시 verification meta 미렌더 (빈 문자열 default → truthy gate 미통과 — Layout 테스트로 검증)
+- [x] `NAVER_SITE_VERIFICATION = "xyz789"` 설정 시 `<meta name="naver-site-verification" content="xyz789">` 렌더
+- [x] `CLOUDFLARE_ANALYTICS_TOKEN = "token123"` 설정 시 root `<body>` 끝에 Cloudflare Web Analytics `<script>` 스니펫 삽입
+- [x] 가정 A008 — wrangler vars로 토큰 주입 패턴 확정. A011/A012는 MVP 후로 잔존.
+
+### Deferred to T022 (배포 후 검증)
+- Web Analytics가 쿠키를 설정하지 않음 (DevTools Application → Cookies 검증) — 실제 토큰 발급 후 운영 환경에서 검증
 
 ## Implementation Plan (TDD Cycle)
 

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -22,6 +22,10 @@ enabled = true
 APP_ENV = "development"
 CONTACT_TO_EMAIL = "hello@tkstar.dev"
 TURNSTILE_SITE_KEY = "1x00000000000000000000AA"
+# T020: 빈 문자열 default — 실제 토큰은 T022 deploy 단계에서 주입 (선택적)
+GOOGLE_SITE_VERIFICATION = ""
+NAVER_SITE_VERIFICATION = ""
+CLOUDFLARE_ANALYTICS_TOKEN = ""
 
 [[kv_namespaces]]
 binding = "RATE_LIMIT_KV"
@@ -35,6 +39,9 @@ name = "tkstar-dev-staging"
 APP_ENV = "staging"
 CONTACT_TO_EMAIL = "hello@tkstar.dev"
 TURNSTILE_SITE_KEY = "1x00000000000000000000AA"
+GOOGLE_SITE_VERIFICATION = ""
+NAVER_SITE_VERIFICATION = ""
+CLOUDFLARE_ANALYTICS_TOKEN = ""
 
 [[env.staging.kv_namespaces]]
 binding = "RATE_LIMIT_KV"
@@ -48,6 +55,10 @@ APP_ENV = "production"
 CONTACT_TO_EMAIL = "hello@tkstar.dev"
 # TURNSTILE_SITE_KEY: T022 deploy 단계에서 prod widget site key 로 교체 (공개 가능 값)
 TURNSTILE_SITE_KEY = "1x00000000000000000000AA"
+# T020: 검색엔진 인증 토큰 + Web Analytics token — T022 deploy 단계에서 실제 값 주입
+GOOGLE_SITE_VERIFICATION = ""
+NAVER_SITE_VERIFICATION = ""
+CLOUDFLARE_ANALYTICS_TOKEN = ""
 
 [[env.production.kv_namespaces]]
 binding = "RATE_LIMIT_KV"


### PR DESCRIPTION
## Summary
- **F019** Google + Naver Search Console verification meta + **F013** Cloudflare Web Analytics 스니펫의 **메커니즘**만 root layout 에 구축. 실제 토큰 발급 / 도메인 검증 / Web Analytics 등록은 T022 (정식 배포) 에서.
- 3 keys 모두 빈 문자열 default 패턴 (T015 \`TURNSTILE_SITE_KEY\` 와 동일) — env truthy 시에만 \`<head>\` 의 verification meta 2 개 + \`<body>\` 끝의 beacon \`<script>\` 조건부 렌더.
- 한 단계 하위(infrastructure) 헬퍼 + 정본 \`Cloudflare.Env\` 사용 + ErrorBoundary fallback 모두 테스트로 회귀 가드.

## Changes
- \`app/infrastructure/analytics/cloudflare-web-analytics.ts\` 신규 — \`getAnalyticsScriptProps(token)\` 순수 함수, 빈 토큰/undefined → \`null\`. \`defer: true\` + JSON-encoded \`data-cf-beacon\`.
- \`app/root.tsx\` loader 확장 — \`googleVerification\` / \`naverVerification\` / \`analyticsToken\` 3 키 (env 미설정 시 \`""\`). \`Cloudflare.Env\` 정본 어설션 (contact.tsx:51 컨벤션과 동일).
- \`app/root.tsx\` Layout — \`useRouteLoaderData("root")\` (ErrorBoundary 시 undefined fallback) → 3 키 truthy gate 로 meta + script 조건부 렌더.
- \`wrangler.toml\` 3 환경 (default / staging / production) \`[vars]\` 에 빈 문자열 default 추가 → \`wrangler types\` 가 \`Cloudflare.Env\` 에 자동 union 등록.
- 테스트: 11 신규 (analytics 헬퍼 4 + root loader 3 + Layout 4 — mixed-truthy 점진 롤아웃 회귀 가드 포함).

## Test plan
- [x] \`bun run test\` — 479/479 pass (T020 신규 11)
- [x] \`bun run typecheck\` — clean (\`Cloudflare.Env\` 에 3 키 자동 등장)
- [x] \`bun run lint\` — Biome clean
- [ ] \`bunx wrangler dev\` 띄우고 \`.dev.vars\` 에 임시 값 (\`GOOGLE_SITE_VERIFICATION="test-google"\`) 주입 → root view-source 에 \`<meta>\` 노출 확인 (T022 단계에서 실제 배포 검증)
- [ ] DevTools → Application → Cookies 비어있음 (Web Analytics 쿠키 미설정 — T022 배포 후 검증)

## Out of Scope (T022)
- 실제 GSC 도메인 인증 / Naver Search Advisor 등록
- Cloudflare Web Analytics 토큰 발급 + 트래픽 수집 확인
- 배포 후 \`site:tkstar.dev\` 인덱싱 확인

Closes #72

🤖 Generated with [Claude Code](https://claude.com/claude-code)