### PR TITLE
🚀 chore: T022 Stage 2 — search engines + web analytics tokens (#84)

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -550,14 +550,14 @@ tkstarDev는 다음 핵심 가치를 단일 도메인에서 달성한다:
   - 번들 사이즈: total +4.09 kB raw / +0.02 kB gzip (사실상 동일).
   - PR 1개 / 브랜치: `fix/issue-75-mdx-renderer-workers-eval`
 
-- [ ] **Task 022: Cloudflare Workers 배포 + 도메인 연결 + Email Routing + 검색엔진 인증 완료** (Stage 1 진행 중)
+- [x] **Task 022: Cloudflare Workers 배포 + 도메인 연결 + Email Routing + 검색엔진 인증 완료**
   - **Must** Read: [tasks/T022-deploy-production.md](tasks/T022-deploy-production.md)
   - blockedBy: Task 021, **Task 021.5** (Critical fix 없이는 detail 페이지 SSR 차단)
   - Layer: 운영
   - 관련 Feature: F019 (인증 완료), 운영 (도메인/이메일)
   - 관련 AC: 없음 (운영 검증)
   - **2단계 PR 분리** (DNS 전파 24~48h 흡수):
-    - **Stage 1 — Bootstrap** (`chore/issue-78-deploy-production-bootstrap`, Issue #78, 진행 중):
+    - **Stage 1 — Bootstrap** (`chore/issue-78-deploy-production-bootstrap`, Issue #78, PR #79 머지 + v0.1.0/v0.1.1 release):
       - [x] Cloudflare Registrar 도메인 등록 (`tkstar.dev`, expires 2027-05-05) — A010 결정: CF Registrar
       - [x] Cloudflare Email Routing: `hello@tkstar.dev` → 개인 Gmail forward (외부 수신 검증)
       - [x] Resend domain verification (region ap-northeast-1, status Verified) + API key 발급
@@ -565,16 +565,16 @@ tkstarDev는 다음 핵심 가치를 단일 도메인에서 달성한다:
       - [x] GitHub Actions secrets (`CLOUDFLARE_API_TOKEN` + `CLOUDFLARE_ACCOUNT_ID`)
       - [x] `wrangler.toml` `[[env.production.routes]]` apex+www custom_domain 추가 + `TURNSTILE_SITE_KEY` 평문 주입
       - [x] `wrangler secret put` × 4 (production/staging × `RESEND_API_KEY`/`TURNSTILE_SECRET`)
-      - [ ] PR #N → development 머지 → main release → `https://tkstar.dev` 200 응답 확인 + Contact form 실 메일 발송 검증
-    - **Stage 2 — Search Engines** (별도 PR, Stage 1 머지 후 24~48h DNS 전파 완료 시 진행):
-      - [ ] Google Search Console 도메인 소유권 (TXT) + sitemap.xml 제출
-      - [ ] Naver Search Advisor HTML meta 인증 + sitemap 제출
-      - [ ] Cloudflare Web Analytics token 발급 + `wrangler.toml` `CLOUDFLARE_ANALYTICS_TOKEN` 주입
-      - [ ] `GOOGLE_SITE_VERIFICATION` / `NAVER_SITE_VERIFICATION` 평문 주입 → CI 재배포 → meta tag SSR 노출 → 인증 통과
-      - [ ] (수일~수주 후) `site:tkstar.dev` Google 검색 indexing 확인
-  - 가정 해소: A010 결정 (CF Registrar) ✅, A008 (Stage 2 에서 완료 예정)
+      - [x] PR #79 → development 머지 → v0.1.0 release → CI typecheck fix (PR #82, Issue #81) → v0.1.1 release → `https://tkstar.dev` 200 OK + sitemap/og/robots/contact route 자동 검증 통과 + Contact/OG validator (카톡 unfurl) 수동 검증 통과
+    - **Stage 2 — Search Engines** (`chore/issue-84-deploy-production-search-engines`, Issue #84):
+      - [x] Google Search Console domain property (Cloudflare 통합 자동 인증) + `sitemap.xml` 제출 — 첫 status `가져올 수 없음` 은 Google 처리 큐 transient (24h 내 자동 재시도)
+      - [x] Naver Search Advisor HTML meta token 발급 (소유 확인 + 사이트맵 제출은 main release 후 진행)
+      - [x] Cloudflare Web Analytics site token 발급 (Manual mode — Workers SSR 응답이 CF HTMLRewriter pipeline 우회로 Auto-inject 불가)
+      - [x] `wrangler.toml` `[env.production.vars]` 의 `GOOGLE_SITE_VERIFICATION` / `NAVER_SITE_VERIFICATION` / `CLOUDFLARE_ANALYTICS_TOKEN` 평문 주입
+      - [ ] (수일~수주 후) `site:tkstar.dev` Google 검색 indexing 확인 (자연 시간)
+  - 가정 해소: A010 결정 (CF Registrar) ✅, A008 (실제 토큰 주입) ✅
   - 잔존 가정: A011(Bing 등록 보류), A012(Motion 라이브러리 보류)
-  - PR 2개 / 브랜치: `chore/issue-78-deploy-production-bootstrap` (Stage 1) + `chore/deploy-production-search-engines` (Stage 2)
+  - PR 4개 / 브랜치: `chore/issue-78-deploy-production-bootstrap` (Stage 1, PR #79) + `fix/issue-81-ci-typecheck-pretypecheck-lifecycle` (CI fix, PR #82) + `chore/issue-84-deploy-production-search-engines` (Stage 2, PR #N)
   - 보고서: [reports/deploy-2026-05-05.md](reports/deploy-2026-05-05.md)
 
 ---

--- a/docs/reports/deploy-2026-05-05.md
+++ b/docs/reports/deploy-2026-05-05.md
@@ -146,13 +146,64 @@ Staging widget 미발급 — staging 은 always-pass test key 유지.
 - [ ] OG validator (Twitter Card / Facebook Debugger) → 1200×630 PNG
 - [ ] Email Routing — 외부 → `hello@tkstar.dev` 추가 1회 수신
 
-## Out of Scope (Stage 2 로 이관)
+## Stage 2 — Search Engines + Web Analytics (2026-05-06 추가)
 
-- `GOOGLE_SITE_VERIFICATION` 토큰 주입 → Google Search Console domain property 인증 + sitemap 제출
-- `NAVER_SITE_VERIFICATION` 토큰 주입 → Naver Search Advisor HTML meta 인증 + sitemap 제출
-- `CLOUDFLARE_ANALYTICS_TOKEN` 주입 → Web Analytics 활성화
+`chore/issue-84-deploy-production-search-engines` branch / Issue #84.
 
-Stage 1 머지 후 24~48h DNS 전파 완료 시점에 별도 PR 진행.
+### External actions (사용자 GUI)
+
+#### C.1.1 — Google Search Console domain property
+
+| Item | Value |
+|---|---|
+| Property type | Domain (`tkstar.dev`) |
+| 인증 방법 | **자동 (도메인 이름 공급업체 통합 — Cloudflare)** — Google Search Console 의 Cloudflare 통합으로 OAuth 후 Google 이 CF API 로 TXT record 자동 생성 |
+| TXT record | `tkstar.dev` apex, `"google-site-verification=9dqFGGSK_NYqbgfrEb0ZwfEcYTTAtsgpW6XX-FqiXCM"` |
+| Verification status | ✅ 소유권이 자동으로 확인됨 |
+| Sitemap 제출 | `https://tkstar.dev/sitemap.xml` 제출, 첫 status `가져올 수 없음` (Google 처리 큐 첫 시도의 흔한 transient — 24h 내 재시도 자동 회복 예상) |
+
+#### C.1.2 — Naver Search Advisor
+
+| Item | Value |
+|---|---|
+| 사이트 등록 | `https://tkstar.dev` |
+| 인증 방법 | HTML meta tag (`naver-site-verification` content 값) |
+| Token | `0d3e009372cee5a32511420ca566d2b54629b10c` |
+| 소유 확인 | C.2.4 main release 후 진행 (meta tag SSR 노출 확인 후 클릭) |
+| Sitemap 제출 | C.2.4 후 `요청 → 사이트맵 제출 → sitemap.xml` |
+
+#### C.1.3 — Cloudflare Web Analytics
+
+| Item | Value |
+|---|---|
+| Hostname | `tkstar.dev` |
+| RUM mode | **JS 코드 조각을 설치하여 활성화** (Manual) — Workers SSR 응답이 CF HTMLRewriter pipeline 을 우회하므로 Auto-inject 불가 (auto 모드에서 `cloudflareinsights` script 가 Workers 응답에 포함되지 않음을 curl 로 확인) |
+| Site token | `ff5c6565162c478580790bdb4e32bf5c` |
+
+### `wrangler.toml` 변경
+
+```toml
+[env.production.vars]
+GOOGLE_SITE_VERIFICATION = "9dqFGGSK_NYqbgfrEb0ZwfEcYTTAtsgpW6XX-FqiXCM"
+NAVER_SITE_VERIFICATION = "0d3e009372cee5a32511420ca566d2b54629b10c"
+CLOUDFLARE_ANALYTICS_TOKEN = "ff5c6565162c478580790bdb4e32bf5c"
+```
+
+세 값 모두 클라이언트 노출용 공개 토큰 — git 평문 commit OK (시크릿 X).
+
+### Verification (Stage 2 — 본 PR 머지 + main release 후)
+
+- [ ] `curl -s https://tkstar.dev | grep google-site-verification` → meta tag 확인
+- [ ] `curl -s https://tkstar.dev | grep naver-site-verification` → meta tag 확인
+- [ ] `curl -s https://tkstar.dev | grep cloudflareinsights` → CF Web Analytics script 확인
+- [ ] Naver SA 소유 확인 통과 + sitemap 제출 (`처리 완료`)
+- [ ] CF Web Analytics dashboard 첫 pageview 수신 (Manual inject 후)
+- [ ] (수일~수주) Google `site:tkstar.dev` 검색 색인 확인
+
+## Out of Scope
+
+- Bing Webmaster Tools (가정 A011, MVP 후)
+- Resend bounce webhook (운영 후)
 
 ## Risks & Mitigations
 
@@ -177,3 +228,4 @@ Stage 1 머지 후 24~48h DNS 전파 완료 시점에 별도 PR 진행.
 | Date | Changes | Author |
 |------|---------|--------|
 | 2026-05-05 | Stage 1 Bootstrap — domain + Email Routing + Resend + Turnstile + GH secrets + wrangler routes/secrets | Claude (T022) |
+| 2026-05-06 | Stage 2 Search Engines — Google SC domain (auto via CF integration) + Naver SA HTML meta + CF Web Analytics manual + wrangler vars 평문 주입 | Claude (T022) |

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -60,10 +60,10 @@ APP_ENV = "production"
 CONTACT_TO_EMAIL = "hello@tkstar.dev"
 # T022 Stage 1: production Turnstile widget site key (공개 가능 값 — HTML 에 노출됨)
 TURNSTILE_SITE_KEY = "0x4AAAAAADJerjK_6MJH0kCx"
-# T020: 검색엔진 인증 토큰 + Web Analytics token — T022 deploy 단계에서 실제 값 주입
-GOOGLE_SITE_VERIFICATION = ""
-NAVER_SITE_VERIFICATION = ""
-CLOUDFLARE_ANALYTICS_TOKEN = ""
+# T022 Stage 2: 검색엔진 verification + CF Web Analytics 토큰 (모두 클라이언트 노출용 공개 값)
+GOOGLE_SITE_VERIFICATION = "9dqFGGSK_NYqbgfrEb0ZwfEcYTTAtsgpW6XX-FqiXCM"
+NAVER_SITE_VERIFICATION = "0d3e009372cee5a32511420ca566d2b54629b10c"
+CLOUDFLARE_ANALYTICS_TOKEN = "ff5c6565162c478580790bdb4e32bf5c"
 
 [[env.production.kv_namespaces]]
 binding = "RATE_LIMIT_KV"


### PR DESCRIPTION
## Summary

T022 Stage 2 — 검색엔진 인증 + Cloudflare Web Analytics 토큰을 wrangler.toml `[env.production.vars]` 에 평문 주입. main release 후 CI 가 production 재배포 → Workers SSR 응답에 meta tag / analytics script 노출 → 검색엔진 소유 확인 + Web Analytics 데이터 수집 시작.

## Changes

### `wrangler.toml`

```diff
 [env.production.vars]
-GOOGLE_SITE_VERIFICATION = ""
-NAVER_SITE_VERIFICATION = ""
-CLOUDFLARE_ANALYTICS_TOKEN = ""
+GOOGLE_SITE_VERIFICATION = "9dq...XCM"  # Google SC domain property (CF 자동 통합)
+NAVER_SITE_VERIFICATION = "0d3...10c"   # Naver SA HTML meta (main release 후 소유 확인 클릭 예정)
+CLOUDFLARE_ANALYTICS_TOKEN = "ff5...f5c"  # Web Analytics Manual mode
```

세 토큰 모두 클라이언트 노출용 공개 값 (HTML meta / script 에 그대로 노출됨).

### `docs/reports/deploy-2026-05-05.md`

Stage 2 외부 액션 결과 (Google SC / Naver SA / CF Web Analytics) 보강 + Change History 업데이트.

### `docs/ROADMAP.md`

Task 022 close + Stage 1 / Stage 2 체크박스 모두 체크 + 가정 A008 / A010 해소 표시 + PR 4개 history 기록.

## External actions (사용자 GUI — 본 PR diff 외)

| Step | Item | Status |
|---|---|---|
| C.1.1 | Google Search Console domain property 인증 | ✅ Cloudflare 통합 자동 인증 (TXT 자동 생성됨) |
| C.1.1 | sitemap.xml 제출 | ✅ 제출 완료 (status `가져올 수 없음` → 24h 내 자동 회복 예상) |
| C.1.2 | Naver Search Advisor 사이트 등록 + HTML meta token 발급 | ✅ |
| C.1.3 | Cloudflare Web Analytics site token 발급 (Manual mode) | ✅ |

## Why Manual mode for Web Analytics?

`curl -s https://tkstar.dev | grep cloudflareinsights` 결과 — Auto-inject mode 에서 Workers 응답에 script 가 포함되지 않음. Workers SSR 응답은 CF 의 HTMLRewriter pipeline 을 우회하므로 Auto-inject 불가. → Manual mode 로 envvar 주입 필수.

## Test plan (본 PR 머지 + main release 후)

- [ ] CI deploy step 성공
- [ ] `curl -s https://tkstar.dev | grep google-site-verification` → meta tag 출력
- [ ] `curl -s https://tkstar.dev | grep naver-site-verification` → meta tag 출력
- [ ] `curl -s https://tkstar.dev | grep cloudflareinsights` → CF Web Analytics script 출력
- [ ] Naver SA dashboard → 소유 확인 클릭 → 통과 → 사이트맵 제출 (`처리 완료`)
- [ ] CF Web Analytics dashboard 첫 pageview 수신 (Manual inject 후 1~5분 내)

## Quality gates

- ✅ `bun run lint` — 217 files, no fixes applied
- ✅ `bun run typecheck` — clean
- ✅ `bun run test` — 84 files / 472 passed

## References

- Stage 1 PR: #79
- CI fix PR: #82 (Issue #81)
- 보고서: docs/reports/deploy-2026-05-05.md
- T022 plan: `~/.claude/plans/rosy-snacking-cosmos.md` Phase C

Closes #84

---
Related: #84