### PR TITLE
🚀 chore: T022 Stage 1 — production bootstrap (routes + secrets) (#78)

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -550,24 +550,32 @@ tkstarDev는 다음 핵심 가치를 단일 도메인에서 달성한다:
   - 번들 사이즈: total +4.09 kB raw / +0.02 kB gzip (사실상 동일).
   - PR 1개 / 브랜치: `fix/issue-75-mdx-renderer-workers-eval`
 
-- [ ] **Task 022: Cloudflare Workers 배포 + 도메인 연결 + Email Routing + 검색엔진 인증 완료**
+- [ ] **Task 022: Cloudflare Workers 배포 + 도메인 연결 + Email Routing + 검색엔진 인증 완료** (Stage 1 진행 중)
   - **Must** Read: [tasks/T022-deploy-production.md](tasks/T022-deploy-production.md)
   - blockedBy: Task 021, **Task 021.5** (Critical fix 없이는 detail 페이지 SSR 차단)
   - Layer: 운영
   - 관련 Feature: F019 (인증 완료), 운영 (도메인/이메일)
   - 관련 AC: 없음 (운영 검증)
-  - 검증:
-    - `bunx wrangler deploy` 성공 → workers.dev 우선 동작
-    - `tkstar.dev` 도메인 등록 + Cloudflare DNS 연결 + Workers Custom Domain 매핑
-    - Cloudflare Email Routing: `hello@tkstar.dev` → 개인 Gmail forward 동작 확인 (실제 메일 송수신)
-    - Resend domain verification 완료 (DKIM/SPF DNS record 설정)
-    - `wrangler secret put RESEND_API_KEY` / `TURNSTILE_SECRET` / vars `GOOGLE_SITE_VERIFICATION` / `NAVER_SITE_VERIFICATION` 주입
-    - Google Search Console 도메인 소유권 인증 + `https://tkstar.dev/sitemap.xml` 제출
-    - Naver Search Advisor `naver-site-verification` meta 검증 + sitemap 제출
-    - 배포 후 `site:tkstar.dev` 검색으로 indexing 확인 (수일 ~ 수주 소요)
-  - 가정 해소: A010 (도메인 등록 채널 결정 시 기록), A008 완료 (실제 토큰 주입)
+  - **2단계 PR 분리** (DNS 전파 24~48h 흡수):
+    - **Stage 1 — Bootstrap** (`chore/issue-78-deploy-production-bootstrap`, Issue #78, 진행 중):
+      - [x] Cloudflare Registrar 도메인 등록 (`tkstar.dev`, expires 2027-05-05) — A010 결정: CF Registrar
+      - [x] Cloudflare Email Routing: `hello@tkstar.dev` → 개인 Gmail forward (외부 수신 검증)
+      - [x] Resend domain verification (region ap-northeast-1, status Verified) + API key 발급
+      - [x] Cloudflare Turnstile production widget (`tkstar-dev-production`, hostnames apex+www, Managed mode)
+      - [x] GitHub Actions secrets (`CLOUDFLARE_API_TOKEN` + `CLOUDFLARE_ACCOUNT_ID`)
+      - [x] `wrangler.toml` `[[env.production.routes]]` apex+www custom_domain 추가 + `TURNSTILE_SITE_KEY` 평문 주입
+      - [x] `wrangler secret put` × 4 (production/staging × `RESEND_API_KEY`/`TURNSTILE_SECRET`)
+      - [ ] PR #N → development 머지 → main release → `https://tkstar.dev` 200 응답 확인 + Contact form 실 메일 발송 검증
+    - **Stage 2 — Search Engines** (별도 PR, Stage 1 머지 후 24~48h DNS 전파 완료 시 진행):
+      - [ ] Google Search Console 도메인 소유권 (TXT) + sitemap.xml 제출
+      - [ ] Naver Search Advisor HTML meta 인증 + sitemap 제출
+      - [ ] Cloudflare Web Analytics token 발급 + `wrangler.toml` `CLOUDFLARE_ANALYTICS_TOKEN` 주입
+      - [ ] `GOOGLE_SITE_VERIFICATION` / `NAVER_SITE_VERIFICATION` 평문 주입 → CI 재배포 → meta tag SSR 노출 → 인증 통과
+      - [ ] (수일~수주 후) `site:tkstar.dev` Google 검색 indexing 확인
+  - 가정 해소: A010 결정 (CF Registrar) ✅, A008 (Stage 2 에서 완료 예정)
   - 잔존 가정: A011(Bing 등록 보류), A012(Motion 라이브러리 보류)
-  - PR 1개 / 브랜치: `chore/deploy-production`
+  - PR 2개 / 브랜치: `chore/issue-78-deploy-production-bootstrap` (Stage 1) + `chore/deploy-production-search-engines` (Stage 2)
+  - 보고서: [reports/deploy-2026-05-05.md](reports/deploy-2026-05-05.md)
 
 ---
 

--- a/docs/reports/deploy-2026-05-05.md
+++ b/docs/reports/deploy-2026-05-05.md
@@ -1,0 +1,179 @@
+# T022 Deploy Production — Stage 1 Bootstrap
+
+| Field | Value |
+|---|---|
+| **Task ID** | T022 (Stage 1) |
+| **Date** | 2026-05-05 |
+| **Branch** | `chore/issue-78-deploy-production-bootstrap` |
+| **Issue** | #78 |
+| **Stage** | 1 / 2 — Bootstrap (도메인 + Email Routing + Resend + Turnstile + GH secrets + wrangler routes/secrets) |
+| **Stage 2** | 별도 PR — Google SC + Naver SA + CF Web Analytics 토큰 주입 |
+
+## Goal
+
+`tkstar.dev` apex + `www` custom domain 으로 Cloudflare Workers production 배포. Contact form 실 메일 발송 + Email Routing 동작.
+
+## Changes
+
+### `wrangler.toml`
+
+`[env.production]` 섹션에 routes + TURNSTILE_SITE_KEY 갱신:
+
+```toml
+[[env.production.routes]]
+pattern = "tkstar.dev"
+custom_domain = true
+
+[[env.production.routes]]
+pattern = "www.tkstar.dev"
+custom_domain = true
+
+[env.production.vars]
+TURNSTILE_SITE_KEY = "0x4AAAAAADJerjK_6MJH0kCx"  # production widget site key (공개 가능)
+```
+
+Staging 은 변경 없음 (workers.dev subdomain 만 사용).
+
+### Secrets (Cloudflare Workers — 코드 외)
+
+`wrangler secret put` 으로 주입 (git 에는 평문 저장 X):
+
+| Env | Secret | Source |
+|---|---|---|
+| production | `RESEND_API_KEY` | Resend API key (region: ap-northeast-1, name: tkstar-dev-production, permission: Sending access) |
+| production | `TURNSTILE_SECRET` | Turnstile widget `tkstar-dev-production` Secret Key |
+| staging | `RESEND_API_KEY` | Resend API key (production 동일 key 재사용) |
+| staging | `TURNSTILE_SECRET` | always-pass test secret `1x0000000000000000000000000000000AA` |
+
+검증:
+```
+bunx wrangler secret list --env production
+→ RESEND_API_KEY, TURNSTILE_SECRET (각 secret_text)
+bunx wrangler secret list --env staging
+→ RESEND_API_KEY, TURNSTILE_SECRET (각 secret_text)
+```
+
+### GitHub Actions secrets (CI/CD)
+
+| Secret | Value |
+|---|---|
+| `CLOUDFLARE_API_TOKEN` | "Edit Cloudflare Workers" template, account+zone scope (`tkstar.dev`) |
+| `CLOUDFLARE_ACCOUNT_ID` | `290e3c69f32cdee04dfbfb868433c533` |
+
+검증: `gh secret list` 결과 두 항목 노출.
+
+## External actions (사용자 GUI 작업)
+
+### A.1 — Cloudflare Registrar 도메인 등록
+
+| Field | Value |
+|---|---|
+| Domain | `tkstar.dev` |
+| Registrar | Cloudflare |
+| Expires | 2027-05-05 |
+| Registrant email verified | yes (`hello@tkstar.dev`, A.2 활성화 후 인증 메일 수신) |
+| Zone status | Active |
+| Universal SSL | Active |
+
+`.dev` TLD HSTS preload 강제 → HTTPS only. CF 자동 SSL 으로 무관.
+
+### A.2 — Cloudflare Email Routing
+
+| Item | Value |
+|---|---|
+| MX records (apex) | 3개 — route1/2/3.mx.cloudflare.net (priority 36/49/61) |
+| SPF TXT (apex) | `v=spf1 include:_spf.mx.cloudflare.net ~all` |
+| Custom address | `hello@tkstar.dev` → 개인 Gmail |
+| Destination verified | yes |
+| Catch-all | disabled |
+| External → `hello@tkstar.dev` test | 수신 확인 ✅ |
+
+### A.3 — Resend domain + API key
+
+| Item | Value |
+|---|---|
+| Region | `ap-northeast-1` (Tokyo) |
+| Domain status | Verified |
+| DKIM TXT (`resend._domainkey`) | Verified |
+| SPF TXT (`send`) | `v=spf1 include:amazonses.com ~all` — Verified |
+| MX (`send`) | `feedback-smtp.ap-northeast-1.amazonses.com` priority 10 — Verified |
+| DMARC TXT (`_dmarc`) | `v=DMARC1; p=none;` |
+| API Key | `tkstar-dev-production` (Sending access, domain `tkstar.dev`) |
+| Test email | 수신 확인 ✅ |
+
+⚠️ **DNS topology 분리**: CF Email Routing 은 apex (`tkstar.dev`) MX 점유, Resend 는 subdomain (`send.tkstar.dev`) MX 점유 → 충돌 없음.
+
+### A.4 — Cloudflare Turnstile production widget
+
+| Item | Value |
+|---|---|
+| Widget name | `tkstar-dev-production` |
+| Hostnames | `tkstar.dev`, `www.tkstar.dev` |
+| Widget mode | Managed |
+| Pre-clearance | Off |
+| Site Key | `0x4AAAAAADJerjK_6MJH0kCx` (공개 가능 — wrangler.toml 평문) |
+| Secret Key | (wrangler secret 으로만 주입) |
+
+Staging widget 미발급 — staging 은 always-pass test key 유지.
+
+### A.5 — GitHub Actions secrets
+
+| Item | Value |
+|---|---|
+| CF API Token | "Edit Cloudflare Workers" template, account+zone scope, no IP filter, no TTL |
+| `gh secret list` | `CLOUDFLARE_API_TOKEN` + `CLOUDFLARE_ACCOUNT_ID` 노출 ✅ |
+
+## DNS Records 최종 상태 (CF DNS)
+
+| Type | Name | Content | Source |
+|---|---|---|---|
+| MX | `tkstar.dev` (apex) | `route1/2/3.mx.cloudflare.net` × 3 | CF Email Routing |
+| MX | `send` | `feedback-smtp.ap-northeast-1.amazonses.com` | Resend bounce |
+| TXT | `tkstar.dev` (apex) | `v=spf1 include:_spf.mx.cloudflare.net ~all` | CF Email Routing SPF |
+| TXT | `send` | `v=spf1 include:amazonses.com ~all` | Resend SPF (subdomain) |
+| TXT | `cf2024-1._domainkey` | `v=DKIM1; h=sha256; k=rs...` | CF Email Routing DKIM |
+| TXT | `resend._domainkey` | `p=MIGfMA0GCSqGSlb3D...` | Resend DKIM |
+| TXT | `_dmarc` | `v=DMARC1; p=none;` | DMARC |
+
+## Verification (Stage 1 — Bootstrap)
+
+다음 항목은 PR 머지 + main release 후 수동 검증:
+
+- [ ] `curl -I https://tkstar.dev` → 200 + `cf-ray` header
+- [ ] `curl -I https://www.tkstar.dev` → 200
+- [ ] 브라우저 → `https://tkstar.dev` Home 정상 SSR
+- [ ] `/contact` 폼 제출 → 본인 메일 + 자동응답 수신
+- [ ] OG validator (Twitter Card / Facebook Debugger) → 1200×630 PNG
+- [ ] Email Routing — 외부 → `hello@tkstar.dev` 추가 1회 수신
+
+## Out of Scope (Stage 2 로 이관)
+
+- `GOOGLE_SITE_VERIFICATION` 토큰 주입 → Google Search Console domain property 인증 + sitemap 제출
+- `NAVER_SITE_VERIFICATION` 토큰 주입 → Naver Search Advisor HTML meta 인증 + sitemap 제출
+- `CLOUDFLARE_ANALYTICS_TOKEN` 주입 → Web Analytics 활성화
+
+Stage 1 머지 후 24~48h DNS 전파 완료 시점에 별도 PR 진행.
+
+## Risks & Mitigations
+
+| Risk | Mitigation | Status |
+|---|---|---|
+| `.dev` TLD HSTS preload | CF 자동 SSL | Auto |
+| Resend MX vs CF Email Routing MX 충돌 | Resend 가 subdomain (`send`) namespace 사용 → 자동 해소 | Resolved |
+| DNS 전파 지연 | Stage 1/2 분리 (24h gap) | Planned |
+| Secret 평문 노출 | `wrangler secret put` 만 사용, wrangler.toml 에 평문 X | Verified |
+| GH Actions API token 권한 부족 | "Edit Cloudflare Workers" template + Zone:Read 자동 포함 | Verified |
+
+## References
+
+- [Cloudflare Workers Custom Domains](https://developers.cloudflare.com/workers/configuration/routing/custom-domains/)
+- [Cloudflare Email Routing](https://developers.cloudflare.com/email-routing/)
+- [Resend Domain verification](https://resend.com/docs/dashboard/domains/introduction)
+- [Cloudflare Turnstile](https://developers.cloudflare.com/turnstile/get-started/)
+- [Cloudflare API Tokens](https://developers.cloudflare.com/fundamentals/api/get-started/create-token/)
+
+## Change History
+
+| Date | Changes | Author |
+|------|---------|--------|
+| 2026-05-05 | Stage 1 Bootstrap — domain + Email Routing + Resend + Turnstile + GH secrets + wrangler routes/secrets | Claude (T022) |

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -47,11 +47,19 @@ id = "95b7366f0bf64aab9677eb43174e4b32"
 [env.production]
 name = "tkstar-dev-production"
 
+[[env.production.routes]]
+pattern = "tkstar.dev"
+custom_domain = true
+
+[[env.production.routes]]
+pattern = "www.tkstar.dev"
+custom_domain = true
+
 [env.production.vars]
 APP_ENV = "production"
 CONTACT_TO_EMAIL = "hello@tkstar.dev"
-# TURNSTILE_SITE_KEY: T022 deploy 단계에서 prod widget site key 로 교체 (공개 가능 값)
-TURNSTILE_SITE_KEY = "1x00000000000000000000AA"
+# T022 Stage 1: production Turnstile widget site key (공개 가능 값 — HTML 에 노출됨)
+TURNSTILE_SITE_KEY = "0x4AAAAAADJerjK_6MJH0kCx"
 # T020: 검색엔진 인증 토큰 + Web Analytics token — T022 deploy 단계에서 실제 값 주입
 GOOGLE_SITE_VERIFICATION = ""
 NAVER_SITE_VERIFICATION = ""


### PR DESCRIPTION
## Summary

T022 Stage 1 — Cloudflare Workers production 배포 부트스트랩. Stage 1 의 80% 는 사용자가 외부 서비스 (Cloudflare Dashboard, Resend, GitHub) 에서 GUI 로 수행한 작업이며, 본 PR diff 는 그 결과를 코드/설정에 반영한다.

**2-stage 분리 전략** — DNS 전파 24~48h 대기 시간 흡수.
- **Stage 1 (본 PR)**: 도메인 + Email Routing + Resend + Turnstile + GH secrets + wrangler routes/secrets
- **Stage 2 (별도 PR)**: Google SC + Naver SA + CF Web Analytics 토큰 주입 (Stage 1 머지 후 진행)

## Changes (코드/설정 — 본 PR diff)

### `wrangler.toml`
- `[env.production]` 에 `[[routes]]` custom_domain 2건 추가 (apex + www)
- `TURNSTILE_SITE_KEY` 를 production widget 값으로 교체

### `docs/reports/deploy-2026-05-05.md` (신규)
Stage 1 결과 (외부 액션 5건 + Claude 작업 요약 + DNS records 최종 상태) 기록.

### `docs/ROADMAP.md`
T022 항목을 Stage 1 (체크박스 체크) / Stage 2 (체크박스 미체크) 분리 구조로 갱신. A010 결정 기록 (CF Registrar).

## External actions (사용자 GUI — 본 PR diff 외)

| Step | Item | Status |
|---|---|---|
| A.1 | Cloudflare Registrar `tkstar.dev` 등록 (expires 2027-05-05) | ✅ |
| A.2 | CF Email Routing `hello@tkstar.dev` → 개인 Gmail (Verified, 외부 수신 검증) | ✅ |
| A.3 | Resend domain ap-northeast-1 (DKIM/SPF/MX/DMARC Verified) + API key | ✅ |
| A.4 | Cloudflare Turnstile production widget (apex+www, Managed mode) | ✅ |
| A.5 | GitHub Actions: `CLOUDFLARE_API_TOKEN` + `CLOUDFLARE_ACCOUNT_ID` | ✅ |
| B.3 | `wrangler secret put` × 4 (production/staging × `RESEND_API_KEY`/`TURNSTILE_SECRET`) | ✅ |

## DNS Topology

CF Email Routing 은 **apex** (`tkstar.dev`) MX 점유, Resend 는 **subdomain** (`send.tkstar.dev`) MX 점유 → namespace 분리되어 충돌 없음.

## Test plan

머지 + main release (development → main release PR) 후 production 검증:

- [ ] CI `Deploy to Cloudflare Workers` step 성공
- [ ] `curl -I https://tkstar.dev` → 200 + `cf-ray` header
- [ ] `curl -I https://www.tkstar.dev` → 200
- [ ] 브라우저 → `https://tkstar.dev` Home SSR 정상
- [ ] `/contact` 폼 제출 → 본인 메일 + 자동응답 수신
- [ ] OG validator (Twitter Card / Facebook Debugger) → 1200×630 PNG 정상

## Quality gates

- ✅ `bun run lint` — 217 files, no fixes applied
- ✅ `bun run typecheck` — wrangler types + react-router typegen + tsc -b 통과
- ✅ `bun run test` — 84 files / 472 passed

## Risks & Mitigations

| Risk | Status |
|---|---|
| `.dev` TLD HSTS preload | CF 자동 SSL 으로 무관 |
| Resend MX vs CF Email Routing MX 충돌 | Resend 가 subdomain (`send`) namespace 사용 → 자동 해소 |
| Secret 평문 노출 | `wrangler secret put` 만 사용, wrangler.toml 에 평문 X |

Closes #78

---
Related: #78