### PR TITLE
🧪 chore: T021 — 통합 QA 보고서 + minor a11y fix + CI coverage 강제

### DIFF
--- a/.github/workflows/deploy-cloudflare-workers.yml
+++ b/.github/workflows/deploy-cloudflare-workers.yml
@@ -60,8 +60,8 @@ jobs:
       - name: Typecheck
         run: bun run typecheck
 
-      - name: Run tests
-        run: bun run test
+      - name: Run tests with coverage threshold
+        run: bun run test:coverage
 
       - name: Build project
         run: bun run build

--- a/app/app.css
+++ b/app/app.css
@@ -7,7 +7,7 @@
 	--color-bg-card: #1a1e24;
 	--color-fg: #e8ebef;
 	--color-muted: #8a93a0;
-	--color-faint: #4a525e;
+	--color-faint: #838b9a;
 	--color-line: #2a3038;
 	--color-line-strong: #3a424d;
 	--color-accent: oklch(72% 0.14 155);
@@ -40,7 +40,7 @@
 	--color-bg-card: #f9f7f1;
 	--color-fg: #1a1c20;
 	--color-muted: #5a6068;
-	--color-faint: #a8aab0;
+	--color-faint: #5d616b;
 	--color-line: #c8c2b3;
 	--color-line-strong: #8a8678;
 	--color-accent: oklch(48% 0.14 155);
@@ -215,7 +215,7 @@ html {
 		--color-bg-card: #f9f7f1;
 		--color-fg: #1a1c20;
 		--color-muted: #5a6068;
-		--color-faint: #a8aab0;
+		--color-faint: #5d616b;
 		--color-line: #c8c2b3;
 		--color-line-strong: #8a8678;
 		--color-accent: oklch(48% 0.14 155);

--- a/app/presentation/components/about/AboutHeader.tsx
+++ b/app/presentation/components/about/AboutHeader.tsx
@@ -19,7 +19,7 @@ export default function AboutHeader() {
 					{ABOUT_HEADER.positioning} ·{" "}
 					<a
 						href={`mailto:${ABOUT_HEADER.email}`}
-						className="text-accent underline-offset-4 transition-colors duration-[var(--duration-120)] ease-out hover:underline focus-visible:rounded-sm focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent motion-reduce:transition-none"
+						className="text-accent underline underline-offset-4 transition-colors duration-[var(--duration-120)] ease-out hover:no-underline focus-visible:rounded-sm focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent motion-reduce:transition-none"
 					>
 						{ABOUT_HEADER.email}
 					</a>

--- a/app/presentation/routes/contact.tsx
+++ b/app/presentation/routes/contact.tsx
@@ -28,12 +28,12 @@ export const meta: MetaFunction<typeof loader> = ({ data }) => {
 			ogImage: data.ogImageUrl,
 		}),
 		{
-			"script:ld+json": 				buildBreadcrumbListLd({
-					items: [
-						{ name: "Home", url: `${data.origin}/` },
-						{ name: "Contact", url: data.canonicalUrl },
-					],
-				}),
+			"script:ld+json": buildBreadcrumbListLd({
+				items: [
+					{ name: "Home", url: `${data.origin}/` },
+					{ name: "Contact", url: data.canonicalUrl },
+				],
+			}),
 		},
 	];
 };
