### PR TITLE
🚀 Release v0.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
 		"prebuild": "bun run velite:build",
 		"prestart": "bun run velite:build",
 		"pretest": "bun run velite:build",
+		"pretypecheck": "bun run velite:build",
 		"postinstall": "wrangler types"
 	},
 	"dependencies": {


### PR DESCRIPTION
## v0.1.1 — CI typecheck fix (production deploy 재시도)

v0.1.0 release 의 main CI 가 Typecheck step 에서 실패해 production 배포가 차단된 상태. 본 patch 는 그 fix.

### Changes

- `package.json` 에 `pretypecheck` lifecycle 추가 → CI 의 fresh checkout 환경에서 `.velite/` 산출물 자동 생성 → `tsc -b` 의 `#content` path alias 정상 해석

### Affected behavior

- 로컬은 `pretest` 가 매 test 실행마다 `.velite/` 를 생성해 typecheck 도 우연히 통과 — 회귀 영향 없음
- CI 는 본 patch 적용 후 typecheck step 통과 → build → wrangler deploy 단계 진입

### v0.1.0 included features

(v0.1.0 release notes 참조)

### References

- Issue: #81
- Fix PR: #82