### PR TITLE
🔧 fix: CI typecheck 실패 — pretypecheck lifecycle 추가 (#81)

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
 		"prebuild": "bun run velite:build",
 		"prestart": "bun run velite:build",
 		"pretest": "bun run velite:build",
+		"pretypecheck": "bun run velite:build",
 		"postinstall": "wrangler types"
 	},
 	"dependencies": {


### PR DESCRIPTION
## Summary

PR #80 (v0.1.0 release) 머지 후 main 브랜치 push trigger 의 `Deploy to Cloudflare Workers` workflow 가 **Typecheck** step 에서 실패. 원인은 `pretypecheck` lifecycle 누락.

## Root cause

`package.json` 의 npm lifecycle hooks 가 `predev` / `prebuild` / `prestart` / `pretest` 에만 `bun run velite:build` 를 chain. CI 의 Typecheck step 은 `bun run typecheck` 만 호출 → `.velite/` 미생성 → `tsc -b` 실행 시:

```
app/infrastructure/content/velite-legal.repository.ts(1,23):
  error TS2307: Cannot find module '#content'
app/infrastructure/content/velite-post.repository.ts(8,7):
  error TS2322: Type 'readonly { date: string; }[]' is not assignable to ...
```

로컬에서는 `pretest` 가 매 `bun run test` 실행마다 `.velite/` 를 생성하므로 typecheck 도 우연히 통과. Fresh clone / CI 환경에서만 회귀.

## Fix

```diff
 "pretest": "bun run velite:build",
+"pretypecheck": "bun run velite:build",
 "postinstall": "wrangler types"
```

## Verification

로컬 `.velite/` 디렉토리 제거 후 `bun run typecheck` 재실행 → exit 0 (pretypecheck 가 `.velite/` 재생성).

## Test plan

- [ ] CI `Lint` step 통과
- [ ] CI `Typecheck` step 통과
- [ ] CI `Run tests with coverage` 통과
- [ ] CI `Build project` 통과
- [ ] 본 PR development 머지 후 v0.1.0 재배포를 위한 release PR 별도 진행

Closes #81

---
Related: #81