@@ -132,7 +132,7 @@ export default function Contact() {
 					평균 회신 24시간 이내. 또는{" "}
 					<a
 						href={`mailto:${contactEmail}`}
-						className="text-accent underline-offset-4 transition-colors duration-[var(--duration-120)] ease-out hover:underline focus-visible:rounded-sm focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent motion-reduce:transition-none"
+						className="text-accent underline underline-offset-4 transition-colors duration-[var(--duration-120)] ease-out hover:no-underline focus-visible:rounded-sm focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent motion-reduce:transition-none"
 					>
 						{contactEmail}
 					</a>

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -532,9 +532,25 @@ tkstarDev는 다음 핵심 가치를 단일 도메인에서 달성한다:
     - 발견된 결함은 `fix/issue-N-*` PR로 분리 처리
   - PR 1개 / 브랜치: `chore/qa-pass-mvp`
 
+- [ ] **Task 021.5: MdxRenderer Workers V8 eval 차단 회귀 fix (mdx-bundler 도입) — Critical**
+  - GitHub Issue: #75
+  - blockedBy: Task 021 (minor a11y fix 분리)
+  - Layer: Presentation + Infrastructure (content pipeline)
+  - 관련 Feature: F005, F007, F014 (detail 페이지 SSR)
+  - 관련 AC: AC-F005-1, AC-F007-1, AC-F014-1 (재검증)
+  - 검증:
+    - `bunx wrangler dev --remote` 환경에서 `/projects/:slug`, `/blog/:slug`, `/legal/:app/{terms,privacy}` 모두 200 OK + 정상 렌더
+    - 기존 단위 테스트 Green 유지 (특히 `MdxRenderer.test.tsx`)
+    - velite frontmatter / TOC / cover 메타 회귀 없음
+    - shiki 코드 하이라이트 + rehype-slug 헤딩 anchor 회귀 없음
+    - Workers 번들 사이즈 변화 측정 + 보고서 기록
+  - 회귀 원인: T007 (PR #14) 시점의 `new Function(code)` 패턴이 그 이후 Cloudflare Workers V8 isolate 정책 강화로 차단 (`Code generation from strings disallowed`).
+  - 채택 전략: esbuild 기반 mdx-bundler 가 build-time 에 React component module 산출 → runtime `new Function` 제거. velite 는 frontmatter/TOC/cover 메타만 담당.
+  - PR 1개 / 브랜치: `fix/issue-75-mdx-renderer-workers-eval`
+
 - [ ] **Task 022: Cloudflare Workers 배포 + 도메인 연결 + Email Routing + 검색엔진 인증 완료**
   - **Must** Read: [tasks/T022-deploy-production.md](tasks/T022-deploy-production.md)
-  - blockedBy: Task 021
+  - blockedBy: Task 021, **Task 021.5** (Critical fix 없이는 detail 페이지 SSR 차단)
   - Layer: 운영
   - 관련 Feature: F019 (인증 완료), 운영 (도메인/이메일)
   - 관련 AC: 없음 (운영 검증)
@@ -1142,14 +1158,14 @@ Phase 7.4 (Project Meta+Search Index):
 - [ ] Phase 3: Core Pages UI (Task 010~013, 014a, 014b, 015)
 - [ ] Phase 4: Forms / Email — Command Palette + Contact (Task 016, 017-pre, 017)
 - [ ] Phase 5: SEO / OG / Indexing (Task 018~020)
-- [ ] Phase 6: Polish & Deploy (Task 021~022)
+- [ ] Phase 6: Polish & Deploy (Task 021, **021.5**, 022)
 - [ ] Phase 7: CMS 인프라 — D1 + Drizzle + R2 + Cloudflare Access (Task 023~040)
   - Phase 7.1 Read Path First (Task 023~028, 6 tasks)
   - Phase 7.2 Auth + Admin Foundation (Task 029~032, 4 tasks)
   - Phase 7.3 Admin Editor + Media (Task 033~037, 5 tasks)
   - Phase 7.4 Project Meta + Search Index (Task 038~040, 3 tasks)
 
-**총 42개 task (T014 분리 + T017-pre + Phase 7 신규 18개) / 7개 phase / 100% PRD Feature(F001~F023, F015 제외) coverage / 100% Assumption(A001~A021) 해소 게이트 매핑.**
+**총 43개 task (T014 분리 + T017-pre + T021.5 회귀 fix + Phase 7 신규 18개) / 7개 phase / 100% PRD Feature(F001~F023, F015 제외) coverage / 100% Assumption(A001~A021) 해소 게이트 매핑.**
 
 > **검증 리포트(2026-04-28) 반영 이력**:
 > - Issue #1 (High): T010/T012/T015 자동 테스트(RTL + DOM assertion) 항목 보강

--- a/docs/reports/qa-2026-05-04.md
+++ b/docs/reports/qa-2026-05-04.md
@@ -1,0 +1,232 @@
+# QA Report — 2026-05-04 (T021)
+
+| Field | Value |
+|-------|-------|
+| **Task** | T021 — 통합 QA + Lighthouse + Axe + 18개 AC 회귀 매트릭스 |
+| **Branch** | `chore/issue-74-qa-pass-mvp` |
+| **Issue** | #74 |
+| **PR** | (생성 후 기록) |
+| **Date** | 2026-05-04 |
+| **Tester** | Claude (자동 영역) + 사용자 (수동 영역) |
+| **결정 (사용자)** | T021 = QA 보고서 + minor fix 30건. Critical 회귀 (4건 detail 페이지 SSR 500) 는 별도 issue (#75) 로 분리 → T022 의 blocker. |
+
+---
+
+## 1. Coverage Summary
+
+`bun run test:coverage` 실행 결과 (vitest 4.1.5 + v8 coverage).
+
+| Metric | Result | Threshold | Status |
+|--------|--------|-----------|--------|
+| Statements | **88.76%** (853 / 961) | ≥ 80% | ✅ |
+| Branches | **75.84%** (336 / 443) | ≥ 75% | ✅ |
+| Functions | **88.53%** (247 / 279) | ≥ 80% | ✅ |
+| Lines | **90.47%** (760 / 840) | ≥ 80% | ✅ |
+| Test files | 85 passed | — | ✅ |
+| Tests | 479 passed | — | ✅ |
+
+### 미커버 컴포넌트 (threshold 통과 후 잔여)
+- `app/presentation/components/contact/LogoFallback.tsx` — 0% (admin-only fallback, 정상 경로 미진입)
+- `app/presentation/components/contact/SuccessScreen.tsx` — 0% (Contact form post-submit branch, 통합 단위 별도)
+- `app/presentation/components/contact/ProfileWidget.tsx` — 0% (디스플레이 위젯, props 변동 없음)
+
+> 의도적 leftover. Threshold 자체는 모두 통과하므로 본 task 의 fix 대상 아님 (별도 follow-up 권장).
+
+---
+
+## 2. 18개 PRD AC 회귀 매트릭스
+
+| AC | 정의 (요약) | 자동 테스트 ID / 위치 | Status |
+|----|-------------|------------------------|--------|
+| **AC-F003-1** | About `[⎙ PDF]` 클릭 → `window.print()` + chrome 숨김 | `app/presentation/lib/__tests__/print.test.ts:9` "AC-F003-1: window.print를 정확히 1회 호출한다" + `app/app.css` `@media print` chrome 숨김 CSS | ✅ |
+| **AC-F003-2** | OKLCH 색상이 `print-color-adjust: exact` 로 보존 | `app/app.css:228 print-color-adjust: exact;` (CSS 직검증) | ✅ (정적 검증) |
+| **AC-F003-3** | 헤딩이 페이지 하단에 고립되지 않음 (`break-after: avoid`) | `app/app.css` print 섹션 + `LegalDocLayout.tsx` print CSS | ✅ (정적 검증) |
+| **AC-F008-1** | Contact form 정상 path → Resend 1회 + 자동응답 메일 | `app/application/contact/services/__tests__/submit-contact-form.service.test.ts:31` "AC-F008-1 — happy path" + `app/presentation/routes/__tests__/contact.test.tsx:84` "AC-F008-1 happy path" | ✅ |
+| **AC-F008-2** | RFC 5322 위반 이메일 → 클라이언트 차단 + 인라인 에러 | `app/domain/contact/__tests__/contact-submission.schema.test.ts:19/24/29` "AC-F008-2: foo@bar.com 통과 / foo@ reject / bar.com reject" + `contact.test.tsx:137/171` | ✅ |
+| **AC-F008-3** | 메시지 10자 미만 또는 5000자 초과 → 인라인 에러 + 폼 유지 | `contact-submission.schema.test.ts:37/45/53/61` "AC-F008-3: 9자/10자/5000자/5001자" | ✅ |
+| **AC-F008-4** | Resend 5xx → 토스트 + mailto fallback prefill | `submit-contact-form.service.test.ts:86` "AC-F008-4 — email delivery failure" + `contact.test.tsx:123` "AC-F008-4 EMAIL_DELIVERY_FAILED" | ✅ |
+| **AC-F009-1** | Turnstile 토큰 미수령 → submit 버튼 disabled | `contact.test.tsx:155` "AC-F009-1: Turnstile 토큰 미수령 → submit 버튼 disabled" | ✅ |
+| **AC-F009-2** | 위조 토큰 → siteverify success:false → 400 + Resend 미호출 | `submit-contact-form.service.test.ts:69` "AC-F009-2 — invalid captcha" + `contact.test.tsx:112` "AC-F009-2 INVALID_CAPTCHA" | ✅ |
+| **AC-F009-3** | 동일 IP 1시간 내 6번째 submit → 429 | `submit-contact-form.service.test.ts:51` "AC-F009-3 — rate limit exceeded" + `contact.test.tsx:101` "AC-F009-3 RATE_LIMITED" + `app/infrastructure/ratelimit/**` | ✅ |
+| **AC-F011-1** | `/og/...` Satori PNG 1200×630 + `Cache-Control: immutable` | `app/presentation/routes/__tests__/og.projects.$slug.test.ts:36` + `og.blog.$slug.test.ts:36` "AC-F011-1" | ✅ |
+| **AC-F011-2** | 미존재 slug → fallback PNG 200 | `og.projects.$slug.test.ts:53` + `og.blog.$slug.test.ts:51` "AC-F011-2" | ✅ |
+| **AC-F011-3** | Satori throw → fallback PNG + Workers logs | `og.projects.$slug.test.ts:72` + `og.blog.$slug.test.ts:66` "AC-F011-3" | ✅ |
+| **AC-F016-1** | ⌘K / Ctrl+K / `/` → palette 열림 + input 자동 포커스 | `CommandPalette.test.tsx:63` "Cmd+K 단축키로 팔레트가 열리고 palette-modal이 DOM에 나타난다" + `:89` "palette-input 존재하고 자동 포커스" | ✅ |
+| **AC-F016-2** | input/textarea 포커스 시 단축키 가로채지 않음 | `useCommandPalette.test.ts` shortcut guard 케이스 | ✅ |
+| **AC-F016-3** | "rou nav" 토큰 검색 → 두 토큰 모두 포함 | `useCommandPalette.test.ts` 토큰 검색 케이스 | ✅ |
+| **AC-F016-4** | ↓↑ 네비 + ↵ 진입 + Esc 닫기 (키보드 only) | `CommandPalette.test.tsx` keyboard navigation 그룹 | ✅ |
+| **AC-F016-5** | search-index.json gzip ≤ 100KB + 본문 미포함 + 세션 1회 | `app/application/search/services/__tests__/build-search-index.service.test.ts` + 본문 제외 검증 | ✅ |
+
+**결과: 18 / 18 PASS** (모두 자동 테스트로 회귀 — Critical 회귀 별도 분리, §4 참조).
+
+---
+
+## 3. Pa11y / Axe 자동 스캔 결과
+
+`bunx wrangler dev --port 8787 --local` 환경에서 Pa11y 4.x + axe-core 4.10 runner 로 페이지별 스캔.
+
+### 3.1 1차 baseline (fix 전)
+
+| Route | Violations | 비고 |
+|-------|-----------|------|
+| `/` | 1 (color-contrast) | Home cover placeholder |
+| `/about` | 9 (color-contrast 8 + link-in-text 1) | text-faint heading + mailto link |
+| `/contact` | 3 (color-contrast 2 + link-in-text 1) | text-faint span + mailto link |
+| `/projects` | 5 (color-contrast) | ls-style header row |
+| `/projects/example-project` | **— SSR 500** | Critical, §4 참조 |
+| `/blog` | 5 (color-contrast) | ls-style header row |
+| `/blog/2026-04-shipping-solo` | **— SSR 500** | Critical, §4 참조 |
+| `/legal` | 5 (color-contrast) | text-faint directory tree |
+| `/legal/moai/terms` | **— SSR 500** | Critical, §4 참조 |
+| `/legal/moai/privacy` | **— SSR 500** | Critical, §4 참조 |
+| `/non-existent-page-404` | 0 | — |
+
+**총 30건 (자동 영역)** + 4 페이지 SSR 500 (Critical, 별도).
+
+### 3.2 Fix 적용
+
+| 변경 | 파일 | 효과 |
+|------|------|------|
+| `--color-faint` dark `#4a525e` → `#838b9a` | `app/app.css:10` | dark contrast 2.48 → ~6.30 |
+| `--color-faint` light `#a8aab0` → `#5d616b` | `app/app.css:43` | light contrast 2.00 → ~5.60 |
+| `--color-faint` print = light 동일 | `app/app.css:218` | 인쇄 매체 동일 적용 |
+| About mailto `hover:underline` → `underline` (default + `hover:no-underline`) | `app/presentation/components/about/AboutHeader.tsx:22` | link-in-text-block 해소 |
+| Contact mailto `hover:underline` → `underline` | `app/presentation/routes/contact.tsx:135` | link-in-text-block 해소 |
+
+### 3.3 2차 재검증 결과
+
+| Route | Violations | 비고 |
+|-------|-----------|------|
+| `/` | 1 | Home cover placeholder (decorative + hatch overlay, 면제) |
+| `/about` | 1 | `<span aria-hidden="true">⎙</span>` print icon (decorative, aria-hidden 적용) |
+| `/contact` | 0 | ✅ |
+| `/projects` | 0 | ✅ |
+| `/blog` | 0 | ✅ |
+| `/legal` | 2 | `<span class="text-faint">→</span>` decorative arrow (×2) |
+| `/non-existent-page-404` | 0 | ✅ |
+
+**최종 4건 (decorative 면제)** + 4 페이지 SSR 500 (Critical, 별도).
+
+### 3.4 잔존 4건의 면제 사유
+
+| 위치 | 사유 |
+|------|------|
+| Home `cover · 16:9` placeholder | 디자인 의도적 placeholder — `bg-bg-elev` 위 `repeating-linear-gradient` hatch overlay. axe 가 hatch sample 에서 contrast 측정 실패. WCAG 1.4.3 "incidental" 영역. |
+| About `⎙` print icon | `aria-hidden="true"` 적용된 decorative icon. 인접 visible label "Print as PDF" 가 의미 전달. |
+| Legal `→` arrow ×2 | Decorative chevron — 인접 link text ("terms.mdx", "privacy.mdx") 가 의미 전달. WCAG 1.4.3 면제. |
+
+> Pa11y 의 axe runner 는 conservative — `aria-hidden` 만으로 면제하지 않으므로 상기 4건은 자동 도구상 위반으로 잡히지만 WCAG 본 spec 상 면제 정당.
+
+---
+
+## 4. Critical 회귀 (T021 → T021.5 분리)
+
+T021 수행 중 **MdxRenderer SSR 500** 회귀 발견 — Cloudflare Workers V8 isolate 가 `Code generation from strings disallowed for this context` 로 차단.
+
+### 영향
+| Route | HTTP | 원인 |
+|-------|------|------|
+| `/projects/:slug` | 500 | `MdxRenderer.evaluateMdxBody` 의 `new Function(code)({Fragment, jsx, jsxs})` |
+| `/blog/:slug` | 500 | 동일 |
+| `/legal/:app/terms` | 500 | 동일 |
+| `/legal/:app/privacy` | 500 | 동일 |
+
+### 검증 환경
+- `wrangler dev --local` (V8 isolate strict): 500 ✅ 재현
+- `wrangler dev --remote` (실 Cloudflare edge V8 isolate): 500 ✅ 재현 → production 회귀 확정
+
+### 회귀 원인
+`wrangler.jsonc` T007 NOTE 가정 (`Workers V8 Isolate currently permits this without unsafe-eval`) 이 그 이후 Cloudflare 정책 강화로 무효화.
+
+### 분리 결정
+- 본 T021 PR 에서 fix 하기에는 architecture refactor 영역 (mdx-bundler 도입 또는 velite output 형식 변경)
+- 별도 issue **#75** 로 분리 + ROADMAP 에 **T021.5** 신설
+- T022 (배포) 의 blocker 로 등재
+
+### 채택 전략 (T021.5)
+**mdx-bundler 도입**: esbuild 기반 build-time 컴파일 → React component module 산출 → runtime `new Function` 제거. velite 는 frontmatter / TOC / cover 메타만 담당.
+
+---
+
+## 5. CI Workflow 변경
+
+`.github/workflows/deploy-cloudflare-workers.yml`:
+
+```diff
+- - name: Run tests
+-   run: bun run test
++ - name: Run tests with coverage threshold
++   run: bun run test:coverage
+```
+
+push 시점 (development / main / workflow_dispatch) 에 coverage threshold (lines 80 / branches 75 / functions 80 / statements 80) 강제 통과 — regression 차단.
+
+---
+
+## 6. 수동 검증 (사용자 직접 측정)
+
+> 본 섹션은 사용자가 `bun run build && bunx wrangler dev --port 8787 --local` 로 로컬 Workers preview (http://localhost:8787) 띄운 뒤 Chrome DevTools / 키보드 / 토글 직접 측정 후 채워넣는다.
+
+### 6.1 Lighthouse 4 카테고리 (Chrome DevTools Lighthouse 탭, production preview, warm state 3회 평균)
+
+| 페이지 | Performance | Accessibility | Best Practices | SEO | Status |
+|--------|-------------|---------------|----------------|-----|--------|
+| `/` | __ | __ | __ | __ | ⬜ |
+| `/about` | __ | __ | __ | __ | ⬜ |
+| `/contact` | __ | __ | __ | __ | ⬜ |
+| `/projects` | __ | __ | __ | __ | ⬜ |
+| `/blog` | __ | __ | __ | __ | ⬜ |
+| `/legal` | __ | __ | __ | __ | ⬜ |
+
+> **Threshold**: Performance ≥ 90, Accessibility ≥ 95, Best Practices ≥ 95, SEO ≥ 100
+
+**Detail 페이지 (`/projects/:slug`, `/blog/:slug`, `/legal/:app/{terms,privacy}`)**: T021.5 fix 완료 후 별도 측정.
+
+### 6.2 키보드 only 네비게이션
+
+각 단계 통과 시 ✓ 체크. 실패 시 ✗ + 상세.
+
+| Step | 동작 | Status | 비고 |
+|------|------|--------|------|
+| 1 | 페이지 로드 → Tab → "본문으로 건너뛰기" skip link 노출 | ⬜ | |
+| 2 | Cmd+K (또는 Ctrl+K, `/`) → palette 열림 + input 포커스 | ⬜ | |
+| 3 | "blog" 입력 → 결과 필터링 + ↓ ↑ 으로 결과 이동 | ⬜ | |
+| 4 | ↵ → 선택 결과로 진입 | ⬜ | |
+| 5 | Esc → palette 닫힘 + 직전 포커스로 복귀 | ⬜ | |
+| 6 | Topbar `[●]` 테마 토글 → focus ring 가시 + Space/Enter 로 토글 | ⬜ | |
+| 7 | About 페이지 `[⎙ PDF]` 버튼 → Tab 도달 가능 + Enter → print 다이얼로그 | ⬜ | |
+| 8 | Contact 폼 → Tab 순서가 시각 순서와 일치 | ⬜ | |
+
+### 6.3 다크/라이트 모드 시각 회귀
+
+| 페이지 | Dark 정상 | Light 정상 | 비고 |
+|--------|-----------|------------|------|
+| `/` | ⬜ | ⬜ | |
+| `/about` | ⬜ | ⬜ | |
+| `/contact` | ⬜ | ⬜ | |
+| `/projects` | ⬜ | ⬜ | |
+| `/blog` | ⬜ | ⬜ | |
+| `/legal` | ⬜ | ⬜ | |
+
+> **체크 포인트**: text-faint 토큰 lighten 변경 (#4a525e → #838b9a / #a8aab0 → #5d616b) 후 디자인 hierarchy (text-fg > text-muted > text-faint) 유지 여부.
+
+---
+
+## 7. 결론
+
+| 영역 | 결과 |
+|------|------|
+| Coverage threshold | ✅ PASS (88.76 / 75.84 / 88.53 / 90.47) |
+| 18 AC 자동 회귀 | ✅ 18/18 PASS |
+| Axe / Pa11y 자동 스캔 | ⚠️ 4건 잔존 (decorative 면제 정당) — Critical 4 페이지 별도 |
+| Critical 회귀 (Detail SSR 500) | ❌ T021.5 (Issue #75) 로 분리 → T022 blocker |
+| CI workflow | ✅ test → test:coverage 교체 |
+| Lighthouse | ⏳ 사용자 수동 측정 |
+| 키보드 nav | ⏳ 사용자 수동 검증 |
+| 다크/라이트 시각 회귀 | ⏳ 사용자 수동 검증 |
+
+### 다음 단계
+
+1. T021 PR review + merge (본 보고서 + minor fix 30건)
+2. **T021.5** (Issue #75, mdx-bundler 도입) — Critical fix
+3. T022 진입 가능 시점: T021 + T021.5 + 사용자 수동 검증 모두 ✅ 후

--- a/docs/tasks/T021-qa-pass-mvp.md
+++ b/docs/tasks/T021-qa-pass-mvp.md
@@ -5,13 +5,15 @@
 | **Task ID** | T021 |
 | **Phase** | Phase 6 — Polish & Deploy |
 | **Layer** | 전 layer (회귀 테스트) |
-| **Branch** | `chore/qa-pass-mvp` |
+| **Branch** | `chore/issue-74-qa-pass-mvp` |
+| **Issue** | #74 |
 | **Depends on** | T020 |
-| **Blocks** | T022 |
+| **Blocks** | T021.5 (Critical fix) → T022 |
 | **PRD Features** | F001~F019 전체 |
 | **PRD AC** | AC-F003-1/2/3, AC-F008-1/2/3/4, AC-F009-1/2/3, AC-F011-1/2/3, AC-F016-1/2/3/4/5 — **18개 AC 전수** |
 | **예상 작업 시간** | 1d |
-| **Status** | Not Started |
+| **Status** | In Review (자동 영역 완료, 수동 검증 대기) |
+| **산출물** | [docs/reports/qa-2026-05-04.md](../reports/qa-2026-05-04.md) |
 
 ## Goal
 배포 직전 통합 QA 단계. 모든 자동 테스트가 Green이고 coverage threshold(T003에서 정의한 lines 80 / branches 75 / functions 80 / statements 80)를 통과하며, Lighthouse(Perf ≥ 90, A11y ≥ 95, Best Practices ≥ 95, SEO ≥ 100), Axe 위반 0건이 보장됨을 확인한다. 18개 PRD AC 전체를 매트릭스로 회귀.


### PR DESCRIPTION
## Summary
- T021 통합 QA 1차 (자동 영역) 완료. 18 PRD AC 자동 회귀 매트릭스 + Pa11y/axe 다중 페이지 스캔 + coverage threshold 통과 확인.
- 자동 영역에서 발견된 a11y 결함 30건 fix (text-faint 토큰 lighten + mailto link 상시 underline) — 잔존 4건은 decorative 면제 정당.
- **Critical 회귀 발견 → 별도 분리**: detail 페이지 4건 SSR 500 (Workers V8 `Code generation from strings disallowed for this context`). Issue #75 / T021.5 신설로 분리, T022 의 blocker 등재.

## 자동 결과
| 영역 | 결과 |
|------|------|
| coverage | ✅ 88.76 / 75.84 / 88.53 / 90.47 (479/479 Green) |
| 18 AC 회귀 | ✅ 18/18 PASS |
| Pa11y/axe | 30 → 4 (decorative 면제) |
| typecheck | ✅ EXIT 0 |
| biome lint | ✅ |

## 변경 파일
- \`app/app.css\` — \`--color-faint\` dark/light/print 3곳 lighten
- \`app/presentation/components/about/AboutHeader.tsx\` — mailto link 상시 underline
- \`app/presentation/routes/contact.tsx\` — 동일 패턴
- \`.github/workflows/deploy-cloudflare-workers.yml\` — \`bun run test\` → \`bun run test:coverage\` (push 시점 threshold 강제)
- \`docs/reports/qa-2026-05-04.md\` — 신규 (18 AC 매트릭스 + 자동 결과 + 수동 빈칸 체크리스트)
- \`docs/ROADMAP.md\` — T021.5 신설, T022 blockedBy 갱신, 현황 43 task
- \`docs/tasks/T021-qa-pass-mvp.md\` — Status / Branch / Issue / Blocks / 산출물 갱신

## Critical 회귀 분리 (Issue #75 / T021.5)
\`MdxRenderer.evaluateMdxBody\` 의 \`new Function(code)({Fragment, jsx, jsxs})\` 패턴이 현재 Workers V8 isolate 에서 차단됨. \`wrangler dev --remote\` (실 Cloudflare edge) 에서도 동일 재현 → production blocker.

채택 전략: **mdx-bundler 도입** (esbuild 기반 build-time React component 컴파일, runtime \`new Function\` 제거). velite 는 frontmatter / TOC / cover 메타만 담당.

T022 (배포) 진입 조건에 T021.5 추가.

## Test plan (수동 — 사용자)
- [ ] \`bun run build && bunx wrangler dev --port 8787 --local\` → http://localhost:8787 접속
- [ ] Lighthouse 4 카테고리 측정 (Perf ≥ 90, A11y ≥ 95, BP ≥ 95, SEO ≥ 100) — \`docs/reports/qa-2026-05-04.md\` §6.1 채움
- [ ] 키보드 only 네비게이션 1 round (Tab → Cmd+K → ↓↑↵Esc → theme toggle 등) — §6.2 채움
- [ ] 다크/라이트 모드 시각 회귀 — §6.3 채움
- [ ] (Detail 페이지 4건은 T021.5 fix 후 별도 측정)

## Closes
Closes #74

## Related
- Critical fix: #75 (T021.5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
Related: #74