### PR TITLE
🔧 chore: deploy workflow paths-ignore — docs/.claude/루트 *.md 변경 시 CI/CD 스킵 (#106)

### DIFF
--- a/.github/workflows/deploy-cloudflare-workers.yml
+++ b/.github/workflows/deploy-cloudflare-workers.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - main
       - development
+    paths-ignore:
+      - 'docs/**'
+      - '.claude/**'
+      - '*.md'
   workflow_dispatch:
     inputs:
       environment:


### PR DESCRIPTION
## Summary

`deploy-cloudflare-workers.yml` `on.push`에 `paths-ignore` 추가 — `docs/**`, `.claude/**`, `*.md`(루트)만 변경된 push는 workflow 자체가 trigger되지 않음.

Closes #106

## Why

`ROADMAP.md` 체크박스 flip, PRD/PROJECT-STRUCTURE 수정, agent 설정 변경 같은 비-운영 변경에도 매번 lint → typecheck → test → build → wrangler deploy(약 5–10분)가 풀로 도는 비효율 제거.

## Diff

\`\`\`yaml
on:
  push:
    branches:
      - main
      - development
+    paths-ignore:
+      - 'docs/**'
+      - '.claude/**'
+      - '*.md'
  workflow_dispatch:
\`\`\`

## Verified facts (Phase 0 codebase verification)

- \`app/\`, \`workers/\`, \`vite.config.ts\`, \`react-router.config.ts\`, \`velite.config.ts\` 어디서도 \`docs/\` import/read 없음 (\`grep -rln\` 0건)
- \`velite\`는 \`content/**/*.mdx\`만 소비 — \`docs/\`와 완전 분리
- \`main\` / \`development\` branch protection 없음 → required status check 부재
- \`.github/\` 하위 현재 \`workflows/\`만 존재

## Semantics

- Mixed commit (docs + app) → paths-ignore 표준 동작상 정상 trigger (모든 파일이 패턴 매치해야만 skip)
- \`workflow_dispatch\` (수동 실행) → paths-ignore 무영향 → 강제 deploy escape hatch 유지
- \`*.md\`는 루트 레벨만 — 하위 디렉토리 .md는 \`docs/**\` 또는 별도 위치에서 커버

## Out of scope (Surgical Changes)

- concurrency: cancel-in-progress
- cache 전략 / step 순서
- \`.github/ISSUE_TEMPLATE\`, PR template (미존재)

## Test plan

- [ ] PR 머지 후 \`development\`에 docs-only commit push → GitHub Actions 새 run 안 뜸 확인
- [ ] 직후 \`app/\` 포함 commit push → 정상 trigger 확인
- [ ] (선택) Actions UI → workflow_dispatch 수동 실행 → docs-only 상태에서 강제 deploy 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)